### PR TITLE
Simplify Progress Store structure

### DIFF
--- a/app/data_model/progress.py
+++ b/app/data_model/progress.py
@@ -1,15 +1,13 @@
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass
-from typing import MutableMapping, List, Optional, Mapping
-
-from app.questionnaire.location import Location
+from dataclasses import dataclass
+from typing import List, Optional, Mapping
 
 
 @dataclass
 class Progress:
     section_id: str
-    locations: List
+    block_ids: List[Optional[str]]
     status: Optional[str] = None
     list_item_id: Optional[str] = None
 
@@ -17,24 +15,11 @@ class Progress:
     def from_dict(cls, progress_dict: Mapping) -> Progress:
         return cls(
             section_id=progress_dict['section_id'],
-            locations=[
-                Location.from_dict(location_dict=location)
-                for location in progress_dict['locations']
-            ],
+            block_ids=progress_dict['block_ids'],
             status=progress_dict['status'],
             list_item_id=progress_dict.get('list_item_id'),
         )
 
     def for_json(self) -> Mapping:
-        locations_for_json = [location.for_json() for location in self.locations]
-
-        output = self.to_dict()
-        output['locations'] = locations_for_json
-
-        if not self.list_item_id:
-            del output['list_item_id']
-
-        return output
-
-    def to_dict(self) -> MutableMapping:
-        return asdict(self)
+        attributes = vars(self)
+        return {k: v for k, v in attributes.items() if v is not None}

--- a/app/questionnaire/path_finder.py
+++ b/app/questionnaire/path_finder.py
@@ -49,8 +49,8 @@ class PathFinder:
                 block_type = block.get('type')
 
                 is_location_complete = (
-                    location
-                    in self.progress_store.get_completed_locations(
+                    location.block_id
+                    in self.progress_store.get_completed_block_ids(
                         section_id=location.section_id,
                         list_item_id=location.list_item_id,
                     )

--- a/app/questionnaire/router.py
+++ b/app/questionnaire/router.py
@@ -139,8 +139,11 @@ class Router:
 
         if section_key in self._progress_store:
             for location in routing_path:
-                if location not in self._progress_store.get_completed_locations(
-                    section_id=section_id, list_item_id=list_item_id
+                if (
+                    location.block_id
+                    not in self._progress_store.get_completed_block_ids(
+                        section_id=section_id, list_item_id=list_item_id
+                    )
                 ):
                     return location
 
@@ -153,7 +156,7 @@ class Router:
 
         if section_key in self._progress_store:
             for location in routing_path[::-1]:
-                if location in self._progress_store.get_completed_locations(
+                if location.block_id in self._progress_store.get_completed_block_ids(
                     section_id=section_id, list_item_id=list_item_id
                 ):
                     return location
@@ -187,8 +190,12 @@ class Router:
             for location in routing_path:
                 allowable_path.append(location)
 
-                if location not in self._progress_store.get_completed_locations(
-                    section_id=location.section_id, list_item_id=location.list_item_id
+                if (
+                    location.block_id
+                    not in self._progress_store.get_completed_block_ids(
+                        section_id=location.section_id,
+                        list_item_id=location.list_item_id,
+                    )
                 ):
                     return allowable_path
 

--- a/tests/app/data_model/test_questionnaire_store.py
+++ b/tests/app/data_model/test_questionnaire_store.py
@@ -6,7 +6,6 @@ import simplejson as json
 from app.data_model.answer_store import AnswerStore
 from app.data_model.progress_store import ProgressStore, CompletionStatus
 from app.data_model.questionnaire_store import QuestionnaireStore
-from app.questionnaire.location import Location
 
 
 def get_basic_input():
@@ -19,9 +18,7 @@ def get_basic_input():
                 'section_id': 'a-test-section',
                 'list_item_id': 'abc123',
                 'status': CompletionStatus.COMPLETED,
-                'locations': [
-                    {'section_id': 'a-test-section', 'block_id': 'a-test-block'}
-                ],
+                'block_ids': ['a-test-block'],
             }
         ],
         'COLLECTION_METADATA': {'test-meta': 'test'},
@@ -37,7 +34,7 @@ def get_input_answers_dict():
                 'section_id': 'a-test-section',
                 'list_item_id': None,
                 'status': CompletionStatus.COMPLETED,
-                'locations': [{'block_id': 'a-test-block'}],
+                'block_ids': ['a-test-block'],
             }
         ],
         'COLLECTION_METADATA': {'test-meta': 'test'},
@@ -73,17 +70,17 @@ class TestQuestionnaireStore(TestCase):
         self.assertEqual(store.collection_metadata, expected['COLLECTION_METADATA'])
         self.assertEqual(store.answer_store, AnswerStore(expected['ANSWERS']))
 
-        expected_location = expected['PROGRESS'][0]['locations'][0]
+        expected_completed_block_ids = expected['PROGRESS'][0]['block_ids'][0]
 
         self.assertEqual(
             len(
-                store.progress_store.get_completed_locations('a-test-section', 'abc123')
+                store.progress_store.get_completed_block_ids('a-test-section', 'abc123')
             ),
             1,
         )
         self.assertEqual(
-            store.progress_store.get_completed_locations('a-test-section', 'abc123')[0],
-            Location.from_dict(location_dict=expected_location),
+            store.progress_store.get_completed_block_ids('a-test-section', 'abc123')[0],
+            expected_completed_block_ids,
         )
 
     def test_questionnaire_store_ignores_extra_json(self):
@@ -100,17 +97,17 @@ class TestQuestionnaireStore(TestCase):
         self.assertEqual(store.collection_metadata, expected['COLLECTION_METADATA'])
         self.assertEqual(store.answer_store, AnswerStore(expected['ANSWERS']))
 
-        expected_location = expected['PROGRESS'][0]['locations'][0]
+        expected_completed_block_ids = expected['PROGRESS'][0]['block_ids'][0]
 
         self.assertEqual(
             len(
-                store.progress_store.get_completed_locations('a-test-section', 'abc123')
+                store.progress_store.get_completed_block_ids('a-test-section', 'abc123')
             ),
             1,
         )
         self.assertEqual(
-            store.progress_store.get_completed_locations('a-test-section', 'abc123')[0],
-            Location.from_dict(location_dict=expected_location),
+            store.progress_store.get_completed_block_ids('a-test-section', 'abc123')[0],
+            expected_completed_block_ids,
         )
 
     def test_questionnaire_store_missing_keys(self):

--- a/tests/app/questionnaire/test_path_finder.py
+++ b/tests/app/questionnaire/test_path_finder.py
@@ -22,9 +22,7 @@ class TestPathFinder(
                     'section_id': 'default-section',
                     'list_item_id': None,
                     'status': CompletionStatus.COMPLETED,
-                    'locations': [
-                        {'section_id': 'default-section', 'block_id': 'name-block'}
-                    ],
+                    'block_ids': ['name-block'],
                 }
             ]
         )
@@ -90,9 +88,7 @@ class TestPathFinder(
                     'section_id': 'default-section',
                     'list_item_id': None,
                     'status': CompletionStatus.COMPLETED,
-                    'locations': [
-                        {'section_id': 'default-section', 'block_id': 'number-question'}
-                    ],
+                    'block_ids': ['number-question'],
                 }
             ]
         )
@@ -137,12 +133,7 @@ class TestPathFinder(
                     'section_id': 'introduction-section',
                     'list_item_id': None,
                     'status': CompletionStatus.COMPLETED,
-                    'locations': [
-                        {
-                            'section_id': 'introduction-section',
-                            'block_id': 'introduction',
-                        }
-                    ],
+                    'block_ids': ['introduction'],
                 }
             ]
         )
@@ -177,14 +168,7 @@ class TestPathFinder(
                     'section_id': 'default-section',
                     'list_item_id': None,
                     'status': CompletionStatus.COMPLETED,
-                    'locations': [
-                        {'section_id': 'default-section', 'block_id': 'radio'},
-                        {
-                            'section_id': 'default-section',
-                            'block_id': 'test-number-block',
-                        },
-                        {'section_id': 'default-section', 'block_id': 'dessert-block'},
-                    ],
+                    'block_ids': ['radio', 'test-number-block', 'dessert-block'],
                 }
             ]
         )
@@ -205,17 +189,11 @@ class TestPathFinder(
                 {
                     'section_id': 'section',
                     'status': CompletionStatus.COMPLETED,
-                    'locations': [
-                        {
-                            'section_id': 'section',
-                            'block_id': 'primary-person-list-collector',
-                        },
-                        {'section_id': 'section', 'block_id': 'list-collector'},
-                        {'section_id': 'section', 'block_id': 'next-interstitial'},
-                        {
-                            'section_id': 'section',
-                            'block_id': 'another-list-collector-block',
-                        },
+                    'block_ids': [
+                        'primary-person-list-collector',
+                        'list-collector',
+                        'next-interstitial',
+                        'another-list-collector-block',
                     ],
                 }
             ]
@@ -286,12 +264,7 @@ class TestPathFinder(
                     'section_id': 'default-section',
                     'list_item_id': None,
                     'status': CompletionStatus.COMPLETED,
-                    'locations': [
-                        {
-                            'section_id': 'default-section',
-                            'block_id': 'mandatory-checkbox',
-                        }
-                    ],
+                    'block_ids': ['mandatory-checkbox'],
                 }
             ]
         )
@@ -319,9 +292,7 @@ class TestPathFinder(
                     'section_id': 'default-section',
                     'list_item_id': None,
                     'status': CompletionStatus.COMPLETED,
-                    'locations': [
-                        {'section_id': 'default-section', 'block_id': 'block1'}
-                    ],
+                    'block_ids': ['block1'],
                 }
             ]
         )
@@ -349,12 +320,7 @@ class TestPathFinder(
                     'section_id': 'introduction-section',
                     'list_item_id': None,
                     'status': CompletionStatus.COMPLETED,
-                    'locations': [
-                        {
-                            'section_id': 'introduction-section',
-                            'block_id': 'do-you-want-to-skip',
-                        }
-                    ],
+                    'block_ids': ['do-you-want-to-skip'],
                 }
             ]
         )
@@ -395,12 +361,7 @@ class TestPathFinder(
                     'section_id': 'default-section',
                     'list_item_id': None,
                     'status': CompletionStatus.COMPLETED,
-                    'locations': [
-                        {
-                            'section_id': 'default-section',
-                            'block_id': 'do-you-want-to-skip',
-                        }
-                    ],
+                    'block_ids': ['do-you-want-to-skip'],
                 }
             ]
         )
@@ -441,12 +402,7 @@ class TestPathFinder(
                     'section_id': 'default-section',
                     'list_item_id': None,
                     'status': CompletionStatus.COMPLETED,
-                    'locations': [
-                        {
-                            'section_id': 'default-section',
-                            'block_id': 'do-you-want-to-skip',
-                        }
-                    ],
+                    'block_ids': ['do-you-want-to-skip'],
                 }
             ]
         )
@@ -541,15 +497,9 @@ class TestPathFinder(
                     'section_id': 'default-section',
                     'list_item_id': None,
                     'status': CompletionStatus.COMPLETED,
-                    'locations': [
-                        {
-                            'section_id': 'default-section',
-                            'block_id': 'number-of-employees-total-block',
-                        },
-                        {
-                            'section_id': 'default-section',
-                            'block_id': 'confirm-zero-employees-block',
-                        },
+                    'block_ids': [
+                        'number-of-employees-total-block',
+                        'confirm-zero-employees-block',
                     ],
                 }
             ]
@@ -571,7 +521,7 @@ class TestPathFinder(
 
         self.assertEqual(
             len(
-                path_finder.progress_store.get_completed_locations(
+                path_finder.progress_store.get_completed_block_ids(
                     section_id='default-section'
                 )
             ),
@@ -595,10 +545,10 @@ class TestPathFinder(
         self.assertEqual(routing_path, expected_path)
 
         self.assertEqual(
-            path_finder.progress_store.get_completed_locations(
+            path_finder.progress_store.get_completed_block_ids(
                 section_id='default-section'
             ),
-            [progress_store.get_completed_locations(section_id='default-section')[0]],
+            [progress_store.get_completed_block_ids(section_id='default-section')[0]],
         )
         self.assertEqual(len(path_finder.answer_store), 1)
 

--- a/tests/app/questionnaire/test_router.py
+++ b/tests/app/questionnaire/test_router.py
@@ -88,9 +88,7 @@ class TestRouter(AppContextTestCase):
                     'section_id': 'default-section',
                     'list_item_id': None,
                     'status': CompletionStatus.COMPLETED,
-                    'locations': [
-                        {'section_id': 'default-section', 'block_id': 'name-block'}
-                    ],
+                    'block_ids': ['name-block'],
                 }
             ]
         )
@@ -164,9 +162,7 @@ class TestRouter(AppContextTestCase):
                     'section_id': 'default-section',
                     'list_item_id': None,
                     'status': CompletionStatus.COMPLETED,
-                    'locations': [
-                        {'section_id': 'default-section', 'block_id': 'name-block'}
-                    ],
+                    'block_ids': ['name-block'],
                 }
             ]
         )
@@ -184,16 +180,7 @@ class TestRouter(AppContextTestCase):
                 {
                     'section_id': 'default-section',
                     'status': CompletionStatus.COMPLETED,
-                    'locations': [
-                        {
-                            'section_id': 'default-section',
-                            'block_id': 'mandatory-checkbox',
-                        },
-                        {
-                            'section_id': 'default-section',
-                            'block_id': 'non-mandatory-checkbox',
-                        },
-                    ],
+                    'block_ids': ['mandatory-checkbox', 'non-mandatory-checkbox'],
                 }
             ]
         )
@@ -222,49 +209,18 @@ class TestRouter(AppContextTestCase):
                 {
                     'section_id': 'section',
                     'status': CompletionStatus.COMPLETED,
-                    'locations': [
-                        {
-                            'section_id': 'section',
-                            'block_id': 'primary-person-list-collector',
-                        },
-                        {'section_id': 'section', 'block_id': 'list-collector'},
-                        {'section_id': 'section', 'block_id': 'next-interstitial'},
-                        {
-                            'section_id': 'section',
-                            'block_id': 'another-list-collector-block',
-                        },
+                    'block_ids': [
+                        'primary-person-list-collector',
+                        'list-collector',
+                        'next-interstitial',
+                        'another-list-collector-block',
                     ],
                 },
                 {
                     'section_id': 'personal-details-section',
                     'status': CompletionStatus.COMPLETED,
                     'list_item_id': 'abc123',
-                    'locations': [
-                        {
-                            'section_id': 'personal-details-section',
-                            'block_id': 'proxy',
-                            'list_name': 'people',
-                            'list_item_id': 'ZywslG',
-                        },
-                        {
-                            'section_id': 'personal-details-section',
-                            'block_id': 'date-of-birth',
-                            'list_name': 'people',
-                            'list_item_id': 'ZywslG',
-                        },
-                        {
-                            'section_id': 'personal-details-section',
-                            'block_id': 'confirm-dob',
-                            'list_name': 'people',
-                            'list_item_id': 'ZywslG',
-                        },
-                        {
-                            'section_id': 'personal-details-section',
-                            'block_id': 'sex',
-                            'list_name': 'people',
-                            'list_item_id': 'ZywslG',
-                        },
-                    ],
+                    'block_ids': ['proxy', 'date-of-birth', 'confirm-dob', 'sex'],
                 },
             ]
         )
@@ -288,31 +244,19 @@ class TestRouter(AppContextTestCase):
                     'section_id': 'name-section',
                     'list_item_id': None,
                     'status': CompletionStatus.COMPLETED,
-                    'locations': [
-                        {'section_id': 'name-section', 'block_id': 'name-question'}
-                    ],
+                    'block_ids': ['name-question'],
                 },
                 {
                     'section_id': 'age-input-section',
                     'list_item_id': None,
                     'status': CompletionStatus.COMPLETED,
-                    'locations': [
-                        {
-                            'section_id': 'age-input-section',
-                            'block_id': 'dob-question-block',
-                        }
-                    ],
+                    'block_ids': ['dob-question-block'],
                 },
                 {
                     'section_id': 'age-confirmation-section',
                     'list_item_id': None,
                     'status': CompletionStatus.COMPLETED,
-                    'locations': [
-                        {
-                            'section_id': 'age-confirmation-section',
-                            'block_id': 'confirm-dob-proxy',
-                        }
-                    ],
+                    'block_ids': ['confirm-dob-proxy'],
                 },
             ]
         )
@@ -331,12 +275,7 @@ class TestRouter(AppContextTestCase):
                     'section_id': 'property-details-section',
                     'list_item_id': None,
                     'status': CompletionStatus.COMPLETED,
-                    'locations': [
-                        {
-                            'section_id': 'property-details-section',
-                            'block_id': 'insurance-type',
-                        }
-                    ],
+                    'block_ids': ['insurance-type'],
                 }
             ]
         )
@@ -369,12 +308,7 @@ class TestRouter(AppContextTestCase):
                     'section_id': 'property-details-section',
                     'list_item_id': None,
                     'status': CompletionStatus.COMPLETED,
-                    'locations': [
-                        {
-                            'section_id': 'property-details-section',
-                            'block_id': 'insurance-type',
-                        }
-                    ],
+                    'block_ids': ['insurance-type'],
                 }
             ]
         )
@@ -462,12 +396,7 @@ class TestRouter(AppContextTestCase):
             [
                 {
                     'section_id': 'household-section',
-                    'locations': [
-                        {
-                            'section_id': 'household-section',
-                            'block_id': 'does-anyone-live-here',
-                        }
-                    ],
+                    'block_ids': ['does-anyone-live-here'],
                     'status': 'COMPLETED',
                 }
             ]
@@ -497,12 +426,7 @@ class TestRouter(AppContextTestCase):
             [
                 {
                     'section_id': 'household-section',
-                    'locations': [
-                        {
-                            'section_id': 'household-section',
-                            'block_id': 'does-anyone-live-here',
-                        }
-                    ],
+                    'block_ids': ['does-anyone-live-here'],
                     'status': 'IN_PROGRESS',
                 }
             ]


### PR DESCRIPTION
### What is the context of this PR?
Currently, the progress store contains duplication of `section_id` and `list_item_id` in the state. This makes the state larger than it needs to be. This PR removes these redundant data.
Instead of storing the full location object, only the block ids are now stored. I have also removed list names as we currently do not use them.

### How to review 
- Ensure survey progress works as expected.
- Ensure the new structure is:
```
{
      "section_id": "a-section",
      "block_ids": [
        "block-one",
        "block-two",
      ],
      "status": "IN_PROGRESS",
      "list_item_id": "dEUuoF"
}
```