### PR TITLE
Fix answer and routing values mismatch errors

### DIFF
--- a/data-source/json/test_list_collector_primary_person.json
+++ b/data-source/json/test_list_collector_primary_person.json
@@ -122,7 +122,7 @@
                                             {
                                                 "condition": "equals",
                                                 "id": "anyone-usually-live-at-answer",
-                                                "value": "No, no one usually lives here"
+                                                "value": "No"
                                             }
                                         ]
                                     }

--- a/data-source/json/test_variants_question.json
+++ b/data-source/json/test_variants_question.json
@@ -374,7 +374,7 @@
                                             {
                                                 "id": "age-confirm-answer",
                                                 "condition": "equals",
-                                                "value": "no"
+                                                "value": "No"
                                             }
                                         ]
                                     }

--- a/data-source/jsonnet/england-wales/individual/blocks/identity-and-health/language.jsonnet
+++ b/data-source/jsonnet/england-wales/individual/blocks/identity-and-health/language.jsonnet
@@ -9,27 +9,27 @@ local proxyTitle = {
   ],
 };
 
+local walesString =
+  'English or Welsh';
+
+local englandString =
+  'English';
+
 local englandOption = {
-  label: 'English',
-  value: 'English',
+  label: englandString,
+  value: englandString,
 };
 
 local walesOption = {
-  label: 'English or Welsh',
-  value: 'English or Welsh',
+  label: walesString,
+  value: walesString,
 };
-
-local walesValue =
-  'English or Welsh';
-
-local englandValue =
-  'English';
 
 local nonProxyDefinitionDescription = 'Your main language is the language you use most naturally. It could be the language you use at home.';
 local proxyDefinitionDescription = 'Their main language is the language they use most naturally. It could be the language they use at home.';
 
 local routing(region_code) = (
-  local regionValue = if region_code == 'GB-WLS' then walesValue else englandValue;
+  local regionValue = if region_code == 'GB-WLS' then walesString else englandString;
   {
     block: 'national-identity',
     when: [

--- a/data-source/jsonnet/england-wales/individual/blocks/identity-and-health/language.jsonnet
+++ b/data-source/jsonnet/england-wales/individual/blocks/identity-and-health/language.jsonnet
@@ -65,7 +65,7 @@ local question(title, definitionDescription, region_code) = (
           regionOption,
           {
             label: 'Other, including British Sign Language',
-            value: 'Other',
+            value: 'Other, including British Sign Language',
             description: 'Select to enter answer',
             detail_answer: {
               id: 'language-answer-other',

--- a/data-source/jsonnet/england-wales/individual/blocks/identity-and-health/language.jsonnet
+++ b/data-source/jsonnet/england-wales/individual/blocks/identity-and-health/language.jsonnet
@@ -30,17 +30,17 @@ local proxyDefinitionDescription = 'Their main language is the language they use
 
 local routing(region_code) = (
   local regionValue = if region_code == 'GB-WLS' then walesValue else englandValue;
-    {
-      block: 'national-identity',
-      when: [
-        {
-          id: 'language-answer',
-          condition: 'equals',
-          value: regionValue
-        },
-      ],
-    }
-  );
+  {
+    block: 'national-identity',
+    when: [
+      {
+        id: 'language-answer',
+        condition: 'equals',
+        value: regionValue,
+      },
+    ],
+  }
+);
 
 local question(title, definitionDescription, region_code) = (
   local regionOption = if region_code == 'GB-WLS' then walesOption else englandOption;
@@ -96,8 +96,8 @@ function(region_code) {
   routing_rules: [
     {
       goto:
-      routing(region_code)
-     },
+        routing(region_code),
+    },
     {
       goto: {
         block: 'english',

--- a/data-source/jsonnet/england-wales/individual/blocks/identity-and-health/language.jsonnet
+++ b/data-source/jsonnet/england-wales/individual/blocks/identity-and-health/language.jsonnet
@@ -19,8 +19,28 @@ local walesOption = {
   value: 'English or Welsh',
 };
 
+local walesValue =
+  'English or Welsh';
+
+local englandValue =
+  'English';
+
 local nonProxyDefinitionDescription = 'Your main language is the language you use most naturally. It could be the language you use at home.';
 local proxyDefinitionDescription = 'Their main language is the language they use most naturally. It could be the language they use at home.';
+
+local routing(region_code) = (
+  local regionValue = if region_code == 'GB-WLS' then walesValue else englandValue;
+    {
+      block: 'national-identity',
+      when: [
+        {
+          id: 'language-answer',
+          condition: 'equals',
+          value: regionValue
+        },
+      ],
+    }
+  );
 
 local question(title, definitionDescription, region_code) = (
   local regionOption = if region_code == 'GB-WLS' then walesOption else englandOption;
@@ -45,7 +65,7 @@ local question(title, definitionDescription, region_code) = (
           regionOption,
           {
             label: 'Other, including British Sign Language',
-            value: 'Other, including British Sign Language',
+            value: 'Other',
             description: 'Select to enter answer',
             detail_answer: {
               id: 'language-answer-other',
@@ -75,29 +95,9 @@ function(region_code) {
   ],
   routing_rules: [
     {
-      goto: {
-        block: 'national-identity',
-        when: [
-          {
-            id: 'language-answer',
-            condition: 'equals',
-            value: 'English',
-          },
-        ],
-      },
-    },
-    {
-      goto: {
-        block: 'national-identity',
-        when: [
-          {
-            id: 'language-answer',
-            condition: 'equals',
-            value: 'English or Welsh',
-          },
-        ],
-      },
-    },
+      goto:
+      routing(region_code)
+     },
     {
       goto: {
         block: 'english',


### PR DESCRIPTION
### What is the context of this PR?
This fixes existing routing errors detected by new validator method which checks for answer and routing values mismatches. Routing in census schemas has to be generated dynamically based on region code of given schema.

### How to review 
Build schemas and check if "national-identity" routing uses default "english" and "English" in case of gb_eng census schemas or "English or Welsh" in gb_wls census schemas. The main language question should now lead to national identity one. There are also two test schemas affected by this fix.
