### PR TITLE
Improve flush logging

### DIFF
--- a/app/routes/flush.py
+++ b/app/routes/flush.py
@@ -64,9 +64,12 @@ def _submit_data(user):
         )
         full_routing_path = path_finder.full_routing_path()
 
-        message = json.dumps(convert_answers(
-            schema, questionnaire_store, full_routing_path, flushed=True
-        ), for_json=True)
+        message = json.dumps(
+            convert_answers(
+                schema, questionnaire_store, full_routing_path, flushed=True
+            ),
+            for_json=True,
+        )
 
         encrypted_message = encrypt(
             message, current_app.eq['key_store'], KEY_PURPOSE_SUBMISSION

--- a/app/routes/flush.py
+++ b/app/routes/flush.py
@@ -1,3 +1,4 @@
+import simplejson as json
 from flask import Blueprint, Response, request, session, current_app
 from sdc.crypto.encrypter import encrypt
 from sdc.crypto.decrypter import decrypt
@@ -58,9 +59,10 @@ def _submit_data(user):
         )
         full_routing_path = path_finder.full_routing_path()
 
-        message = convert_answers(
+        message = json.dumps(convert_answers(
             schema, questionnaire_store, full_routing_path, flushed=True
-        )
+        ), for_json=True)
+
         encrypted_message = encrypt(
             message, current_app.eq['key_store'], KEY_PURPOSE_SUBMISSION
         )

--- a/app/routes/flush.py
+++ b/app/routes/flush.py
@@ -86,10 +86,10 @@ def _submit_data(user):
             raise SubmissionFailedException()
 
         get_questionnaire_store(user.user_id, user.user_ik).delete()
-        logger.info("successfully flushed answers")
+        logger.info('successfully flushed answers')
         return True
 
-    logger.info("no answers found to flush")
+    logger.info('no answers found to flush')
     return False
 
 

--- a/app/routes/flush.py
+++ b/app/routes/flush.py
@@ -1,11 +1,11 @@
 import simplejson as json
 from flask import Blueprint, Response, request, session, current_app
-from sdc.crypto.encrypter import encrypt
 from sdc.crypto.decrypter import decrypt
-
+from sdc.crypto.encrypter import encrypt
+from structlog import get_logger
 
 from app.authentication.user import User
-from app.globals import get_answer_store, get_questionnaire_store
+from app.globals import get_answer_store, get_questionnaire_store, get_metadata
 from app.keys import KEY_PURPOSE_AUTHENTICATION, KEY_PURPOSE_SUBMISSION
 from app.questionnaire.path_finder import PathFinder
 from app.submitter.converter import convert_answers
@@ -13,6 +13,8 @@ from app.submitter.submission_failed import SubmissionFailedException
 from app.utilities.schema import load_schema_from_metadata
 
 flush_blueprint = Blueprint('flush', __name__)
+
+logger = get_logger()
 
 
 @flush_blueprint.route('/flush', methods=['POST'])
@@ -36,6 +38,9 @@ def flush_data():
 
     if roles and 'flusher' in roles:
         user = _get_user(decrypted_token['response_id'])
+        metadata = get_metadata(user)
+        if 'tx_id' in metadata:
+            logger.bind(tx_id=metadata['tx_id'])
         if _submit_data(user):
             return Response(status=200)
         return Response(status=404)
@@ -78,8 +83,10 @@ def _submit_data(user):
             raise SubmissionFailedException()
 
         get_questionnaire_store(user.user_id, user.user_ik).delete()
+        logger.info("successfully flushed answers")
         return True
 
+    logger.info("no answers found to flush")
     return False
 
 

--- a/tests/integration/test_flush_data.py
+++ b/tests/integration/test_flush_data.py
@@ -103,7 +103,7 @@ class TestFlushData(IntegrationTestCase):
         self.encrypt_instance.assert_called_once()  # pylint: disable=no-member
         args = self.encrypt_instance.call_args[0]  # pylint: disable=no-member
 
-        self.assertTrue(args[0]['flushed'])
+        self.assertTrue('"flushed": true' in args[0])
 
     @staticmethod
     def get_payload():
@@ -111,9 +111,6 @@ class TestFlushData(IntegrationTestCase):
             'jti': str(uuid.uuid4()),
             'iat': time.time(),
             'exp': time.time() + 1000,
-            'schema_name': 'test_textfield',
-            'collection_exercise_sid': '789',
-            'ru_ref': '123456789012A',
             'response_id': '1234567890123456',
             'roles': ['flusher'],
         }


### PR DESCRIPTION
### What is the context of this PR?

Adds additional context to flush logging through use of the tx_id.

### How to review 

- Begin a survey through launcher, making a note of the the schema/response_id
- Answer a few questions/or none
- Save and sign out to return to launcher
- Populate the response_id/schema fields to match what survey was started with
- Switch from dumper to flusher and click flush survey data
- Confirm the log messages match the state of the answers made

