### PR TITLE
Fix answer and when rules values mismatch errors

### DIFF
--- a/data-source/jsonnet/england-wales/individual/blocks/personal-details/term_time_location.jsonnet
+++ b/data-source/jsonnet/england-wales/individual/blocks/personal-details/term_time_location.jsonnet
@@ -123,7 +123,7 @@ local otherNonUkAddressOptions = {
         {
           id: 'another-address-answer',
           condition: 'equals',
-          value: 'Other',
+          value: 'Yes, an address outside the UK',
         },
       ],
     },
@@ -134,7 +134,7 @@ local otherNonUkAddressOptions = {
         {
           id: 'another-address-answer',
           condition: 'equals',
-          value: 'Other',
+          value: 'Yes, an address outside the UK',
         },
       ],
     },


### PR DESCRIPTION
### What is the context of this PR?
This fixes existing routing errors detected by new validator method which checks for answer and when values mismatches. It adds a fix to census schema to make it pass validator check after merge of new validator branch. 

### How to review 
Build schemas and check if "term-time-location" routing uses default "Yes, an address outside the UK" routing from "another-address" question.