### PR TITLE
Re-implement the view answers after submission page

### DIFF
--- a/app/translations/ccs_household_gb_eng.pot
+++ b/app/translations/ccs_household_gb_eng.pot
@@ -1,14 +1,14 @@
 # Translations template for PROJECT.
-# Copyright (C) 2019 ORGANIZATION
+# Copyright (C) 2020 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 #
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-12-18 15:04+0000\n"
+"POT-Creation-Date: 2020-01-07 08:29+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/app/translations/census_household_gb_nir.pot
+++ b/app/translations/census_household_gb_nir.pot
@@ -1,14 +1,14 @@
 # Translations template for PROJECT.
-# Copyright (C) 2019 ORGANIZATION
+# Copyright (C) 2020 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 #
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-12-18 15:04+0000\n"
+"POT-Creation-Date: 2020-01-07 08:29+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/app/translations/census_household_gb_wls.pot
+++ b/app/translations/census_household_gb_wls.pot
@@ -1,14 +1,14 @@
 # Translations template for PROJECT.
-# Copyright (C) 2019 ORGANIZATION
+# Copyright (C) 2020 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 #
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-12-18 15:04+0000\n"
+"POT-Creation-Date: 2020-01-07 08:29+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/app/translations/census_individual_gb_nir.pot
+++ b/app/translations/census_individual_gb_nir.pot
@@ -1,14 +1,14 @@
 # Translations template for PROJECT.
-# Copyright (C) 2019 ORGANIZATION
+# Copyright (C) 2020 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 #
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-12-18 15:04+0000\n"
+"POT-Creation-Date: 2020-01-07 08:29+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/app/translations/census_individual_gb_wls.pot
+++ b/app/translations/census_individual_gb_wls.pot
@@ -1,14 +1,14 @@
 # Translations template for PROJECT.
-# Copyright (C) 2019 ORGANIZATION
+# Copyright (C) 2020 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 #
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-12-18 15:04+0000\n"
+"POT-Creation-Date: 2020-01-07 08:29+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/app/translations/messages.pot
+++ b/app/translations/messages.pot
@@ -1,14 +1,14 @@
 # Translations template for PROJECT.
-# Copyright (C) 2019 ORGANIZATION
+# Copyright (C) 2020 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 #
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-12-18 16:11+0000\n"
+"POT-Creation-Date: 2020-01-07 08:29+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -377,16 +377,35 @@ msgstr ""
 msgid "We may contact you to query your answers via phone or secure message."
 msgstr ""
 
-#: templates/thank-you.html:32
+#: templates/thank-you.html:33
 msgid "For more information on how we use this data."
 msgstr ""
 
-#: templates/thank-you.html:34
+#: templates/thank-you.html:35
 msgid "Thank you for submitting your census"
 msgstr ""
 
-#: templates/thank-you.html:36
+#: templates/thank-you.html:37
 msgid "We have received your answers and you do not need to do anything else."
+msgstr ""
+
+#: templates/thank-you.html:44
+msgid "View and print a copy of your answers"
+msgstr ""
+
+#: templates/thank-you.html:45
+#, python-format
+msgid ""
+"Your answers will only be available for <b>%(duration)s</b> to keep them "
+"secure."
+msgstr ""
+
+#: templates/thank-you.html:50
+msgid "You are no longer able to view and print your answers"
+msgstr ""
+
+#: templates/thank-you.html:51
+msgid "The link expires to maintain the security of your information"
 msgstr ""
 
 #: templates/view-submission.html:7

--- a/app/translations/test_language.pot
+++ b/app/translations/test_language.pot
@@ -1,14 +1,14 @@
 # Translations template for PROJECT.
-# Copyright (C) 2019 ORGANIZATION
+# Copyright (C) 2020 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 #
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-12-18 15:04+0000\n"
+"POT-Creation-Date: 2020-01-07 08:29+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/data-source/jsonnet/england-wales/census_household.jsonnet
+++ b/data-source/jsonnet/england-wales/census_household.jsonnet
@@ -122,6 +122,10 @@ function(region_code, census_date, census_month_year_date) {
   navigation: {
     visible: false,
   },
+  view_submitted_response: {
+    enabled: true,
+    duration: 900,
+  },
   metadata: [
     {
       name: 'user_id',

--- a/data-source/jsonnet/england-wales/census_individual.jsonnet
+++ b/data-source/jsonnet/england-wales/census_individual.jsonnet
@@ -89,6 +89,10 @@ function(region_code, census_date, census_month_year_date) {
   navigation: {
     visible: false,
   },
+  view_submitted_response: {
+    enabled: true,
+    duration: 900,
+  },
   metadata: [
     {
       name: 'user_id',

--- a/templates/thank-you.html
+++ b/templates/thank-you.html
@@ -29,10 +29,31 @@
       <p class="u-mb-s">{{ _("Your answers will be processed in the next few weeks.") }}
       {{ _("We may contact you to query your answers via phone or secure message.") }}</p>
 
+
       <p class="u-mb-s">{{ _("For more information on how we use this data.") }}<br><a href="https://www.ons.gov.uk/surveys">https://www.ons.gov.uk/surveys</a></p>
   {% else %}
       <h1 data-qa="submission-successful-title"><span class="icon--check-green"></span>{{ _("Thank you for submitting your census") }}</h1>
 
       <p class="u-mb-s">{{ _("We have received your answers and you do not need to do anything else.") }}</p>
   {% endif %}
+
+  {% block view_submission %}
+    {% if is_view_submitted_response_enabled %}
+      <div class="u-mb-s">
+        {% if view_submission_url %}
+          <p class="u-mb-m@s u-fs-r" data-qa="view-submission"><a href={{view_submission_url}}>{{ _("View and print a copy of your answers") }}</a></p>
+          <p class="u-mb-s u-fs-r">{{ _("Your answers will only be available for <b>%(duration)s</b> to keep them secure.",
+                                                                                        duration=view_submission_duration) }}</p>
+        {% else %}
+          <div class="panel panel--simple panel--info" data-qa="view-submission-expired">
+          <div class="panel__body">
+          <p>{{ _("You are no longer able to view and print your answers") }}.</p>
+          <p>{{ _("The link expires to maintain the security of your information") }}.</p>
+          </div>
+      </div>
+    {% endif %}
+    </div>
+  {% endif %}
+  {% endblock %}
+
 {% endblock %}


### PR DESCRIPTION
### What is the context of this PR?
This PR has been raised to re-implement the the view answers after submission page.

I have made the link to this page available from the "Thank You" page. For census, the page is available for 15 minutes post submission.

### How to review 
Check that the view answers link has been added to the thank you page for the census household/individual schema, and that it is only available for 15 minutes. 
