### PR TITLE
Add census schemas to docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ COPY Pipfile.lock Pipfile.lock
 RUN pip install pipenv==2018.11.26
 
 RUN pipenv install --deploy --system
+RUN make load-schemas
 RUN make build
 
 CMD ["sh", "docker-entrypoint.sh"]


### PR DESCRIPTION
### What is the context of this PR?

Census schemas need to be brought down as part of the docker build and were accidentally removed as part of https://github.com/ONSdigital/eq-questionnaire-runner/pull/27.

### How to test

Check that the schemas appear in runner when calling docker-compose up, after runner has been rebuilt.
