### PR TITLE
Use correct sha for pull requests

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Install apt dependencies
         run: sudo apt-get install libsnappy-dev libgconf-2-4
       - name: Write app version
-        run: printf "$GITHUB_SHA" > .application-version
+        run: printf "${{ github.event.pull_request.head.sha }}" > .application-version
       - name: Install pipenv
         run: pip install pipenv==2018.11.26
       - name: Cache virtualenv
@@ -144,7 +144,7 @@ jobs:
       steps:
         - uses: actions/checkout@v2
         - name: Write app version
-          run: printf "$GITHUB_SHA" > .application-version
+          run: printf "${{ github.event.pull_request.head.sha }}" > .application-version
         - name: Tag
           run: |
             export BRANCH=${{ github.event.pull_request.head.ref }}


### PR DESCRIPTION
### What is the context of this PR?

As per the actions docs here: https://help.github.com/en/actions/automating-your-workflow-with-github-actions/events-that-trigger-workflows the $GITHUB_SHA environment variable returns different values depending on the event that triggered it. On a pull_request, it is the merge commit on the branch, rather than the sha of the trigger commit. This means that the .application-version is currently incorrect on builds from our PRs.

This reverts the recent changes for the PR workflow.

### How to review 
Confirm that the sha in dockerhub image matches that of the commit for this PR (9dc2ccc7f1fd0350fab0c1bc6113406549f460d4). Update your docker-compose file to point to onsdigital/eq-questionnaire-runner:branch-use-head-sha-on-pr and check that /status returns the commit when brought up.

