### PR TITLE
Use new questionnaire-validator repo

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -88,7 +88,7 @@ jobs:
       runs-on: ubuntu-latest
       services:
         validator:
-          image: onsdigital/eq-schema-validator:v3
+          image: onsdigital/eq-questionnaire-validator:latest
           ports:
             - 5001:5000
       steps:
@@ -146,9 +146,7 @@ jobs:
         - name: Write app version
           run: printf "${{ github.event.pull_request.head.sha }}" > .application-version
         - name: Tag
-          run: |
-            export BRANCH=${{ github.event.pull_request.head.ref }}
-            echo "::set-env name=TAG::branch-$BRANCH"
+          run: echo "::set-env name=TAG::${{ github.event.pull_request.head.ref }}"
         - name: Build
           run: docker build -t onsdigital/eq-questionnaire-runner:$TAG .
         - name: Push

--- a/scripts/run_validator.sh
+++ b/scripts/run_validator.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-branch=v3
-docker pull onsdigital/eq-schema-validator:$branch
-docker run -d -p 5001:5000 "onsdigital/eq-schema-validator:$branch"
+branch=eq-create-questionnaire-validator
+docker pull onsdigital/eq-questionnaire-validator:$branch
+docker run -d -p 5001:5000 "onsdigital/eq-questionnaire-validator:$branch"

--- a/scripts/run_validator.sh
+++ b/scripts/run_validator.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-branch=eq-create-questionnaire-validator
+branch=latest
 docker pull onsdigital/eq-questionnaire-validator:$branch
 docker run -d -p 5001:5000 "onsdigital/eq-questionnaire-validator:$branch"


### PR DESCRIPTION
### What is the context of this PR?

Update runner and github actions to use the new questionnaire-validator repo.

### How to review 

You can check locally by using `pipenv run ./scripts/run_validator.sh` and then `pipenv run ./scripts/validate_test_schemas.sh`

Depends on [the following pr](https://github.com/ONSdigital/eq-questionnaire-validator/pull/1), which will cause actions to fail until it's merged.

