### PR TITLE
Update runner config name

### DIFF
--- a/k8s/helm/templates/deployment.yaml
+++ b/k8s/helm/templates/deployment.yaml
@@ -92,10 +92,10 @@ spec:
             - name: EQ_REDIS_HOST
               valueFrom:
                 configMapKeyRef:
-                  name: runner-config
+                  name: runner-redis-config
                   key: redis_host
             - name: EQ_REDIS_PORT
               valueFrom:
                 configMapKeyRef:
-                  name: runner-config
+                  name: runner-redis-config
                   key: redis_port


### PR DESCRIPTION
### What is the context of this PR?
The config map name was changed in https://github.com/ONSdigital/eq-terraform-gcp/blob/master/deploy_infrastructure.sh#L33

This PR changes the config name to match the change.

Note: This cannot be merged until staging and whitelodge is using `eq-terraform-gcp

### How to review 
- Deploy the infrastructure using `eq-terraform-gcp`.
- Helm deploy runner using this branch and ensure runner deploys successfully.