### PR TITLE
Run validator script on PR over service

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -86,13 +86,10 @@ jobs:
         run: pipenv run ./scripts/run_tests_unit.sh
   validate-schemas:
       runs-on: ubuntu-latest
-      services:
-        validator:
-          image: onsdigital/eq-questionnaire-validator:latest
-          ports:
-            - 5001:5000
       steps:
         - uses: actions/checkout@v2
+        - name: Run validator
+          run: ./scripts/run_validator.sh
         - name: Running schema tests
           run: ./scripts/validate_test_schemas.sh
   test-functional:


### PR DESCRIPTION
### What is the context of this PR?
We currently run validator as a docker service image within our action PR workflow, which means for every validator change we make we need to update both the workflow and script to run the appropriate validator branch.

If we change to use our existing script, we don't duplicate the branch or run the risk of accidentally committing a broken PR template into runner using the wrong branch.

### How to review 

Decide if your happy with the change.
