### PR TITLE
Fix placeholder rendering of Checkbox answer on the summary pages

### DIFF
--- a/app/jinja_filters.py
+++ b/app/jinja_filters.py
@@ -397,7 +397,8 @@ class SummaryRowItem:
             self.valueList = [SummaryRowItemValue(no_answer_provided)]
         elif answer_type == "checkbox":
             self.valueList = [
-                SummaryRowItemValue(val.label, val.detail_answer_value) for val in value
+                SummaryRowItemValue(option["label"], option["detail_answer_value"])
+                for option in value
             ]
         elif answer_type == "currency":
             self.valueList = [

--- a/app/views/contexts/summary/question.py
+++ b/app/views/contexts/summary/question.py
@@ -1,5 +1,3 @@
-import collections
-
 from jinja2 import escape
 
 from app.views.contexts.summary.answer import Answer
@@ -74,9 +72,6 @@ class Question:
 
     def _build_checkbox_answers(self, answer, answer_schema, answer_store):
         multiple_answers = []
-        CheckboxSummaryAnswer = collections.namedtuple(
-            "CheckboxSummaryAnswer", "label detail_answer_value"
-        )
         for option in answer_schema["options"]:
             if option["value"] in answer:
                 detail_answer_value = self._get_detail_answer_value(
@@ -84,9 +79,10 @@ class Question:
                 )
 
                 multiple_answers.append(
-                    CheckboxSummaryAnswer(
-                        label=option["label"], detail_answer_value=detail_answer_value
-                    )
+                    {
+                        "label": option["label"],
+                        "detail_answer_value": detail_answer_value,
+                    }
                 )
 
         return multiple_answers or None

--- a/test_schemas/en/test_placeholder_full.json
+++ b/test_schemas/en/test_placeholder_full.json
@@ -19,6 +19,10 @@
             "type": "string"
         },
         {
+            "name": "display_address",
+            "type": "string"
+        },
+        {
             "name": "ru_name",
             "type": "string"
         }
@@ -246,6 +250,73 @@
                     ],
                     "id": "group",
                     "title": ""
+                }
+            ]
+        },
+        {
+            "id": "mutually-exclusive-checkbox-section",
+            "title": "Checkbox",
+            "groups": [
+                {
+                    "id": "mutually-exclusive-mandatory-group",
+                    "title": "",
+                    "blocks": [
+                        {
+                            "type": "Question",
+                            "id": "mutually-exclusive-checkbox",
+                            "question": {
+                                "id": "mutually-exclusive-checkbox-question",
+                                "type": "MutuallyExclusive",
+                                "title": "Were you a resident at any of the following addresses?",
+                                "mandatory": true,
+                                "answers": [
+                                    {
+                                        "id": "checkbox-answer",
+                                        "label": "Select an answer",
+                                        "type": "Checkbox",
+                                        "mandatory": false,
+                                        "options": [
+                                            {
+                                                "label": {
+                                                    "placeholders": [
+                                                        {
+                                                            "placeholder": "household_address",
+                                                            "value": {
+                                                                "identifier": "display_address",
+                                                                "source": "metadata"
+                                                            }
+                                                        }
+                                                    ],
+                                                    "text": "{household_address}"
+                                                },
+                                                "value": "{household_address}"
+                                            },
+                                            {
+                                                "label": "7 Evelyn Street, Barry",
+                                                "value": "7 Evelyn Street, Barry"
+                                            },
+                                            {
+                                                "label": "251 Argae Lane, Barry",
+                                                "value": "251 Argae Lane, Barry"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "id": "checkbox-exclusive-answer",
+                                        "mandatory": false,
+                                        "type": "Checkbox",
+                                        "options": [
+                                            {
+                                                "label": "I prefer not to say",
+                                                "description": "Some description",
+                                                "value": "I prefer not to say"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    ]
                 }
             ]
         },

--- a/tests/app/questionnaire/test_router.py
+++ b/tests/app/questionnaire/test_router.py
@@ -366,6 +366,12 @@ class TestRouter(AppContextTestCase):  # pylint: disable=too-many-public-methods
                     "status": CompletionStatus.COMPLETED,
                     "block_ids": ["confirm-dob-proxy"],
                 },
+                {
+                    "section_id": "mutually-exclusive-checkbox-section",
+                    "list_item_id": None,
+                    "status": CompletionStatus.COMPLETED,
+                    "block_ids": ["mutually-exclusive-checkbox"],
+                },
             ]
         )
 

--- a/tests/app/views/contexts/summary/test_question.py
+++ b/tests/app/views/contexts/summary/test_question.py
@@ -193,8 +193,8 @@ class TestQuestion(AppContextTestCase):  # pylint: disable=too-many-public-metho
 
         # Then
         self.assertEqual(len(question.answers[0]["value"]), 2)
-        self.assertEqual(question.answers[0]["value"][0].label, "Light Side label")
-        self.assertEqual(question.answers[0]["value"][1].label, "Dark Side label")
+        self.assertEqual(question.answers[0]["value"][0]["label"], "Light Side label")
+        self.assertEqual(question.answers[0]["value"][1]["label"], "Dark Side label")
 
     def test_checkbox_button_detail_answer_empty(self):
         # Given
@@ -228,8 +228,8 @@ class TestQuestion(AppContextTestCase):  # pylint: disable=too-many-public-metho
 
         # Then
         self.assertEqual(len(question.answers[0]["value"]), 1)
-        self.assertEqual(question.answers[0]["value"][0].label, "Other option label")
-        self.assertEqual(question.answers[0]["value"][0].detail_answer_value, None)
+        self.assertEqual(question.answers[0]["value"][0]["label"], "Other option label")
+        self.assertEqual(question.answers[0]["value"][0]["detail_answer_value"], None)
 
     def test_checkbox_answer_with_detail_answer_returns_the_value(self):
         # Given
@@ -266,7 +266,7 @@ class TestQuestion(AppContextTestCase):  # pylint: disable=too-many-public-metho
 
         # Then
         self.assertEqual(len(question.answers[0]["value"]), 2)
-        self.assertEqual(question.answers[0]["value"][1].detail_answer_value, "Test")
+        self.assertEqual(question.answers[0]["value"][1]["detail_answer_value"], "Test")
 
     def test_checkbox_answer_with_numeric_detail_answer_returns_number(self):
         # Given
@@ -303,7 +303,7 @@ class TestQuestion(AppContextTestCase):  # pylint: disable=too-many-public-metho
 
         # Then
         self.assertEqual(len(question.answers[0]["value"]), 2)
-        self.assertEqual(question.answers[0]["value"][1].detail_answer_value, 2)
+        self.assertEqual(question.answers[0]["value"][1]["detail_answer_value"], 2)
 
     def test_checkbox_button_other_option_text(self):
         # Given
@@ -339,8 +339,10 @@ class TestQuestion(AppContextTestCase):  # pylint: disable=too-many-public-metho
 
         # Then
         self.assertEqual(len(question.answers[0]["value"]), 2)
-        self.assertEqual(question.answers[0]["value"][0].label, "Light Side")
-        self.assertEqual(question.answers[0]["value"][1].detail_answer_value, "Neither")
+        self.assertEqual(question.answers[0]["value"][0]["label"], "Light Side")
+        self.assertEqual(
+            question.answers[0]["value"][1]["detail_answer_value"], "Neither"
+        )
 
     def test_checkbox_button_none_selected_should_be_none(self):
         # Given

--- a/tests/integration/integration_test_case.py
+++ b/tests/integration/integration_test_case.py
@@ -282,9 +282,7 @@ class IntegrationTestCase(unittest.TestCase):  # pylint: disable=too-many-public
         )
 
     def assertEqualPageTitle(self, title):
-        self.assertEqual(
-            self.getHtmlSoup().title.string, title
-        )  # pylint: disable=no-member
+        self.assertEqual(title, self.getHtmlSoup().title.string)
 
     def assertStatusOK(self):
         self.assertStatusCode(200)

--- a/tests/integration/questionnaire/test_questionnaire_page_titles.py
+++ b/tests/integration/questionnaire/test_questionnaire_page_titles.py
@@ -82,9 +82,11 @@ class TestQuestionnairePageTitles(IntegrationTestCase):
 
     def test_should_not_use_names_in_question_page_titles(self):
         # Given
-        self.launchSurvey("test_placeholder_full")
-        self.post({"first-name": "Kevin", "last-name": "Bacon"})
+        self.launchSurvey(
+            "test_placeholder_full", display_address="68 Abingdon Road, Goathill"
+        )
         # When
+        self.post({"first-name": "Kevin", "last-name": "Bacon"})
         # Then
         self.assertEqualPageTitle("What is … date of birth? - Placeholder Test")
 

--- a/tests/integration/questionnaire/test_questionnaire_placeholders.py
+++ b/tests/integration/questionnaire/test_questionnaire_placeholders.py
@@ -3,7 +3,9 @@ from tests.integration.integration_test_case import IntegrationTestCase
 
 class TestPlaceholders(IntegrationTestCase):
     def test_title_placeholders_rendered_in_summary(self):
-        self.launchSurvey("test_placeholder_full")
+        self.launchSurvey(
+            "test_placeholder_full", display_address="68 Abingdon Road, Goathill"
+        )
         self.assertInBody("Please enter a name")
         self.post({"first-name": "Kevin", "last-name": "Bacon"})
 
@@ -23,5 +25,10 @@ class TestPlaceholders(IntegrationTestCase):
             }
         )
 
+        self.post(
+            {"checkbox-answer": ["{household_address}", "7 Evelyn Street, Barry"]}
+        )
+
         self.assertInUrl("/summary/")
         self.assertInBody("What is Kevin Bacon’s date of birth?")
+        self.assertInBody("68 Abingdon Road, Goathill")


### PR DESCRIPTION
### What is the context of this PR?
Fixes an issue where placeholders for Checkbox answers were not being rendered correctly on summaries. 

### How to review 
Use`test_placeholder_full.json` to ensure that Checkbox answers with placeholders are rendered as expected on the summary page.