### PR TITLE
Implement strings based on a number of items

### DIFF
--- a/app/questionnaire/placeholder_parser.py
+++ b/app/questionnaire/placeholder_parser.py
@@ -20,12 +20,14 @@ class PlaceholderParser:
         metadata=None,
         list_item_id=None,
         location=None,
+        list_store=None,
     ):
 
         self._schema = schema
         self._answer_store = answer_store or AnswerStore()
         self._metadata = metadata
         self._list_item_id = list_item_id
+        self._list_store = list_store
         self._location = location
         self._transformer = PlaceholderTransforms(language)
         self._placeholder_map = {}
@@ -60,6 +62,8 @@ class PlaceholderParser:
 
         if source == "answers":
             return self._lookup_answer(source_id, self._list_item_id)
+        if source == "list":
+            return len(self._list_store[source_id].items)
         return self._metadata[source_id]
 
     def _parse_transforms(self, transform_list: Sequence[Mapping]):

--- a/app/questionnaire/plural_forms.py
+++ b/app/questionnaire/plural_forms.py
@@ -1,0 +1,27 @@
+from babel.plural import PluralRule
+
+from app.questionnaire.questionnaire_schema import DEFAULT_LANGUAGE_CODE
+
+
+def get_plural_form_key(count, language=DEFAULT_LANGUAGE_CODE):
+    mappings = {
+        "en": {"one": "n is 1"},
+        "cy": {
+            "zero": "n is 0",
+            "one": "n is 1",
+            "two": "n is 2",
+            "few": "n is 3",
+            "many": "n is 6",
+        },
+        "ga": {
+            "one": "n is 1",
+            "two": "n is 2",
+            "few": "n in 3..6",
+            "many": "n in 7..10",
+        },
+        "eo": {"one": "n is 1"},
+    }
+
+    plural_rule = PluralRule(mappings[language])
+
+    return plural_rule(count)

--- a/app/questionnaire/schema_utils.py
+++ b/app/questionnaire/schema_utils.py
@@ -1,6 +1,32 @@
 from app.questionnaire.rules import evaluate_when_rules
 
 
+def find_pointers_containing(input_data, search_key, pointer=None):
+    """
+    Recursive function which lists pointers which contain a search key
+
+    :param input_data: the input data to search
+    :param search_key: the key to search for
+    :param pointer: the key to search for
+    :return: generator of the json pointer paths
+    """
+    if isinstance(input_data, dict):
+        if search_key in input_data:
+            yield pointer or ""
+        for k, v in input_data.items():
+            if isinstance(v, dict) and search_key in v:
+                yield pointer + "/" + k if pointer else "/" + k
+            else:
+                yield from find_pointers_containing(
+                    v, search_key, pointer + "/" + k if pointer else "/" + k
+                )
+    elif isinstance(input_data, list):
+        for index, item in enumerate(input_data):
+            yield from find_pointers_containing(
+                item, search_key, "{}/{}".format(pointer, index)
+            )
+
+
 def _choose_variant(
     block,
     schema,

--- a/app/views/handlers/block.py
+++ b/app/views/handlers/block.py
@@ -58,6 +58,7 @@ class BlockHandler:
                 answer_store=self._questionnaire_store.answer_store,
                 metadata=self._questionnaire_store.metadata,
                 location=self._current_location,
+                list_store=self._questionnaire_store.list_store,
             )
 
         return self._placeholder_renderer

--- a/app/views/handlers/question.py
+++ b/app/views/handlers/question.py
@@ -63,7 +63,6 @@ class Question(BlockHandler):
         context["return_to_hub_url"] = self.get_return_to_hub_url()
 
         if "list_summary" in self.rendered_block:
-
             list_collector_context = ListCollectorContext(
                 language=self._language,
                 schema=self._schema,
@@ -79,6 +78,7 @@ class Question(BlockHandler):
                 ),
                 "editable": False,
             }
+
         return context
 
     def handle_post(self):
@@ -119,11 +119,12 @@ class Question(BlockHandler):
             self._current_location,
         )
 
-        self.page_title = self._get_page_title(variant_block)
-
         rendered_question = self.placeholder_renderer.render(
-            variant_block.pop("question"), self._current_location.list_item_id
+            variant_block["question"], self._current_location.list_item_id
         )
+
+        if variant_block["question"]:
+            self.page_title = self._get_page_title(variant_block["question"])
 
         return {**variant_block, **{"question": rendered_question}}
 
@@ -134,17 +135,15 @@ class Question(BlockHandler):
         ):
             return url_for(".get_questionnaire")
 
-    def _get_page_title(self, transformed_block):
-        question = transformed_block.get("question")
-        if question:
-            if isinstance(question["title"], str):
-                question_title = question["title"]
-            else:
-                question_title = question["title"]["text"]
+    def _get_page_title(self, question):
+        if isinstance(question["title"], str):
+            question_title = question["title"]
+        elif "text_plural" in question["title"]:
+            question_title = question["title"]["text_plural"]["forms"]["other"]
+        else:
+            question_title = question["title"]["text"]
 
-            page_title = f'{question_title} - {self._schema.json["title"]}'
-
-            return safe_content(page_title)
+        return safe_content(f'{question_title} - {self._schema.json["title"]}')
 
     def evaluate_and_update_section_status_on_list_change(self, list_name):
         section_ids = self._schema.get_section_ids_dependent_on_list(list_name)

--- a/test_schemas/en/test_plural_forms.json
+++ b/test_schemas/en/test_plural_forms.json
@@ -1,0 +1,143 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.3",
+    "survey_id": "0",
+    "title": "Test Plural Forms",
+    "theme": "default",
+    "description": "A questionnaire to test different forms of plurals",
+    "metadata": [
+        {
+            "name": "user_id",
+            "type": "string"
+        },
+        {
+            "name": "period_id",
+            "type": "string"
+        },
+        {
+            "name": "ru_name",
+            "type": "string"
+        }
+    ],
+    "sections": [
+        {
+            "id": "plural-section",
+            "title": "Test Plural Section",
+            "groups": [
+                {
+                    "id": "plural-group",
+                    "title": "Test Plurals",
+                    "blocks": [
+                        {
+                            "type": "Question",
+                            "id": "number-of-people-block",
+                            "question": {
+                                "answers": [
+                                    {
+                                        "id": "number-of-people-answer",
+                                        "label": "How many people live here?",
+                                        "mandatory": true,
+                                        "type": "Number",
+                                        "min_value": {
+                                            "value": 0
+                                        },
+                                        "max_value": {
+                                            "value": 100
+                                        }
+                                    }
+                                ],
+                                "description": "",
+                                "id": "number-of-people-question",
+                                "title": "",
+                                "type": "General"
+                            }
+                        },
+                        {
+                            "type": "Question",
+                            "id": "confirm-number-of-people",
+                            "question": {
+                                "type": "General",
+                                "id": "total-people-question",
+                                "title": {
+                                    "text_plural": {
+                                        "forms": {
+                                            "one": "{number_of_people} person lives here, is this correct?",
+                                            "other": "{number_of_people} people live here, is this correct?"
+                                        },
+                                        "count": {
+                                            "source": "answers",
+                                            "identifier": "number-of-people-answer"
+                                        }
+                                    },
+                                    "placeholders": [
+                                        {
+                                            "placeholder": "number_of_people",
+                                            "value": {
+                                                "source": "answers",
+                                                "identifier": "number-of-people-answer"
+                                            }
+                                        }
+                                    ]
+                                },
+                                "answers": [
+                                    {
+                                        "id": "confirm-count",
+                                        "mandatory": true,
+                                        "type": "Radio",
+                                        "options": [
+                                            {
+                                                "label": {
+                                                    "text_plural": {
+                                                        "forms": {
+                                                            "one": "Yes, {number_of_people} person lives here",
+                                                            "other": "Yes, {number_of_people} people live here"
+                                                        },
+                                                        "count": {
+                                                            "source": "answers",
+                                                            "identifier": "number-of-people-answer"
+                                                        }
+                                                    },
+                                                    "placeholders": [
+                                                        {
+                                                            "placeholder": "number_of_people",
+                                                            "value": {
+                                                                "source": "answers",
+                                                                "identifier": "number-of-people-answer"
+                                                            }
+                                                        }
+                                                    ]
+                                                },
+                                                "value": "Yes"
+                                            },
+                                            {
+                                                "label": "No",
+                                                "value": "No"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "submit-answers",
+            "title": "Submit answers",
+            "groups": [
+                {
+                    "blocks": [
+                        {
+                            "type": "Summary",
+                            "id": "summary"
+                        }
+                    ],
+                    "id": "confirmation-group",
+                    "title": "Submit answers"
+                }
+            ]
+        }
+    ]
+}

--- a/tests/app/questionnaire/test_placeholder_parser.py
+++ b/tests/app/questionnaire/test_placeholder_parser.py
@@ -1,4 +1,5 @@
 from app.data_model.answer_store import AnswerStore
+from app.data_model.list_store import ListStore
 from app.questionnaire.placeholder_parser import PlaceholderParser
 from app.questionnaire.questionnaire_schema import QuestionnaireSchema
 
@@ -274,6 +275,24 @@ def test_mixed_transform_placeholder_value():
     placeholders = parser(placeholder_list)
 
     assert placeholders["age"] == "20 years"
+
+
+def test_list_source_count():
+    placeholder_list = [
+        {
+            "placeholder": "number_of_people",
+            "value": {"source": "list", "identifier": "people"},
+        }
+    ]
+
+    list_store = ListStore()
+    list_store.add_list_item("people")
+    list_store.add_list_item("people")
+
+    parser = PlaceholderParser(language="en", list_store=list_store)
+    placeholders = parser(placeholder_list)
+
+    assert placeholders["number_of_people"] == 2
 
 
 def test_chain_transform_placeholder():

--- a/tests/app/questionnaire/test_plural_forms.py
+++ b/tests/app/questionnaire/test_plural_forms.py
@@ -1,0 +1,21 @@
+from app.questionnaire.plural_forms import get_plural_form_key
+
+
+def test_lookup_count_key_en():
+    assert get_plural_form_key(1) == "one"
+    assert get_plural_form_key(0) == "other"
+    assert get_plural_form_key(2) == "other"
+    assert get_plural_form_key(3) == "other"
+    assert get_plural_form_key(4) == "other"
+    assert get_plural_form_key(5) == "other"
+    assert get_plural_form_key(500) == "other"
+
+
+def test_lookup_count_key_cy():
+    assert get_plural_form_key(0, language="cy") == "zero"
+    assert get_plural_form_key(1, language="cy") == "one"
+    assert get_plural_form_key(2, language="cy") == "two"
+    assert get_plural_form_key(3, language="cy") == "few"
+    assert get_plural_form_key(6, language="cy") == "many"
+    assert get_plural_form_key(7, language="cy") == "other"
+    assert get_plural_form_key(500, language="cy") == "other"

--- a/tests/integration/questionnaire/test_questionnaire_plurals.py
+++ b/tests/integration/questionnaire/test_questionnaire_plurals.py
@@ -1,0 +1,19 @@
+from tests.integration.integration_test_case import IntegrationTestCase
+
+
+class TestQuestionnairePlurals(IntegrationTestCase):
+    def test_plural_page(self):
+        self.launchSurvey("test_plural_forms")
+
+        self.post({"number-of-people-answer": 0})
+
+        self.assertEqualPageTitle(
+            "… people live here, is this correct? - Test Plural Forms"
+        )
+        self.assertInBody("0 people live here, is this correct?")
+        self.assertInBody("Yes, 0 people live here")
+
+        # Continue check question and answer on summary
+        self.post()
+        self.assertInBody("0 people live here, is this correct?")
+        self.assertInBody("Yes, 0 people live here")


### PR DESCRIPTION
### What is the context of this PR?

Adds the ability to use plural variations of a string using babel to look up an appropriate key based on a value. Based on the proposal found [here](https://github.com/ONSdigital/eq-schema-validator/blob/v3/doc/decisions/0003-plural-forms-in-schema-text.md). Added the ability to use the length of a list as a placeholder.

Both english and welsh rule maps are added but translation is not handled as part of this card.

Depends on the [following validator PR](https://github.com/ONSdigital/eq-questionnaire-validator/pull/4), which ignores validation of text_plural labels.

### How to review 

Check you agree with the approach and that tests pass.

