### PR TITLE
Allow unbound variable in deploy_app.sh

### DIFF
--- a/k8s/deploy_app.sh
+++ b/k8s/deploy_app.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euxo pipefail
+set -exo pipefail
 
 if [[ -z "$SUBMISSION_BUCKET_NAME" ]]; then
   echo "SUBMISSION_BUCKET_NAME is mandatory"


### PR DESCRIPTION
### What is the context of this PR?
Old pipelines are failing since they do not pass all the variables into `deploy_app.sh`. This PR ensures the script still works even when a variable isn't set.

### How to review 
Try to deploy the app without setting a variable like `GOOGLE_TAG_MANAGER_ID` and ensure it deploys as expected.
