### PR TITLE
Remove GCR image publishing

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -14,16 +14,9 @@ jobs:
           run: printf "$GITHUB_SHA" > .application-version
         - name: Build
           run: >
-            docker build -t onsdigital/eq-questionnaire-runner:latest
-            -t ${{ secrets.GCR_NAME }}/eq-questionnaire-runner:latest
-            -t ${{ secrets.GCR_NAME }}/eq-questionnaire-runner:$GITHUB_SHA .
+            docker build -t onsdigital/eq-questionnaire-runner:latest .
         - name: Push to Docker Hub
           run: |
             echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
             echo "Pushing with tag [latest]"
             docker push onsdigital/eq-questionnaire-runner:latest
-        - name: Push to GCR
-          run: |
-            echo ${{ secrets.DOCKER_GCR_PASSWORD }} | base64 --decode | docker login --username ${{ secrets.DOCKER_GCR_USERNAME }} --password-stdin https://eu.gcr.io
-            echo "Pushing to GCR with tags [latest, $GITHUB_SHA]"
-            docker push ${{ secrets.GCR_NAME }}/eq-questionnaire-runner

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -153,15 +153,9 @@ jobs:
             printf $SHA > .application-version
         - name: Build
           run: >
-            docker build -t onsdigital/eq-questionnaire-runner:$TAG -t ${{ secrets.GCR_NAME }}/eq-questionnaire-runner:$TAG
-            -t eu.gcr.io/census-eq-ci/eq-questionnaire-runner:$SHA .
+            docker build -t onsdigital/eq-questionnaire-runner:$TAG .
         - name: Push to Docker Hub
           run: |
             echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
             echo "Pushing to DockerHub with tag $TAG"
             docker push onsdigital/eq-questionnaire-runner
-        - name: Push to GCR
-          run: |
-            echo ${{ secrets.DOCKER_GCR_PASSWORD }} | base64 --decode | docker login --username ${{ secrets.DOCKER_GCR_USERNAME }} --password-stdin https://eu.gcr.io
-            echo "Pushing to GCR with tags [$TAG, $SHA]"
-            docker push ${{ secrets.GCR_NAME}}/eq-questionnaire-runner

--- a/docker-compose-dev-linux.yml
+++ b/docker-compose-dev-linux.yml
@@ -14,7 +14,7 @@ services:
 
   eq-questionnaire-launcher:
     network_mode: "host"
-    image: eu.gcr.io/census-eq-ci/eq-questionnaire-launcher:latest
+    image: onsdigital/eq-questionnaire-launcher:latest
     environment:
       SURVEY_RUNNER_URL: http://localhost:5000
       SURVEY_RUNNER_SCHEMA_URL: http://localhost:5000

--- a/docker-compose-dev-mac.yml
+++ b/docker-compose-dev-mac.yml
@@ -13,7 +13,7 @@ services:
       - "6379:6379"
 
   eq-questionnaire-launcher:
-    image: eu.gcr.io/census-eq-ci/eq-questionnaire-launcher:latest
+    image: onsdigital/eq-questionnaire-launcher:latest
     environment:
       SURVEY_RUNNER_URL: http://localhost:5000
       SURVEY_RUNNER_SCHEMA_URL: http://docker.for.mac.host.internal:5000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - "5000:5000"
 
   eq-questionnaire-launcher:
-    image: eu.gcr.io/census-eq-ci/eq-questionnaire-launcher:latest
+    image: onsdigital/eq-questionnaire-launcher:latest
     environment:
       SURVEY_RUNNER_URL: http://localhost:5000
       SURVEY_RUNNER_SCHEMA_URL: http://eq-questionnaire-runner:5000


### PR DESCRIPTION
### What is the context of this PR?
Removes the publishing to GCR as part of the Github actions.

This shouldn't be merged until the new pipeline in https://github.com/ONSdigital/census-eq-concourse/pull/46 is running in Concourse.

### How to review 
- Check that all references to GCR are removed