### PR TITLE
Verify Kubernetes deployment success on app deploy

### DIFF
--- a/ci/deploy_app.yaml
+++ b/ci/deploy_app.yaml
@@ -46,3 +46,5 @@ run:
 
       cd eq-questionnaire-runner
       ./k8s/deploy_app.sh
+
+      kubectl rollout status deployment.v1.apps/runner


### PR DESCRIPTION
### What is the context of this PR?
Currently we verify app deployment success with the `wait` task. This polls the status endpoint waiting for the version returned to match the requested deploy version. This means a deployment is considered complete as soon as one pod returns the updated version, even though other pods may not have been updated yet. This issue would be more apparent in larger scale environments.

This pull request proposes using the Kubernetes deployment status to verify deployment success. `kubectl` provides a way to check for completion of a deployment via the `rollout status` command (see https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#deployment-status). This command returns a zero exit code when deployment is successful and will time out if the progress deadline is reached.

### How to review 
- If you don't already have a deployed environment, create one
- Deploy the app via the Concourse task:
```
REGION=europe-west2 \
PROJECT_ID=<your_project_id> \
SUBMISSION_BUCKET_NAME=<your_project_id>-survey-runner-submission DOCKER_REGISTRY=onsdigital \
IMAGE_TAG=latest \
REQUESTED_CPU_PER_POD=3 \
MIN_REPLICAS=2 \
MAX_REPLICAS=3 \
fly -t census-development execute \
  --config ci/deploy_app.yaml
```
- Deploy a failing version of the app via the Concourse task. I have pushed a bad release to docker hub (`bad-release`) for testing this that returns a 500 error code for the `/status` endpoint:
```
REGION=europe-west2 \
PROJECT_ID=<your_project_id> \
SUBMISSION_BUCKET_NAME=<your_project_id>-survey-runner-submission \
DOCKER_REGISTRY=ajmaddaford \
IMAGE_TAG=bad-release \
REQUESTED_CPU_PER_POD=3 \
MIN_REPLICAS=2 \
MAX_REPLICAS=3 \
fly -t census-development execute \
  --config ci/deploy_app.yaml
```

### Example output

Successful deployment:
```
+ kubectl rollout status deployment.v1.apps/runner
Waiting for deployment "runner" rollout to finish: 1 out of 2 new replicas have been updated...
Waiting for deployment "runner" rollout to finish: 1 out of 2 new replicas have been updated...
Waiting for deployment "runner" rollout to finish: 1 out of 2 new replicas have been updated...
Waiting for deployment "runner" rollout to finish: 1 old replicas are pending termination...
Waiting for deployment spec update to be observed...
Waiting for deployment "runner" rollout to finish: 2 out of 3 new replicas have been updated...
Waiting for deployment "runner" rollout to finish: 2 out of 3 new replicas have been updated...
Waiting for deployment "runner" rollout to finish: 1 old replicas are pending termination...
Waiting for deployment "runner" rollout to finish: 1 old replicas are pending termination...
Waiting for deployment "runner" rollout to finish: 1 old replicas are pending termination...
deployment "runner" successfully rolled out
```

Failed deployment:
```
+ kubectl rollout status deployment.v1.apps/runner
Waiting for deployment spec update to be observed...
Waiting for deployment "runner" rollout to finish: 0 out of 2 new replicas have been updated...
Waiting for deployment "runner" rollout to finish: 0 out of 2 new replicas have been updated...
Waiting for deployment "runner" rollout to finish: 0 out of 2 new replicas have been updated...
Waiting for deployment "runner" rollout to finish: 1 out of 2 new replicas have been updated...
error: deployment "runner" exceeded its progress deadline
```