### PR TITLE
Remove autocomplete when using lookups

### DIFF
--- a/templates/partials/answers/textfield.html
+++ b/templates/partials/answers/textfield.html
@@ -32,6 +32,9 @@
     "ariaLimitedResults": "Results have been limited to 10 suggestions. Type more characters to improve your search.",
     "typeaheadData": answer.suggestions_url
   }) %}
+  {% set config = config | setAttribute("other", {
+    "autocomplete": "off"
+  }) %}
 {% endif %}
 
 {{ onsInput(config) }}

--- a/templates/partials/answers/textfield.html
+++ b/templates/partials/answers/textfield.html
@@ -32,9 +32,7 @@
     "ariaLimitedResults": "Results have been limited to 10 suggestions. Type more characters to improve your search.",
     "typeaheadData": answer.suggestions_url
   }) %}
-  {% set config = config | setAttribute("other", {
-    "autocomplete": "off"
-  }) %}
+  {% set config = config | setAttribute("autocomplete", "off") %}
 {% endif %}
 
 {{ onsInput(config) }}


### PR DESCRIPTION
### What is the context of this PR?
This removes autocomplete from input field using lookup component. Previously there was a bug in Design System that caused autocomplete to be set to "null".

