### PR TITLE
Remove the version number from deployment waits

### DIFF
--- a/ci/wait.yaml
+++ b/ci/wait.yaml
@@ -10,4 +10,4 @@ run:
   args:
     - -exc
     - |
-      until $(wget -q https://${RUNNER_FQDN}/status); do sleep 5; printf '.'; done
+      until $(wget -q https://${RUNNER_FQDN}/status 2>&1); do sleep 5; printf '.'; done

--- a/ci/wait.yaml
+++ b/ci/wait.yaml
@@ -3,8 +3,6 @@ image_resource:
   type: docker-image
   source:
     repository: alpine
-inputs:
-  - name: eq-questionnaire-runner
 params:
   RUNNER_FQDN:
 run:
@@ -12,5 +10,4 @@ run:
   args:
     - -exc
     - |
-      survey_runner_version=$(cat eq-questionnaire-runner/.git/HEAD | xargs echo -n)
-      until wget -qO- https://${RUNNER_FQDN}/status 2>&1 | grep $survey_runner_version; do sleep 5; done
+      until $(wget -q https://${RUNNER_FQDN}/status); do sleep 5; printf '.'; done


### PR DESCRIPTION
### What is the context of this PR?

The wait task currently explicitly checks the commit used as the version number from runner's .git/HEAD. For manual-tagged deployments, this will be a tag, not a commit hash. We can safely assume the version we ask to be deployed is deployed, so we can remove this check.

### How to review 
Fly the task with a reachable/unreachable endpoint and check the response is as expected.

