### PR TITLE
Update schema release to v0.0.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ clean:
 	rm -rf templates/layout
 
 load-schemas:
-	./scripts/load_release.sh onsdigital/eq-questionnaire-schemas v0.0.7
+	./scripts/load_release.sh onsdigital/eq-questionnaire-schemas v0.0.8
 
 load-templates:
 	./scripts/load_release.sh onsdigital/design-system 17.0.0


### PR DESCRIPTION
### What is the context of this PR?
Updates runner to use version 0.0.8 of the eq questionnaire schemas which includes the latest changes to the HH and HI schemas.
