### PR TITLE
Add questionnaire state backup ci task

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -30,3 +30,13 @@ To deploy the app to the cluster via Concourse, use the following task command:
 fly -t <target-concourse> execute \
   --config ci/deploy_app.yaml
 ```
+
+## Backing up questionnaire state
+
+Questionnaire state can be backed up using the `backup_questionnaire_state.yaml` task. This can be done via Concourse using the following command:
+
+```sh
+PROJECT_ID=<project_id> \
+fly -t <target-concourse> execute \
+  --config ci/backup_questionnaire_state.yaml
+```

--- a/ci/backup_questionnaire_state.yaml
+++ b/ci/backup_questionnaire_state.yaml
@@ -1,0 +1,34 @@
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: google/cloud-sdk
+    tag: alpine
+params:
+  SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+  PROJECT_ID:
+outputs:
+  - name: backup-questionnaire-state-output
+run:
+  path: bash
+  args:
+    - -exc
+    - |
+      export GOOGLE_APPLICATION_CREDENTIALS=~/gcloud-service-key.json
+      cat >$GOOGLE_APPLICATION_CREDENTIALS <<EOL
+      $SERVICE_ACCOUNT_JSON
+      EOL
+
+      gcloud auth activate-service-account --key-file $GOOGLE_APPLICATION_CREDENTIALS
+      gcloud config set project "${PROJECT_ID}"
+
+      EXPORT_DESTINATION_BUCKET="$PROJECT_ID-datastore-exports"
+      EXPORT_OPERATION=$(gcloud datastore export --kinds="questionnaire-state" gs://"$EXPORT_DESTINATION_BUCKET" --format="value(name.scope())")
+      EXPORT_STATE=$(gcloud datastore operations describe "$EXPORT_OPERATION" --format="value(metadata.common.state.scope())")
+      TOTAL_ENTITIES_EXPORTED=$(gcloud datastore operations describe "$EXPORT_OPERATION" --format="value(metadata.progressEntities.workCompleted.scope())")
+      
+      if [[ "$EXPORT_STATE" == "SUCCESSFUL" ]]; then
+        echo "Questionnaire State Backup Successful - ${TOTAL_ENTITIES_EXPORTED:-0} entities exported" > "backup-questionnaire-state-output/notification-message"
+      else
+        exit 1
+      fi


### PR DESCRIPTION
### What is the context of this PR?
Adds a Concourse CI task file for backing up questionnaire state. Most of the content of the task was lifted from https://github.com/ONSdigital/census-eq-concourse/blob/master/eq-backup-questionnaire-state.yaml.

Some key changes:
- `PROJECT_ID` is explicitly passed as an input to the task (rather than using the gcloud projects list command). 
- The file written on success contains the full message text for the Slack notification. This was done as `arbourd/concourse-slack-alert-resource` doesn't allow for the previous approach of setting `fields` in the notification.
- Due to the way the notifications now work, the output is only written if the export was successful. Although we could write a file on failure, this wouldn't cover other failures e.g. the project doesn't exist, and would mean a duplication of the failure message in the task and the calling pipeline.

### How to review 
- fly the task to the dev Concourse to backup your GCP questionnaire runner state
- Verify the state is backed up
- Vary the amount of state to backup and verify the output has the correct number of entities
- Try a failed backup (e.g. a non-existent project id) and verify the output
- Test the `if` conditional by editing the task to set `EXPORT_STATE` to something like `FAILED`