### PR TITLE
Upgrade to Helm 3 + Use app deploy image

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ gcloud container clusters get-credentials survey-runner --region <region> --proj
 
 You need to have Helm installed locally
 
-1. Install Helm: https://helm.sh/docs/intro/install/. For Homebrew (macOS), install using: `brew install helm`
+1. Install Helm: <https://helm.sh/docs/intro/install/>. For Homebrew (macOS), install using: `brew install helm`
 
 
 ### Deploying credentials

--- a/README.md
+++ b/README.md
@@ -223,9 +223,7 @@ gcloud container clusters get-credentials survey-runner --region <region> --proj
 
 You need to have Helm installed locally
 
-1. Install Helm with `brew install kubernetes-helm` and then run `helm init --client-only`
-
-2. Install Helm Tiller plugin for _Tillerless_ deploys `helm plugin install https://github.com/rimusz/helm-tiller`
+1. Install Helm: https://helm.sh/docs/intro/install/. For Homebrew (macOS), install using: `brew install helm`
 
 
 ### Deploying credentials

--- a/ci/README.md
+++ b/ci/README.md
@@ -24,11 +24,12 @@ In addition to the environment variables specified in [Deploying the app](../REA
 | REGION                                    | What region to authenticate against                                                  |
 | PROJECT_ID                                | The ID of the GCP target project                                                     |
 
-To deploy the app to the cluster via Concourse, use the following task command:
-
+To deploy the app to the cluster via Concourse, use the following task command, specifying the `image_registry` and the `build_image_version` variables:
 ```sh
 fly -t <target-concourse> execute \
-  --config ci/deploy_app.yaml
+  --config ci/deploy_app.yaml \
+  -v image_registry=<docker-registry> \
+  -v build_image_version=<image-tag>
 ```
 
 ## Backing up questionnaire state

--- a/ci/README.md
+++ b/ci/README.md
@@ -24,12 +24,12 @@ In addition to the environment variables specified in [Deploying the app](../REA
 | REGION                                    | What region to authenticate against                                                  |
 | PROJECT_ID                                | The ID of the GCP target project                                                     |
 
-To deploy the app to the cluster via Concourse, use the following task command, specifying the `image_registry` and the `build_image_version` variables:
+To deploy the app to the cluster via Concourse, use the following task command, specifying the `image_registry` and the `deploy_image_version` variables:
 ```sh
 fly -t <target-concourse> execute \
   --config ci/deploy_app.yaml \
   -v image_registry=<docker-registry> \
-  -v build_image_version=<image-tag>
+  -v deploy_image_version=<image-tag>
 ```
 
 ## Backing up questionnaire state

--- a/ci/deploy_app.yaml
+++ b/ci/deploy_app.yaml
@@ -2,7 +2,8 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: theorf/google-cloud-sdk-helm
+    repository: ((image_registry))/eq-app-deploy-image
+    tag: ((build_image_version))
 inputs:
   - name: eq-questionnaire-runner
 params:
@@ -30,8 +31,6 @@ run:
   args:
     - -exc
     - |
-      apt-get install -y procps
-
       export GOOGLE_APPLICATION_CREDENTIALS=/root/gcloud-service-key.json
       cat >$GOOGLE_APPLICATION_CREDENTIALS <<EOL
       $SERVICE_ACCOUNT_JSON
@@ -40,9 +39,6 @@ run:
       gcloud auth activate-service-account --key-file "${GOOGLE_APPLICATION_CREDENTIALS}"
 
       gcloud container clusters get-credentials survey-runner --region "${REGION}" --project "${PROJECT_ID}"
-
-      helm init --client-only
-      helm  plugin install https://github.com/rimusz/helm-tiller
 
       cd eq-questionnaire-runner
       ./k8s/deploy_app.sh

--- a/ci/deploy_app.yaml
+++ b/ci/deploy_app.yaml
@@ -42,6 +42,3 @@ run:
 
       cd eq-questionnaire-runner
       ./k8s/deploy_app.sh
-
-      kubectl rollout restart deployment.v1.apps/runner
-      kubectl rollout status deployment.v1.apps/runner

--- a/ci/deploy_app.yaml
+++ b/ci/deploy_app.yaml
@@ -3,7 +3,7 @@ image_resource:
   type: docker-image
   source:
     repository: ((image_registry))/eq-app-deploy-image
-    tag: ((build_image_version))
+    tag: ((deploy_image_version))
 inputs:
   - name: eq-questionnaire-runner
 params:

--- a/ci/deploy_app.yaml
+++ b/ci/deploy_app.yaml
@@ -43,4 +43,5 @@ run:
       cd eq-questionnaire-runner
       ./k8s/deploy_app.sh
 
+      kubectl rollout restart deployment.v1.apps/runner
       kubectl rollout status deployment.v1.apps/runner

--- a/ci/deploy_credentials.yaml
+++ b/ci/deploy_credentials.yaml
@@ -2,7 +2,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: theorf/google-cloud-sdk-helm
+    repository: google/cloud-sdk
 inputs:
   - name: eq-questionnaire-runner
 params:
@@ -16,8 +16,6 @@ run:
   args:
     - -exc
     - |
-      apt-get install -y procps
-
       export GOOGLE_APPLICATION_CREDENTIALS=/root/gcloud-service-key.json
       cat >$GOOGLE_APPLICATION_CREDENTIALS <<EOL
       $SERVICE_ACCOUNT_JSON
@@ -26,9 +24,6 @@ run:
       gcloud auth activate-service-account --key-file "${GOOGLE_APPLICATION_CREDENTIALS}"
 
       gcloud container clusters get-credentials survey-runner --region "${REGION}" --project "${PROJECT_ID}"
-
-      helm init --client-only
-      helm plugin install https://github.com/rimusz/helm-tiller
 
       cd eq-questionnaire-runner
       ./k8s/deploy_credentials.sh

--- a/k8s/deploy_app.sh
+++ b/k8s/deploy_app.sh
@@ -25,3 +25,6 @@ helm upgrade --install \
     --set-string newRelic.enabled="${EQ_NEW_RELIC_ENABLED}" \
     --set-string newRelic.licenseKey="${NEW_RELIC_LICENSE_KEY}" \
     --set-string newRelic.appName="${NEW_RELIC_APP_NAME}"
+
+kubectl rollout restart deployment.v1.apps/runner
+kubectl rollout status deployment.v1.apps/runner

--- a/k8s/deploy_app.sh
+++ b/k8s/deploy_app.sh
@@ -6,9 +6,8 @@ if [[ -z "$SUBMISSION_BUCKET_NAME" ]]; then
   exit 1
 fi
 
-helm tiller run \
-    helm upgrade --install \
-    survey-runner \
+helm upgrade --install \
+    questionnaire-runner \
     k8s/helm \
     --set-string submissionBucket="${SUBMISSION_BUCKET_NAME}" \
     --set-string googleTagManagerId="${GOOGLE_TAG_MANAGER_ID}" \

--- a/k8s/helm/Chart.yaml
+++ b/k8s/helm/Chart.yaml
@@ -1,5 +1,4 @@
-apiVersion: v1
-appVersion: "1.0"
-description: A Helm chart for deploying Survey Runner to Kubernetes
+apiVersion: v2
+description: A Helm chart for deploying Questionnaire Runner to Kubernetes
 name: runner
-version: 0.1.0
+version: 1.0.0

--- a/k8s/helm/templates/NOTES.txt
+++ b/k8s/helm/templates/NOTES.txt
@@ -1,1 +1,1 @@
-Survey Runner Application deployed.
+Questionnaire Runner Application deployed.

--- a/k8s/helm/templates/deployment.yaml
+++ b/k8s/helm/templates/deployment.yaml
@@ -23,7 +23,6 @@ spec:
       labels:
         app.kubernetes.io/name: {{ .Chart.Name }}
         app.kubernetes.io/instance: {{ .Release.Name }}
-        date: "{{ .Release.Time.Seconds }}"
     spec:
       volumes:
       - name: keys

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eq-questionnaire-runner",
   "version": "1.0.0",
-  "description": "ONS Digital eQ Survey Runner App",
+  "description": "ONS Digital eQ Questionnaire Runner App",
   "author": {
     "name": "ONS Digital",
     "url": "http://onsdigital.github.io/"


### PR DESCRIPTION
### What is the context of this PR?
- Upgrades runner to support Helm 3.
- Specify the app deploy image and version when deploying with CI.
- `deploy_credential.yaml` now used the official `google/cloud-sdk`.

### How to review 
- Deploy a cluster using: https://github.com/ONSdigital/census-eq-terraform or Concourse.
- Use the `ci/README.md` to deploy the application to the cluster. Ensure the instructions are clear. 
**IMPORTANT NOTE**: If you are using an existing cluster with any deployments of runner made by Helm 2, you must use Helm 2 to delete the runner release before deploying with Helm 3. This is because Helm 3 cannot see the releases made by Helm 2 however, you cannot apply on top due to conflicts.

	To delete the release with Helm 2:
	1. Log in to the cluster _(You may need to add your IP to the cluster)_:
`gcloud container clusters get-credentials survey-runner --region europe-west2 --project <project_id>`
	2. Run: `helm init --client-only`
	3. Run: `helm tiller run helm delete survey-runner --purge`
	4. Verify there are no releases using: `helm tiller run helm ls`
	5. Additionally, you can check that secrets stored by Helm 2 are also deleted: 
		`kubectl get secret --namespace kube-system  | grep 'survey-runner'`
	6. Helm 3 secrets are stored in the `default` namespace with the scheme:
		`sh.helm.release.v1.<release_name>.v<revision_version>.`

- Use must now specify the `image_registry` and the `deploy_image_version` variables when using the task yaml to fly execute.
	
	For testing, you can use:
	```yaml
	image_registry: 'eu.gcr.io/census-eq-ci'
	deploy_image_version: 'latest'
	```
- Ensure you can still deploy runner credentials as expected.
- Ensure when deploying the same image tag, the deployment is re-pulls in image.
		- Fixed by: https://github.com/ONSdigital/eq-questionnaire-runner/pull/86/commits/93537eff8cb475cb43b5cc60fb8b59f9aaf00973

**If you want to make things easier, use Concourse to test all of this using:**
	- https://github.com/ONSdigital/census-eq-concourse/pull/53