### PR TITLE
Add SameSite Strict to session cookie

### DIFF
--- a/app/setup.py
+++ b/app/setup.py
@@ -257,6 +257,8 @@ def setup_secure_headers(application):
         # browsersync is configured to bind on port 5075
         csp_policy["connect-src"] += ["ws://localhost:35729"]
 
+    application.config["SESSION_COOKIE_SAMESITE"] = "Strict"
+
     Talisman(
         application,
         content_security_policy=csp_policy,


### PR DESCRIPTION
### What is the context of this PR?
Sets the `SameSite` property of the session cookie to `Strict`. The session cookie is a first party cookie that should never be shared with other sites. 

This is not yet possible in via the Talisman library so is done via Flask.

### How to review 
- Inspect the cookies and verify the `SameSite` property is set to `Strict`. 
- Verify the app works.