### PR TITLE
WLH content changes - return link

### DIFF
--- a/templates/list-action.tmpl
+++ b/templates/list-action.tmpl
@@ -6,7 +6,7 @@
       {% if content.block.cancel_text %}
         {{ content.block.cancel_text }} <br>
       {% endif %}
-      <a id="cancel-and-return" href="{{ previous_location_url }}">{{ _("Return to the previous page") }}</a>
+      <a id="cancel-and-return" href="{{ previous_location_url }}">{{ _("Cancel and return to the previous page") }}</a>
     </p>
   {% endif %}
 {% endblock cancel_and_return %}

--- a/templates/listremovequestion.html
+++ b/templates/listremovequestion.html
@@ -1,1 +1,11 @@
 {% extends 'list-action.tmpl' %}
+
+{% block cancel_and_return %}
+  {% if previous_location_url %}
+    <p class="u-mt-l">
+      {% if content.block.cancel_text %}
+        {{ content.block.cancel_text }} <br>
+      {% endif %}
+    </p>
+  {% endif %}
+{% endblock cancel_and_return %}

--- a/templates/listremovequestion.html
+++ b/templates/listremovequestion.html
@@ -1,11 +1,4 @@
 {% extends 'list-action.tmpl' %}
 
 {% block cancel_and_return %}
-  {% if previous_location_url %}
-    <p class="u-mt-l">
-      {% if content.block.cancel_text %}
-        {{ content.block.cancel_text }} <br>
-      {% endif %}
-    </p>
-  {% endif %}
 {% endblock cancel_and_return %}

--- a/tests/functional/spec/list_collector.spec.js
+++ b/tests/functional/spec/list_collector.spec.js
@@ -116,17 +116,6 @@ describe('List Collector', function() {
       expect(browser.getUrl()).to.contain(ListCollectorPage.pageName);
     });
 
-    it('The user is returned to the list collector when the cancel link is clicked on the remove page.', function() {
-      $(ListCollectorPage.yes()).click();
-      $(ListCollectorPage.submit()).click();
-      $(ListCollectorAddPage.firstName()).setValue('Someone');
-      $(ListCollectorAddPage.lastName()).setValue('Else');
-      $(ListCollectorAddPage.submit()).click();
-      $(ListCollectorPage.listRemoveLink(1)).click();
-      $(ListCollectorRemovePage.cancelAndReturn()).click();
-      expect(browser.getUrl()).to.contain(ListCollectorPage.pageName);
-    });
-
     it('The collector shows everyone on the summary', function() {
       const peopleExpected = ['Samuel Clemens', 'Olivia Clemens', 'Suzy Clemens', 'Clara Clemens', 'Jean Clemens'];
 

--- a/tests/integration/questionnaire/test_questionnaire_list_collector.py
+++ b/tests/integration/questionnaire/test_questionnaire_list_collector.py
@@ -245,4 +245,4 @@ class TestQuestionnaireListCollector(IntegrationTestCase):
 
         self.get(remove_link)
 
-        self.assertInBody("Don’t need to remove this person?")
+        self.assertNotInBody("Don’t need to remove this person?")

--- a/tests/integration/questionnaire/test_questionnaire_list_collector.py
+++ b/tests/integration/questionnaire/test_questionnaire_list_collector.py
@@ -231,18 +231,3 @@ class TestQuestionnaireListCollector(IntegrationTestCase):
         self.get(change_link)
 
         self.assertInBody("Don’t need to change anything?")
-
-    def test_cancel_text_displayed_on_remove_block_if_exists(self):
-        self.launchSurvey("test_list_collector")
-
-        self.post(action="start_questionnaire")
-
-        self.post({"anyone-else": "Yes"})
-
-        self.add_person("Someone", "Else")
-
-        remove_link = self.get_link("1", "Remove")
-
-        self.get(remove_link)
-
-        self.assertNotInBody("Don’t need to remove this person?")


### PR DESCRIPTION
### What is the context of this PR?
This changes the text on a return link to `Cancel and return to the previous page` for a multiple questions. It is part of a larger WLH schema changes card: [schemas PR](https://github.com/ONSdigital/eq-questionnaire-schemas/pull/49).

### How to review 
Check the overflow to make sure the change is correctly implemented. Check Google sheet attached to the card to compare individual changes.
