### PR TITLE
Temporarily revert validator branch

### DIFF
--- a/scripts/run_validator.sh
+++ b/scripts/run_validator.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
-tag=latest
+
+# https://github.com/ONSdigital/eq-questionnaire-validator/commit/ef9e236d8428a5661f7e7501323cc29bcf313e4c
+tag=allow-multiple-list-collectors
 docker pull onsdigital/eq-questionnaire-validator:$tag
 docker run -d -p 5001:5000 "onsdigital/eq-questionnaire-validator:$tag"


### PR DESCRIPTION
### What is the context of this PR?
Temporarily revert the validator branch to: https://github.com/ONSdigital/eq-questionnaire-validator/commit/ef9e236d8428a5661f7e7501323cc29bcf313e4c

I used the last PR branch prior to the breaking change since we don't push the commit hash on master.

### How to review 
Ensure all schemas validate as expected.