### PR TITLE
Correct backend error message on max length

### DIFF
--- a/app/forms/error_messages.py
+++ b/app/forms/error_messages.py
@@ -36,7 +36,7 @@ error_messages = {
         "Enter a number rounded to %(max)d decimal places."
     ),
     "MAX_LENGTH_EXCEEDED": lazy_gettext(
-        "Your answer is too long, it has to be less than %(max)d characters."
+        "You have entered too many characters. Enter up to %(max)d characters."
     ),
     "INVALID_DATE": lazy_gettext("Enter a valid date."),
     "INVALID_DATE_RANGE": lazy_gettext(

--- a/app/translations/messages.pot
+++ b/app/translations/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-06-02 13:09+0100\n"
+"POT-Creation-Date: 2020-06-03 09:10+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -122,7 +122,7 @@ msgstr ""
 
 #: app/forms/error_messages.py:38
 #, python-format
-msgid "Your answer is too long, it has to be less than %(max)d characters."
+msgid "You have entered too many characters. Enter up to %(max)d characters."
 msgstr ""
 
 #: app/forms/error_messages.py:41

--- a/test_schemas/en/test_textarea.json
+++ b/test_schemas/en/test_textarea.json
@@ -47,7 +47,7 @@
                                         "max_length": 20,
                                         "validation": {
                                             "messages": {
-                                                "MAX_LENGTH_EXCEEDED": "Your answer has to be less than %(max)d characters long"
+                                                "MAX_LENGTH_EXCEEDED": "You have entered too many characters. Enter up to %(max)d characters"
                                             }
                                         }
                                     }

--- a/tests/functional/spec/textfield.spec.js
+++ b/tests/functional/spec/textfield.spec.js
@@ -22,6 +22,6 @@ describe("Textfield", function() {
     browser.openQuestionnaire("test_textfield.json");
     $(TextFieldPage.name()).setValue("This string is too long");
     $(TextFieldPage.submit()).click();
-    expect($(TextFieldPage.errorNumber(1)).getText()).to.contain("Your answer is too long, it has to be less than 20 characters.");
+    expect($(TextFieldPage.errorNumber(1)).getText()).to.contain("You have entered too many characters. Enter up to 20 characters.");
   });
 });

--- a/tests/integration/test_textarea.py
+++ b/tests/integration/test_textarea.py
@@ -19,7 +19,9 @@ class TestTextArea(IntegrationTestCase):
         self.launchSurvey("test_textarea")
         self.post({"answer": "This is longer than twenty characters"})
 
-        self.assertInBody("You have entered too many characters. Enter up to 20 characters")
+        self.assertInBody(
+            "You have entered too many characters. Enter up to 20 characters"
+        )
 
     def test_acceptable_submission(self):
         self.launchSurvey("test_textarea")

--- a/tests/integration/test_textarea.py
+++ b/tests/integration/test_textarea.py
@@ -19,7 +19,7 @@ class TestTextArea(IntegrationTestCase):
         self.launchSurvey("test_textarea")
         self.post({"answer": "This is longer than twenty characters"})
 
-        self.assertInBody("Your answer has to be less than 20 characters")
+        self.assertInBody("You have entered too many characters. Enter up to 20 characters")
 
     def test_acceptable_submission(self):
         self.launchSurvey("test_textarea")


### PR DESCRIPTION
### What is the context of this PR?
The backend message on max length for has been changed

### How to review 
A quick and dirty way of testing as the frontend JS will stop you entering too many characters if you use test_textarea, is either to remove JS support from your browser, or start the survey, full the box to current max_length then change and reload the schema to be less, at which point the JS will give you a minus number and let you submit