### PR TITLE
Add interstitial instruction

### DIFF
--- a/scripts/run_validator.sh
+++ b/scripts/run_validator.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-tag=latest
+tag=add-interstitial-instruction
 docker pull onsdigital/eq-questionnaire-validator:$tag
 docker run -d -p 5001:5000 "onsdigital/eq-questionnaire-validator:$tag"

--- a/templates/interstitial.html
+++ b/templates/interstitial.html
@@ -3,9 +3,9 @@
 {% set save_on_signout = true %}
 
 {% set continue_button_text = _("Continue") %}
-{% set interstitial_instruction = format_paragraphs(block.content.instruction) if block.content.instruction else None %}
 
 {% block form_content %}
+  {% set interstitial_instruction = format_paragraphs(block.content.instruction) if block.content.instruction else None %}
   {% if block.content.title %}
     <h1>{{ block.content.title }}</h1>
   {% endif %}

--- a/templates/interstitial.html
+++ b/templates/interstitial.html
@@ -8,6 +8,9 @@
   {% if block.content.title %}
     <h1>{{ block.content.title }}</h1>
   {% endif %}
+  {% if block.content.instruction %}
+      <div class="question__instruction u-mb-s">{{ block.content.instruction | safe }}</div>
+  {% endif %}
   {% set contents = block.content.contents %}
   {% include 'partials/contents.html' %}
 {% endblock form_content %}

--- a/templates/interstitial.html
+++ b/templates/interstitial.html
@@ -3,13 +3,14 @@
 {% set save_on_signout = true %}
 
 {% set continue_button_text = _("Continue") %}
+{% set interstitial_instruction = format_paragraphs(block.content.instruction) if block.content.instruction else None %}
 
 {% block form_content %}
   {% if block.content.title %}
     <h1>{{ block.content.title }}</h1>
   {% endif %}
-  {% if block.content.instruction %}
-      <div class="question__instruction u-mb-s">{{ block.content.instruction | safe }}</div>
+  {% if interstitial_instruction %}
+      <div class="question__instruction u-mb-s">{{ interstitial_instruction | safe }}</div>
   {% endif %}
   {% set contents = block.content.contents %}
   {% include 'partials/contents.html' %}

--- a/test_schemas/en/test_interstitial_instruction.json
+++ b/test_schemas/en/test_interstitial_instruction.json
@@ -37,33 +37,13 @@
                             "id": "introduction"
                         },
                         {
-                            "type": "Question",
-                            "id": "breakfast-block",
-                            "question": {
-                                "answers": [
-                                    {
-                                        "id": "favourite-breakfast",
-                                        "label": "What is your favourite breakfast food",
-                                        "mandatory": false,
-                                        "q_code": "0",
-                                        "type": "TextField"
-                                    }
-                                ],
-                                "description": "",
-                                "id": "favourite-breakfast-question",
-                                "title": "What is your favourite breakfast food",
-                                "type": "General"
-                            },
-                            "routing_rules": []
-                        },
-                        {
-                            "id": "breakfast-interstitial",
+                            "id": "interstitial",
                             "content": {
                                 "title": "Breakfast interstitial",
                                 "instruction": "Just pause for a second",
                                 "contents": [
                                     {
-                                        "description": "You have successfully completed the breakfast section. Next we want to know about your lunch."
+                                        "description": "Next we want to know about your lunch."
                                     }
                                 ]
                             },

--- a/test_schemas/en/test_interstitial_instruction.json
+++ b/test_schemas/en/test_interstitial_instruction.json
@@ -1,0 +1,106 @@
+{
+  "mime_type": "application/json/ons/eq",
+  "language": "en",
+  "schema_version": "0.0.1",
+  "data_version": "0.0.3",
+  "survey_id": "0",
+  "title": "Interstitial Pages",
+  "theme": "default",
+  "description": "A questionnaire to demo interstitial pages.",
+  "messages": {
+    "NUMBER_TOO_LARGE": "Number is too large",
+    "NUMBER_TOO_SMALL": "Number cannot be less than zero",
+    "INVALID_NUMBER": "Please enter an integer"
+  },
+  "metadata": [
+    {
+      "name": "user_id",
+      "type": "string"
+    },
+    {
+      "name": "period_id",
+      "type": "string"
+    },
+    {
+      "name": "ru_name",
+      "type": "string"
+    }
+  ],
+  "sections": [
+    {
+      "id": "default-section",
+      "groups": [
+        {
+          "blocks": [
+            {
+              "type": "Introduction",
+              "id": "introduction"
+            },
+            {
+              "type": "Question",
+              "id": "breakfast-block",
+              "question": {
+                "answers": [
+                  {
+                    "id": "favourite-breakfast",
+                    "label": "What is your favourite breakfast food",
+                    "mandatory": false,
+                    "q_code": "0",
+                    "type": "TextField"
+                  }
+                ],
+                "description": "",
+                "id": "favourite-breakfast-question",
+                "title": "What is your favourite breakfast food",
+                "type": "General"
+              },
+              "routing_rules": []
+            },
+            {
+              "id": "breakfast-interstitial",
+              "content": {
+                "title": "Breakfast interstitial",
+                "instruction": "Just pause for a second",
+                "contents": [
+                  {
+                    "description": "You have successfully completed the breakfast section. Next we want to know about your lunch."
+                  }
+                ]
+              },
+              "type": "Interstitial"
+            },
+            {
+              "type": "Question",
+              "id": "lunch-block",
+              "question": {
+                "answers": [
+                  {
+                    "id": "favourite-lunch",
+                    "label": "What is your favourite lunchtime food",
+                    "mandatory": false,
+                    "q_code": "0",
+                    "type": "TextField"
+                  }
+                ],
+                "description": "",
+                "id": "favourite-lunch-question",
+                "title": "",
+                "type": "General"
+              },
+              "routing_rules": []
+            },
+            {
+              "type": "Confirmation",
+              "id": "confirmation",
+              "content": {
+                "title": "Thank you for your answers, do you wish to submit"
+              }
+            }
+          ],
+          "id": "favourite-foods",
+          "title": "Favourite food"
+        }
+      ]
+    }
+  ]
+}

--- a/test_schemas/en/test_interstitial_instruction.json
+++ b/test_schemas/en/test_interstitial_instruction.json
@@ -1,106 +1,106 @@
 {
-  "mime_type": "application/json/ons/eq",
-  "language": "en",
-  "schema_version": "0.0.1",
-  "data_version": "0.0.3",
-  "survey_id": "0",
-  "title": "Interstitial Pages",
-  "theme": "default",
-  "description": "A questionnaire to demo interstitial pages.",
-  "messages": {
-    "NUMBER_TOO_LARGE": "Number is too large",
-    "NUMBER_TOO_SMALL": "Number cannot be less than zero",
-    "INVALID_NUMBER": "Please enter an integer"
-  },
-  "metadata": [
-    {
-      "name": "user_id",
-      "type": "string"
+    "mime_type": "application/json/ons/eq",
+    "language": "en",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.3",
+    "survey_id": "0",
+    "title": "Interstitial Pages",
+    "theme": "default",
+    "description": "A questionnaire to demo interstitial pages.",
+    "messages": {
+        "NUMBER_TOO_LARGE": "Number is too large",
+        "NUMBER_TOO_SMALL": "Number cannot be less than zero",
+        "INVALID_NUMBER": "Please enter an integer"
     },
-    {
-      "name": "period_id",
-      "type": "string"
-    },
-    {
-      "name": "ru_name",
-      "type": "string"
-    }
-  ],
-  "sections": [
-    {
-      "id": "default-section",
-      "groups": [
+    "metadata": [
         {
-          "blocks": [
-            {
-              "type": "Introduction",
-              "id": "introduction"
-            },
-            {
-              "type": "Question",
-              "id": "breakfast-block",
-              "question": {
-                "answers": [
-                  {
-                    "id": "favourite-breakfast",
-                    "label": "What is your favourite breakfast food",
-                    "mandatory": false,
-                    "q_code": "0",
-                    "type": "TextField"
-                  }
-                ],
-                "description": "",
-                "id": "favourite-breakfast-question",
-                "title": "What is your favourite breakfast food",
-                "type": "General"
-              },
-              "routing_rules": []
-            },
-            {
-              "id": "breakfast-interstitial",
-              "content": {
-                "title": "Breakfast interstitial",
-                "instruction": "Just pause for a second",
-                "contents": [
-                  {
-                    "description": "You have successfully completed the breakfast section. Next we want to know about your lunch."
-                  }
-                ]
-              },
-              "type": "Interstitial"
-            },
-            {
-              "type": "Question",
-              "id": "lunch-block",
-              "question": {
-                "answers": [
-                  {
-                    "id": "favourite-lunch",
-                    "label": "What is your favourite lunchtime food",
-                    "mandatory": false,
-                    "q_code": "0",
-                    "type": "TextField"
-                  }
-                ],
-                "description": "",
-                "id": "favourite-lunch-question",
-                "title": "",
-                "type": "General"
-              },
-              "routing_rules": []
-            },
-            {
-              "type": "Confirmation",
-              "id": "confirmation",
-              "content": {
-                "title": "Thank you for your answers, do you wish to submit"
-              }
-            }
-          ],
-          "id": "favourite-foods",
-          "title": "Favourite food"
+            "name": "user_id",
+            "type": "string"
+        },
+        {
+            "name": "period_id",
+            "type": "string"
+        },
+        {
+            "name": "ru_name",
+            "type": "string"
         }
-      ]
-    }
-  ]
+    ],
+    "sections": [
+        {
+            "id": "default-section",
+            "groups": [
+                {
+                    "blocks": [
+                        {
+                            "type": "Introduction",
+                            "id": "introduction"
+                        },
+                        {
+                            "type": "Question",
+                            "id": "breakfast-block",
+                            "question": {
+                                "answers": [
+                                    {
+                                        "id": "favourite-breakfast",
+                                        "label": "What is your favourite breakfast food",
+                                        "mandatory": false,
+                                        "q_code": "0",
+                                        "type": "TextField"
+                                    }
+                                ],
+                                "description": "",
+                                "id": "favourite-breakfast-question",
+                                "title": "What is your favourite breakfast food",
+                                "type": "General"
+                            },
+                            "routing_rules": []
+                        },
+                        {
+                            "id": "breakfast-interstitial",
+                            "content": {
+                                "title": "Breakfast interstitial",
+                                "instruction": "Just pause for a second",
+                                "contents": [
+                                    {
+                                        "description": "You have successfully completed the breakfast section. Next we want to know about your lunch."
+                                    }
+                                ]
+                            },
+                            "type": "Interstitial"
+                        },
+                        {
+                            "type": "Question",
+                            "id": "lunch-block",
+                            "question": {
+                                "answers": [
+                                    {
+                                        "id": "favourite-lunch",
+                                        "label": "What is your favourite lunchtime food",
+                                        "mandatory": false,
+                                        "q_code": "0",
+                                        "type": "TextField"
+                                    }
+                                ],
+                                "description": "",
+                                "id": "favourite-lunch-question",
+                                "title": "",
+                                "type": "General"
+                            },
+                            "routing_rules": []
+                        },
+                        {
+                            "type": "Confirmation",
+                            "id": "confirmation",
+                            "content": {
+                                "title": "Thank you for your answers, do you wish to submit"
+                            }
+                        }
+                    ],
+                    "id": "favourite-foods",
+                    "title": "Favourite food"
+                }
+            ]
+        }
+    ]
 }

--- a/tests/integration/questionnaire/test_questionnaire_interstitial.py
+++ b/tests/integration/questionnaire/test_questionnaire_interstitial.py
@@ -21,3 +21,9 @@ class TestQuestionnaireInterstitial(IntegrationTestCase):
         self.assertInUrl("confirmation")
         self.post()
         self.assertInBody("Submission successful")
+
+    def test_interstitial_instruction(self):
+        self.launchSurvey("test_interstitial_instruction")
+        self.post(action="start_questionnaire")
+        self.post({"favourite-breakfast": "Cereal"})
+        self.assertInBody("Just pause for a second")

--- a/tests/integration/questionnaire/test_questionnaire_interstitial.py
+++ b/tests/integration/questionnaire/test_questionnaire_interstitial.py
@@ -25,5 +25,4 @@ class TestQuestionnaireInterstitial(IntegrationTestCase):
     def test_interstitial_instruction(self):
         self.launchSurvey("test_interstitial_instruction")
         self.post(action="start_questionnaire")
-        self.post({"favourite-breakfast": "Cereal"})
         self.assertInBody("Just pause for a second")


### PR DESCRIPTION
### What is the context of this PR?

Allow interviewer instructions to be added to interstitial pages. 

NB: The instruction on question pages is created as part of the onsQuestionComponent, so I've added the necessary html from the macro and we can look at possibly adding an instruction component at a later date. It's not ideal (includes question in the classname for instance), but allows us to support the feature.

### How to review 

Check you agree with the approach. Review https://github.com/ONSdigital/eq-questionnaire-validator/pull/39 and https://github.com/ONSdigital/eq-translations/pull/61 on which this depends.
