### PR TITLE
Remove response_id from downstream payload

### DIFF
--- a/app/submitter/converter.py
+++ b/app/submitter/converter.py
@@ -33,7 +33,6 @@ def convert_answers(schema, questionnaire_store, routing_path, flushed=False):
         },
         'started_at': '2016-03-06T15:28:05Z',
         'submitted_at': '2016-03-07T15:28:05Z',
-        'response_id': '1234567890123456',
         'questionnaire_id': '1234567890000000',
         'channel': 'RH',
         'metadata': {
@@ -72,7 +71,6 @@ def convert_answers(schema, questionnaire_store, routing_path, flushed=False):
         "submitted_at": submitted_at.isoformat(),
         "collection": _build_collection(metadata),
         "metadata": _build_metadata(metadata),
-        "response_id": metadata["response_id"],
         "questionnaire_id": metadata["questionnaire_id"],
     }
 

--- a/app/views/handlers/submission.py
+++ b/app/views/handlers/submission.py
@@ -21,6 +21,7 @@ class SubmissionHandler:
             ),
             for_json=True,
         )
+
         encrypted_message = encrypt(
             message, current_app.eq["key_store"], KEY_PURPOSE_SUBMISSION
         )

--- a/app/views/handlers/submission.py
+++ b/app/views/handlers/submission.py
@@ -21,7 +21,6 @@ class SubmissionHandler:
             ),
             for_json=True,
         )
-
         encrypted_message = encrypt(
             message, current_app.eq["key_store"], KEY_PURPOSE_SUBMISSION
         )

--- a/tests/app/submitter/test_converter.py
+++ b/tests/app/submitter/test_converter.py
@@ -43,13 +43,6 @@ def test_ref_period_start_and_end_date_is_in_output(
     assert answer_object["metadata"]["ref_period_end_date"] == "2016-03-03"
 
 
-def test_response_id_is_in_output(fake_questionnaire_schema, fake_questionnaire_store):
-    answer_object = convert_answers(
-        fake_questionnaire_schema, fake_questionnaire_store, {}
-    )
-    assert answer_object["response_id"] == "1234567890123456"
-
-
 def test_convert_answers_flushed_flag_overriden_to_true(
     fake_questionnaire_schema, fake_questionnaire_store
 ):

--- a/tests/integration/routes/test_dump.py
+++ b/tests/integration/routes/test_dump.py
@@ -80,7 +80,6 @@ class TestDumpSubmission(IntegrationTestCase):
                 "tx_id": actual["submission"]["tx_id"],
                 "submitted_at": actual["submission"]["submitted_at"],
                 "case_id": actual["submission"]["case_id"],
-                "response_id": "1234567890123456",
                 "questionnaire_id": actual["submission"]["questionnaire_id"],
                 "collection": {
                     "period": "201604",
@@ -123,7 +122,6 @@ class TestDumpSubmission(IntegrationTestCase):
                 "started_at": actual["submission"]["started_at"],
                 "submitted_at": actual["submission"]["submitted_at"],
                 "case_id": actual["submission"]["case_id"],
-                "response_id": "1234567890123456",
                 "questionnaire_id": actual["submission"]["questionnaire_id"],
                 "collection": {
                     "period": "201604",
@@ -172,7 +170,6 @@ class TestDumpSubmission(IntegrationTestCase):
                 "started_at": actual["submission"]["started_at"],
                 "submitted_at": actual["submission"]["submitted_at"],
                 "case_id": actual["submission"]["case_id"],
-                "response_id": "1234567890123456",
                 "questionnaire_id": actual["submission"]["questionnaire_id"],
                 "collection": {
                     "period": "201604",

--- a/tests/integration/routes/test_thank_you.py
+++ b/tests/integration/routes/test_thank_you.py
@@ -2,25 +2,6 @@ from tests.integration.integration_test_case import IntegrationTestCase
 
 
 class TestThankYou(IntegrationTestCase):
-    example_payload = {
-        "user_id": "integration-test",
-        "period_str": "April 2016",
-        "period_id": "201604",
-        "collection_exercise_sid": "789",
-        "questionnaire_id": "0123456789000000",
-        "ru_ref": "123456789012A",
-        "response_id": "1234567890123456",
-        "ru_name": "Integration Testing",
-        "ref_p_start_date": "2016-04-01",
-        "ref_p_end_date": "2016-04-30",
-        "return_by": "2016-05-06",
-        "employment_date": "1983-06-02",
-        "region_code": "GB-ENG",
-        "language_code": "en",
-        "roles": [],
-        "account_service_url": "http://upstream.url",
-    }
-
     def test_thank_you_page_no_sign_out(self):
         self.launchSurvey("test_currency")
 


### PR DESCRIPTION
### What is the context of this PR?
This PR removes response_id from the downstream payload. The card also included removing it from logging, however it doesn't seem to currently

### How to review 
Check response_id has been removed from all the right places, and there is nowhere else
