### PR TITLE
Fix missing census logo

### DIFF
--- a/app/helpers/template_helper.py
+++ b/app/helpers/template_helper.py
@@ -24,7 +24,7 @@ def get_page_header_context(language, theme):
         "northernireland": default_context,
         "census": {
             **default_context,
-            "titleLogo": "census-logo-" + language,
+            "titleLogo": f"census-logo-{language}",
             "titleLogoAlt": lazy_gettext("Census 2021"),
         },
         "census-nisra": {

--- a/app/helpers/template_helper.py
+++ b/app/helpers/template_helper.py
@@ -34,6 +34,7 @@ def get_page_header_context(language, theme):
             ),
             "titleLogo": "census-logo-en",
             "titleLogoAlt": lazy_gettext("Census 2021"),
+            "customHeaderLogo": "nisra",
         },
     }
     return context.get(theme)

--- a/app/helpers/template_helper.py
+++ b/app/helpers/template_helper.py
@@ -29,6 +29,7 @@ def get_page_header_context(language, theme):
         },
         "census-nisra": {
             "logo": "nisra-logo-en",
+            "mobileLogo": "nisra-logo-en",
             "logoAlt": lazy_gettext(
                 "Northern Ireland Statistics and Research Agency logo"
             ),

--- a/app/helpers/template_helper.py
+++ b/app/helpers/template_helper.py
@@ -24,7 +24,7 @@ def get_page_header_context(language, theme):
         "northernireland": default_context,
         "census": {
             **default_context,
-            "titleLogo": "/img/census-logo-" + language + ".svg",
+            "titleLogo": "census-logo-" + language,
             "titleLogoAlt": lazy_gettext("Census 2021"),
         },
         "census-nisra": {
@@ -32,7 +32,7 @@ def get_page_header_context(language, theme):
             "logoAlt": lazy_gettext(
                 "Northern Ireland Statistics and Research Agency logo"
             ),
-            "titleLogo": "/img/census-logo-en.svg",
+            "titleLogo": "census-logo-en",
             "titleLogoAlt": lazy_gettext("Census 2021"),
         },
     }


### PR DESCRIPTION
### What is the context of this PR?
Updates runner with the latest changes to the page header in the design system (https://github.com/ONSdigital/design-system/pull/762). This fixes the missing Census logo and NISRA logo alignment.

### How to review 
Check that the Census and NISRA logos are displayed properly. You can look at https://ons-design-system.netlify.app/components/header/ to see how they should look. 
