### PR TITLE
Question summary: Add support for Checkbox and Number answer types

### DIFF
--- a/app/views/contexts/summary/question.py
+++ b/app/views/contexts/summary/question.py
@@ -65,16 +65,16 @@ class Question:
             for answer_schema in self.answer_schemas
         ]
 
-        values_to_use = []
+        values_to_concatenate = []
         for answer_value in answer_values:
             if not answer_value:
                 continue
 
-            values_to_use.extend(
+            values_to_concatenate.extend(
                 answer_value if isinstance(answer_value, list) else [answer_value]
             )
 
-        return answer_separator.join(str(value) for value in values_to_use)
+        return answer_separator.join(str(value) for value in values_to_concatenate)
 
     def _build_answer(
         self, answer_store, question_schema, answer_schema, answer_value=None

--- a/app/views/contexts/summary/question.py
+++ b/app/views/contexts/summary/question.py
@@ -32,7 +32,7 @@ class Question:
             return [
                 {
                     "id": f"{self.id}-concatenated-answer",
-                    "value": self._concatenate_textfield_answers(
+                    "value": self._concatenate_answers(
                         answer_store, self.summary["concatenation_type"]
                     ),
                 }
@@ -55,7 +55,7 @@ class Question:
             return summary_answers[:-1]
         return summary_answers
 
-    def _concatenate_textfield_answers(self, answer_store, concatenation_type):
+    def _concatenate_answers(self, answer_store, concatenation_type):
 
         answer_separators = {"Newline": "<br>", "Space": " "}
         answer_separator = answer_separators.get(concatenation_type, " ")
@@ -64,9 +64,17 @@ class Question:
             self._get_answer(answer_store, answer_schema["id"])
             for answer_schema in self.answer_schemas
         ]
-        return answer_separator.join(
-            [answer_value for answer_value in answer_values if answer_value]
-        )
+
+        values_to_use = []
+        for answer_value in answer_values:
+            if not answer_value:
+                continue
+
+            values_to_use.extend(
+                answer_value if isinstance(answer_value, list) else [answer_value]
+            )
+
+        return answer_separator.join(str(value) for value in values_to_use)
 
     def _build_answer(
         self, answer_store, question_schema, answer_schema, answer_value=None

--- a/scripts/run_validator.sh
+++ b/scripts/run_validator.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-tag=extend-question-summary-concat-answer-types
+tag=latest
 docker pull onsdigital/eq-questionnaire-validator:$tag
 docker run -d -p 5001:5000 "onsdigital/eq-questionnaire-validator:$tag"

--- a/scripts/run_validator.sh
+++ b/scripts/run_validator.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-tag=latest
+tag=extend-question-summary-concat-answer-types
 docker pull onsdigital/eq-questionnaire-validator:$tag
 docker run -d -p 5001:5000 "onsdigital/eq-questionnaire-validator:$tag"

--- a/test_schemas/en/test_custom_question_summary.json
+++ b/test_schemas/en/test_custom_question_summary.json
@@ -43,21 +43,18 @@
                                         "id": "first-name",
                                         "label": "First name",
                                         "mandatory": false,
-                                        "q_code": "30",
                                         "type": "TextField"
                                     },
                                     {
                                         "id": "middle-name",
                                         "label": "Middle name",
                                         "mandatory": false,
-                                        "q_code": "30",
                                         "type": "TextField"
                                     },
                                     {
                                         "id": "last-name",
                                         "label": "Last name",
                                         "mandatory": false,
-                                        "q_code": "30",
                                         "type": "TextField"
                                     }
                                 ]
@@ -78,36 +75,62 @@
                                         "id": "address-line1",
                                         "label": "Address Line 1",
                                         "mandatory": false,
-                                        "q_code": "30",
                                         "type": "TextField"
                                     },
                                     {
                                         "id": "address-line2",
                                         "label": "Address Line 2",
                                         "mandatory": false,
-                                        "q_code": "30",
                                         "type": "TextField"
                                     },
                                     {
                                         "id": "town-city",
                                         "label": "Town/City",
                                         "mandatory": false,
-                                        "q_code": "30",
                                         "type": "TextField"
                                     },
                                     {
                                         "id": "county",
                                         "label": "County",
                                         "mandatory": false,
-                                        "q_code": "30",
                                         "type": "TextField"
                                     },
                                     {
                                         "id": "postcode",
                                         "label": "Postcode",
                                         "mandatory": false,
-                                        "q_code": "30",
                                         "type": "TextField"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "type": "Question",
+                            "id": "age",
+                            "question": {
+                                "id": "age-question",
+                                "title": "Age",
+                                "type": "General",
+                                "summary": {
+                                    "concatenation_type": "Newline"
+                                },
+                                "answers": [
+                                    {
+                                        "id": "age-number",
+                                        "label": "Enter your age",
+                                        "mandatory": false,
+                                        "type": "Number"
+                                    },
+                                    {
+                                        "id": "single-checkbox-answer",
+                                        "mandatory": false,
+                                        "options": [
+                                            {
+                                                "label": "This age is an estimate",
+                                                "value": "This age is an estimate"
+                                            }
+                                        ],
+                                        "type": "Checkbox"
                                     }
                                 ]
                             }

--- a/tests/app/views/contexts/summary/test_question.py
+++ b/tests/app/views/contexts/summary/test_question.py
@@ -167,6 +167,58 @@ class TestQuestion(AppContextTestCase):  # pylint: disable=too-many-public-metho
         )
         self.assertEqual(len(question.answers), 1)
 
+    def test_concatenate_number_and_checkbox_answers(self):
+        answer_separators = {"Newline": "<br>", "Space": " "}
+
+        for concatenation_type, concatenation_character in answer_separators.items():
+            with self.subTest(
+                concatenation_type=concatenation_type,
+                concatenation_character=concatenation_character,
+            ):
+                # Given
+                self.answer_store.add_or_update(Answer(answer_id="age", value=7))
+                self.answer_store.add_or_update(
+                    Answer(answer_id="estimate", value=["This age is an estimate"])
+                )
+
+                age_answer_schema = {
+                    "id": "age",
+                    "label": "Enter your age",
+                    "mandatory": False,
+                    "type": "Number",
+                }
+                checkbox_answer_schema = {
+                    "id": "estimate",
+                    "mandatory": False,
+                    "options": [
+                        {
+                            "label": "This age is an estimate",
+                            "value": "This age is an estimate",
+                        }
+                    ],
+                    "type": "Checkbox",
+                }
+
+                question_schema = {
+                    "id": "question_id",
+                    "title": "question_title",
+                    "type": "General",
+                    "answers": [age_answer_schema, checkbox_answer_schema],
+                    "summary": {"concatenation_type": concatenation_type},
+                }
+
+                # When
+                question = Question(
+                    question_schema, self.answer_store, self.schema, None
+                )
+
+                # Then
+                self.assertEqual(
+                    question.answers[0]["value"],
+                    f"7{concatenation_character}This age is an estimate",
+                )
+                self.assertEqual(len(question.answers), 1)
+
     def test_create_question_with_multiple_answers(self):
         # Given
         self.answer_store.add_or_update(Answer(answer_id="answer_1", value="Han"))

--- a/tests/app/views/contexts/summary/test_question.py
+++ b/tests/app/views/contexts/summary/test_question.py
@@ -70,102 +70,82 @@ class TestQuestion(AppContextTestCase):  # pylint: disable=too-many-public-metho
         self.assertEqual(question.title, "Age")
         self.assertEqual(len(question.answers), 1)
 
-    def test_concatenate_textfield_answers_space(self):
+    def test_concatenate_textfield_answers(self):
+        answer_separators = {"Newline": "<br>", "Space": " "}
 
-        # Given
-        self.answer_store.add_or_update(Answer(answer_id="first-name", value="John"))
-        self.answer_store.add_or_update(Answer(answer_id="last-name", value="Smith"))
+        for concatenation_type, concatenation_character in answer_separators.items():
+            with self.subTest(
+                concatenation_type=concatenation_type,
+                concatenation_character=concatenation_character,
+            ):
 
-        first_name_schema = {
-            "id": "first-name",
-            "label": "First name",
-            "mandatory": True,
-            "type": "TextField",
-        }
-        middle_name_schema = {
-            "id": "middle-name",
-            "label": "Middle name",
-            "mandatory": False,
-            "type": "TextField",
-        }
-        last_name_schema = {
-            "id": "last-name",
-            "label": "Last name",
-            "mandatory": True,
-            "type": "TextField",
-        }
+                # Given
+                self.answer_store.add_or_update(
+                    Answer(answer_id="address-line-1", value="Cardiff Rd")
+                )
+                self.answer_store.add_or_update(
+                    Answer(answer_id="town-city", value="Newport")
+                )
+                self.answer_store.add_or_update(
+                    Answer(answer_id="postcode", value="NP10 8XG")
+                )
 
-        question_schema = {
-            "id": "question_id",
-            "title": "question_title",
-            "type": "General",
-            "answers": [first_name_schema, middle_name_schema, last_name_schema],
-            "summary": {"concatenation_type": "Space"},
-        }
+                address_line_1 = {
+                    "id": "address-line-1",
+                    "label": "Address line 1",
+                    "mandatory": False,
+                    "type": "TextField",
+                }
+                address_line_2 = {
+                    "id": "address-line-2",
+                    "label": "Address line 2",
+                    "mandatory": False,
+                    "type": "TextField",
+                }
+                town_city = {
+                    "id": "town-city",
+                    "label": "Town or City",
+                    "mandatory": False,
+                    "type": "TextField",
+                }
+                county = {
+                    "id": "county",
+                    "label": "County",
+                    "mandatory": False,
+                    "type": "TextField",
+                }
+                postcode = {
+                    "id": "postcode",
+                    "label": "Postcode",
+                    "mandatory": False,
+                    "type": "TextField",
+                }
 
-        # When
-        question = Question(question_schema, self.answer_store, self.schema, None)
+                question_schema = {
+                    "id": "question_id",
+                    "title": "question_title",
+                    "type": "General",
+                    "answers": [
+                        address_line_1,
+                        address_line_2,
+                        town_city,
+                        county,
+                        postcode,
+                    ],
+                    "summary": {"concatenation_type": concatenation_type},
+                }
 
-        # Then
-        self.assertEqual(question.answers[0]["value"], "John Smith")
-        self.assertEqual(len(question.answers), 1)
+                # When
+                question = Question(
+                    question_schema, self.answer_store, self.schema, None
+                )
 
-    def test_concatenate_textfield_answers_new_line(self):
-
-        # Given
-        self.answer_store.add_or_update(
-            Answer(answer_id="address-line-1", value="Cardiff Rd")
-        )
-        self.answer_store.add_or_update(Answer(answer_id="town-city", value="Newport"))
-        self.answer_store.add_or_update(Answer(answer_id="postcode", value="NP10 8XG"))
-
-        address_line_1 = {
-            "id": "address-line-1",
-            "label": "Address line 1",
-            "mandatory": False,
-            "type": "TextField",
-        }
-        address_line_2 = {
-            "id": "address-line-2",
-            "label": "Address line 2",
-            "mandatory": False,
-            "type": "TextField",
-        }
-        town_city = {
-            "id": "town-city",
-            "label": "Town or City",
-            "mandatory": False,
-            "type": "TextField",
-        }
-        county = {
-            "id": "county",
-            "label": "County",
-            "mandatory": False,
-            "type": "TextField",
-        }
-        postcode = {
-            "id": "postcode",
-            "label": "Postcode",
-            "mandatory": False,
-            "type": "TextField",
-        }
-
-        question_schema = {
-            "id": "question_id",
-            "title": "question_title",
-            "type": "General",
-            "answers": [address_line_1, address_line_2, town_city, county, postcode],
-            "summary": {"concatenation_type": "Newline"},
-        }
-
-        # When
-        question = Question(question_schema, self.answer_store, self.schema, None)
-
-        # Then
-        self.assertEqual(
-            question.answers[0]["value"], "Cardiff Rd<br>Newport<br>NP10 8XG"
-        )
-        self.assertEqual(len(question.answers), 1)
+                # Then
+                self.assertEqual(
+                    question.answers[0]["value"],
+                    f"Cardiff Rd{concatenation_character}Newport{concatenation_character}NP10 8XG",
+                )
+                self.assertEqual(len(question.answers), 1)
 
     def test_concatenate_number_and_checkbox_answers(self):
         answer_separators = {"Newline": "<br>", "Space": " "}

--- a/tests/functional/spec/features/summary/custom_question_summary.spec.js
+++ b/tests/functional/spec/features/summary/custom_question_summary.spec.js
@@ -1,7 +1,8 @@
 import AddressBlockPage from "../../../generated_pages/custom_question_summary/address.page.js";
+import AgeBlock from "../../../generated_pages/custom_question_summary/age.page.js";
 import NameBlockPage from "../../../generated_pages/custom_question_summary/name.page.js";
 import SummaryPage from "../../../generated_pages/custom_question_summary/summary.page.js";
-import AgeBlock from "../../../generated_pages/custom_question_summary/age.page.js";
+
 import BaseSummaryPage from "../../../base_pages/summary.page.js";
 
 describe("Summary Screen", () => {

--- a/tests/functional/spec/features/summary/custom_question_summary.spec.js
+++ b/tests/functional/spec/features/summary/custom_question_summary.spec.js
@@ -4,7 +4,6 @@ import SummaryPage from "../../../generated_pages/custom_question_summary/summar
 import AgeBlock from "../../../generated_pages/custom_question_summary/age.page.js";
 import BaseSummaryPage from "../../../base_pages/summary.page.js";
 
-
 describe("Summary Screen", () => {
   beforeEach("Load the survey", () => {
     browser.openQuestionnaire("test_custom_question_summary.json");
@@ -14,6 +13,7 @@ describe("Summary Screen", () => {
     completeAllQuestions();
     expect($(BaseSummaryPage.summaryRowState(1)).getText()).to.contain("John Smith");
     expect($(BaseSummaryPage.summaryRowState(2)).getText()).to.contain("Cardiff Road\nNewport\nNP10 8XG");
+    expect($(BaseSummaryPage.summaryRowState(3)).getText()).to.contain("7\nThis age is an estimate");
   });
 
   it("Given no values are entered in a question with multiple answers and concatenation set, when on the summary screen then the correct response should be displayed", () => {

--- a/tests/functional/spec/features/summary/custom_question_summary.spec.js
+++ b/tests/functional/spec/features/summary/custom_question_summary.spec.js
@@ -1,7 +1,9 @@
 import AddressBlockPage from "../../../generated_pages/custom_question_summary/address.page.js";
 import NameBlockPage from "../../../generated_pages/custom_question_summary/name.page.js";
 import SummaryPage from "../../../generated_pages/custom_question_summary/summary.page.js";
+import AgeBlock from "../../../generated_pages/custom_question_summary/age.page.js";
 import BaseSummaryPage from "../../../base_pages/summary.page.js";
+
 
 describe("Summary Screen", () => {
   beforeEach("Load the survey", () => {
@@ -17,6 +19,7 @@ describe("Summary Screen", () => {
   it("Given no values are entered in a question with multiple answers and concatenation set, when on the summary screen then the correct response should be displayed", () => {
     $(NameBlockPage.submit()).click();
     $(AddressBlockPage.submit()).click();
+    $(AgeBlock.submit()).click();
     expect(browser.getUrl()).to.contain(SummaryPage.pageName);
     expect($(BaseSummaryPage.summaryRowState(1)).getText()).to.contain("No answer provided");
   });
@@ -29,5 +32,8 @@ describe("Summary Screen", () => {
     $(AddressBlockPage.townCity()).setValue("Newport");
     $(AddressBlockPage.postcode()).setValue("NP10 8XG");
     $(AddressBlockPage.submit()).click();
+    $(AgeBlock.number()).setValue(7);
+    $(AgeBlock.singleCheckboxThisAgeIsAnEstimate()).click();
+    $(AgeBlock.submit()).click();
   }
 });


### PR DESCRIPTION
### What is the context of this PR?
Added supports for Checkbox and Number answer types when using custom question summary.

### How to review 
- Ensure the concatenation is as expected when using Number/Checkbox.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
