### PR TITLE
Remove expects from middle of tests

### DIFF
--- a/tests/functional/spec/features/repeating_sections/repeating_sections_with_hub_and_spoke.spec.js
+++ b/tests/functional/spec/features/repeating_sections/repeating_sections_with_hub_and_spoke.spec.js
@@ -193,15 +193,7 @@ describe("Feature: Repeating Sections with Hub and Spoke", () => {
       $(ProxyPage.noIMAnsweringForMyself()).click();
       $(ProxyPage.submit()).click();
 
-      $(DateOfBirthPage.day()).setValue("07");
-      $(DateOfBirthPage.month()).setValue("07");
-      $(DateOfBirthPage.year()).setValue("1970");
-      $(DateOfBirthPage.submit()).click();
-
-      $(ConfirmDateOfBirthPage.confirmDateOfBirthYesIAmAgeOld()).click();
-      $(ConfirmDateOfBirthPage.submit()).click();
-
-      expect($(SexPage.questionText()).getText()).to.equal("What is your sex?");
+      expect($(DateOfBirthPage.questionText()).getText()).to.equal("What is your date of birth?");
     });
 
     it("When the user answers on on behalf of someone else, Then they are shown the proxy question variant for the relevant repeating section", () => {
@@ -214,10 +206,7 @@ describe("Feature: Repeating Sections with Hub and Spoke", () => {
       $(DateOfBirthPage.year()).setValue("1990");
       $(DateOfBirthPage.submit()).click();
 
-      $(ConfirmDateOfBirthPage.confirmDateOfBirthYesPersonNameIsAgeOld()).click();
-      $(ConfirmDateOfBirthPage.submit()).click();
-
-      expect($(SexPage.questionText()).getText()).to.equal("What is Samuel Clemens’ sex?");
+      expect($(DateOfBirthPage.questionText()).getText()).to.equal("What is Samuel Clemens’ date of birth?");
     });
 
     it("When the user completes all sections, Then the Hub should be in the completed state", () => {

--- a/tests/functional/spec/features/repeating_sections/repeating_sections_with_hub_and_spoke.spec.js
+++ b/tests/functional/spec/features/repeating_sections/repeating_sections_with_hub_and_spoke.spec.js
@@ -193,7 +193,15 @@ describe("Feature: Repeating Sections with Hub and Spoke", () => {
       $(ProxyPage.noIMAnsweringForMyself()).click();
       $(ProxyPage.submit()).click();
 
-      expect($(DateOfBirthPage.questionText()).getText()).to.equal("What is your date of birth?");
+      $(DateOfBirthPage.day()).setValue("07");
+      $(DateOfBirthPage.month()).setValue("07");
+      $(DateOfBirthPage.year()).setValue("1970");
+      $(DateOfBirthPage.submit()).click();
+
+      $(ConfirmDateOfBirthPage.confirmDateOfBirthYesIAmAgeOld()).click();
+      $(ConfirmDateOfBirthPage.submit()).click();
+
+      expect($(SexPage.questionText()).getText()).to.equal("What is your sex?");
     });
 
     it("When the user answers on on behalf of someone else, Then they are shown the proxy question variant for the relevant repeating section", () => {
@@ -206,7 +214,9 @@ describe("Feature: Repeating Sections with Hub and Spoke", () => {
       $(DateOfBirthPage.year()).setValue("1990");
       $(DateOfBirthPage.submit()).click();
 
-      expect($(DateOfBirthPage.questionText()).getText()).to.equal("What is Samuel Clemens’ date of birth?");
+      $(ConfirmDateOfBirthPage.confirmDateOfBirthYesPersonNameIsAgeOld()).click();
+      $(ConfirmDateOfBirthPage.submit()).click();
+      expect($(SexPage.questionText()).getText()).to.equal("What is Samuel Clemens’ sex?");
     });
 
     it("When the user completes all sections, Then the Hub should be in the completed state", () => {

--- a/tests/functional/spec/features/repeating_sections/repeating_sections_with_hub_and_spoke.spec.js
+++ b/tests/functional/spec/features/repeating_sections/repeating_sections_with_hub_and_spoke.spec.js
@@ -158,7 +158,6 @@ describe("Feature: Repeating Sections with Hub and Spoke", () => {
       $(FirstListCollectorPage.submit()).click();
       $(SecondListCollectorInterstitialPage.submit()).click();
       $(SecondListCollectorPage.submit()).click();
-      expect($(SexPage.questionText()).getText()).to.equal("This is the visitors list collector. Add a visitor?");
 
       // Add first visitor
       $(VisitorsListCollectorPage.yes()).click();
@@ -194,14 +193,10 @@ describe("Feature: Repeating Sections with Hub and Spoke", () => {
       $(ProxyPage.noIMAnsweringForMyself()).click();
       $(ProxyPage.submit()).click();
 
-      expect($(DateOfBirthPage.questionText()).getText()).to.equal("What is your date of birth?");
-
       $(DateOfBirthPage.day()).setValue("07");
       $(DateOfBirthPage.month()).setValue("07");
       $(DateOfBirthPage.year()).setValue("1970");
       $(DateOfBirthPage.submit()).click();
-
-      expect($(ConfirmDateOfBirthPage.questionText()).getText()).to.equal("You are 49 years old. Is this correct?");
 
       $(ConfirmDateOfBirthPage.confirmDateOfBirthYesIAmAgeOld()).click();
       $(ConfirmDateOfBirthPage.submit()).click();
@@ -213,8 +208,6 @@ describe("Feature: Repeating Sections with Hub and Spoke", () => {
       $(HubPage.summaryRowLink(4)).click();
       $(ProxyPage.yes()).click();
       $(ProxyPage.submit()).click();
-
-      expect($(DateOfBirthPage.questionText()).getText()).to.equal("What is Samuel Clemens’ date of birth?");
 
       $(DateOfBirthPage.day()).setValue("11");
       $(DateOfBirthPage.month()).setValue("11");
@@ -290,9 +283,6 @@ describe("Feature: Repeating Sections with Hub and Spoke", () => {
     });
 
     it("When the user removes a member from the household, Then their section is not longer displayed on he Hub", () => {
-      // Ensure final householder exists
-      expect($(HubPage.summaryRowState(8)).isExisting()).to.be.true;
-
       $(HubPage.summaryRowLink(1)).click();
       $(PrimaryPersonPage.submit()).click();
       $(PrimaryPersonAddPage.submit()).click();


### PR DESCRIPTION
### What is the context of this PR?

Remove interim expects from middle of functional tests which serve no purpose. Currently one such expect is unnecessarily testing an age.

### How to review 

Check the tests continue to pass.
