### PR TITLE
Remove redundant group title text

### DIFF
--- a/test_schemas/en/test_big_list_naughty_strings.json
+++ b/test_schemas/en/test_big_list_naughty_strings.json
@@ -3586,7 +3586,6 @@
                             "id": "textarea-summary"
                         }
                     ],
-                    "title": "Title",
                     "id": "textarea-group"
                 }
             ]

--- a/test_schemas/en/test_checkbox.json
+++ b/test_schemas/en/test_checkbox.json
@@ -174,8 +174,7 @@
                             "id": "summary"
                         }
                     ],
-                    "id": "checkboxes",
-                    "title": "Title"
+                    "id": "checkboxes"
                 }
             ]
         }

--- a/test_schemas/en/test_checkbox_multiple_detail_answers.json
+++ b/test_schemas/en/test_checkbox_multiple_detail_answers.json
@@ -112,8 +112,7 @@
                             "id": "summary"
                         }
                     ],
-                    "id": "checkboxes",
-                    "title": "Title"
+                    "id": "checkboxes"
                 }
             ]
         }

--- a/test_schemas/en/test_checkbox_numeric_detail_answers.json
+++ b/test_schemas/en/test_checkbox_numeric_detail_answers.json
@@ -88,8 +88,7 @@
                             "id": "summary"
                         }
                     ],
-                    "id": "checkboxes",
-                    "title": "Title"
+                    "id": "checkboxes"
                 }
             ]
         }

--- a/test_schemas/en/test_currency.json
+++ b/test_schemas/en/test_currency.json
@@ -102,8 +102,7 @@
                             "id": "summary"
                         }
                     ],
-                    "id": "group",
-                    "title": "Title"
+                    "id": "group"
                 }
             ]
         }

--- a/test_schemas/en/test_custom_question_summary.json
+++ b/test_schemas/en/test_custom_question_summary.json
@@ -140,8 +140,7 @@
                             "id": "summary"
                         }
                     ],
-                    "id": "default-group",
-                    "title": "Title"
+                    "id": "default-group"
                 }
             ]
         }

--- a/test_schemas/en/test_date_range.json
+++ b/test_schemas/en/test_date_range.json
@@ -58,8 +58,7 @@
                             "id": "summary"
                         }
                     ],
-                    "id": "dates",
-                    "title": "Title"
+                    "id": "dates"
                 }
             ]
         }

--- a/test_schemas/en/test_dates.json
+++ b/test_schemas/en/test_dates.json
@@ -28,7 +28,6 @@
             "groups": [
                 {
                     "id": "dates",
-                    "title": "Title",
                     "blocks": [
                         {
                             "type": "Question",

--- a/test_schemas/en/test_default.json
+++ b/test_schemas/en/test_default.json
@@ -67,8 +67,7 @@
                             "id": "summary"
                         }
                     ],
-                    "id": "group",
-                    "title": "Title"
+                    "id": "group"
                 }
             ]
         }

--- a/test_schemas/en/test_default_with_skip.json
+++ b/test_schemas/en/test_default_with_skip.json
@@ -107,8 +107,7 @@
                             "id": "summary"
                         }
                     ],
-                    "id": "group",
-                    "title": "Title"
+                    "id": "group"
                 }
             ]
         }

--- a/test_schemas/en/test_dob_date.json
+++ b/test_schemas/en/test_dob_date.json
@@ -201,8 +201,7 @@
                             ]
                         }
                     ],
-                    "id": "test",
-                    "title": "Title"
+                    "id": "test"
                 },
                 {
                     "blocks": [

--- a/test_schemas/en/test_durations.json
+++ b/test_schemas/en/test_durations.json
@@ -91,8 +91,7 @@
                             "id": "summary"
                         }
                     ],
-                    "id": "durations",
-                    "title": "Title"
+                    "id": "durations"
                 }
             ]
         }

--- a/test_schemas/en/test_error_messages.json
+++ b/test_schemas/en/test_error_messages.json
@@ -62,8 +62,7 @@
                             }
                         }
                     ],
-                    "id": "test",
-                    "title": "Title"
+                    "id": "test"
                 },
                 {
                     "blocks": [

--- a/test_schemas/en/test_hub_and_spoke.json
+++ b/test_schemas/en/test_hub_and_spoke.json
@@ -186,8 +186,7 @@
                             "type": "Question"
                         }
                     ],
-                    "id": "checkboxes",
-                    "title": "Title"
+                    "id": "checkboxes"
                 }
             ]
         },
@@ -306,8 +305,7 @@
                             "type": "Question"
                         }
                     ],
-                    "id": "relationship-group",
-                    "title": "Title"
+                    "id": "relationship-group"
                 }
             ]
         }

--- a/test_schemas/en/test_hub_complete_sections.json
+++ b/test_schemas/en/test_hub_complete_sections.json
@@ -187,8 +187,7 @@
                             "type": "Question"
                         }
                     ],
-                    "id": "checkboxes",
-                    "title": "Title"
+                    "id": "checkboxes"
                 }
             ]
         }

--- a/test_schemas/en/test_language.json
+++ b/test_schemas/en/test_language.json
@@ -23,7 +23,6 @@
             "groups": [
                 {
                     "id": "language-group",
-                    "title": "Title",
                     "blocks": [
                         {
                             "type": "Question",

--- a/test_schemas/en/test_list_change_evaluates_sections.json
+++ b/test_schemas/en/test_list_change_evaluates_sections.json
@@ -325,8 +325,7 @@
                             "type": "Question"
                         }
                     ],
-                    "id": "accommodation-group",
-                    "title": "Title"
+                    "id": "accommodation-group"
                 }
             ],
             "id": "accommodation-section",

--- a/test_schemas/en/test_multiple_answers.json
+++ b/test_schemas/en/test_multiple_answers.json
@@ -58,8 +58,7 @@
                             "id": "summary"
                         }
                     ],
-                    "id": "multiple-questions-group",
-                    "title": "Title"
+                    "id": "multiple-questions-group"
                 }
             ]
         }

--- a/test_schemas/en/test_numbers.json
+++ b/test_schemas/en/test_numbers.json
@@ -284,8 +284,7 @@
                             }
                         }
                     ],
-                    "id": "test",
-                    "title": "Title"
+                    "id": "test"
                 },
                 {
                     "blocks": [

--- a/test_schemas/en/test_percentage.json
+++ b/test_schemas/en/test_percentage.json
@@ -55,8 +55,7 @@
                             "routing_rules": []
                         }
                     ],
-                    "id": "group",
-                    "title": "Title"
+                    "id": "group"
                 }
             ]
         },

--- a/test_schemas/en/test_placeholder_full.json
+++ b/test_schemas/en/test_placeholder_full.json
@@ -35,7 +35,6 @@
             "groups": [
                 {
                     "id": "name-group",
-                    "title": "Title",
                     "blocks": [
                         {
                             "type": "Question",
@@ -70,7 +69,6 @@
             "groups": [
                 {
                     "id": "dob-input-group",
-                    "title": "Title",
                     "blocks": [
                         {
                             "type": "Question",
@@ -245,8 +243,7 @@
                             ]
                         }
                     ],
-                    "id": "group",
-                    "title": "Title"
+                    "id": "group"
                 }
             ]
         },
@@ -256,7 +253,6 @@
             "groups": [
                 {
                     "id": "mutually-exclusive-mandatory-group",
-                    "title": "Title",
                     "blocks": [
                         {
                             "type": "Question",

--- a/test_schemas/en/test_placeholder_metadata.json
+++ b/test_schemas/en/test_placeholder_metadata.json
@@ -51,8 +51,7 @@
                             "routing_rules": []
                         }
                     ],
-                    "id": "group",
-                    "title": "Title"
+                    "id": "group"
                 }
             ]
         },

--- a/test_schemas/en/test_placeholder_playback_list.json
+++ b/test_schemas/en/test_placeholder_playback_list.json
@@ -160,8 +160,7 @@
                             "id": "summary"
                         }
                     ],
-                    "id": "checkboxes",
-                    "title": "Title"
+                    "id": "checkboxes"
                 }
             ]
         }

--- a/test_schemas/en/test_placeholder_transform.json
+++ b/test_schemas/en/test_placeholder_transform.json
@@ -31,7 +31,6 @@
             "groups": [
                 {
                     "id": "retail-turnover-group",
-                    "title": "Title",
                     "blocks": [
                         {
                             "type": "Question",
@@ -101,8 +100,7 @@
                             }
                         }
                     ],
-                    "id": "retail-confirmation-group",
-                    "title": "Title"
+                    "id": "retail-confirmation-group"
                 }
             ]
         },
@@ -112,7 +110,6 @@
             "groups": [
                 {
                     "id": "total-items-group",
-                    "title": "Title",
                     "blocks": [
                         {
                             "type": "Question",

--- a/test_schemas/en/test_question_definition.json
+++ b/test_schemas/en/test_question_definition.json
@@ -27,7 +27,6 @@
             "groups": [
                 {
                     "id": "definition-group",
-                    "title": "Title",
                     "blocks": [
                         {
                             "type": "Question",

--- a/test_schemas/en/test_question_guidance.json
+++ b/test_schemas/en/test_question_guidance.json
@@ -27,7 +27,6 @@
             "groups": [
                 {
                     "id": "group",
-                    "title": "Title",
                     "blocks": [
                         {
                             "type": "Introduction",

--- a/test_schemas/en/test_routing_answer_comparison.json
+++ b/test_schemas/en/test_routing_answer_comparison.json
@@ -28,7 +28,6 @@
             "groups": [
                 {
                     "id": "route-group",
-                    "title": "Title",
                     "blocks": [
                         {
                             "type": "Question",
@@ -114,7 +113,6 @@
                 },
                 {
                     "id": "summary-group",
-                    "title": "Title",
                     "blocks": [
                         {
                             "type": "Summary",

--- a/test_schemas/en/test_routing_checkbox_contains.json
+++ b/test_schemas/en/test_routing_checkbox_contains.json
@@ -121,8 +121,7 @@
                             "id": "summary"
                         }
                     ],
-                    "id": "checkboxes",
-                    "title": "Title"
+                    "id": "checkboxes"
                 }
             ]
         }

--- a/test_schemas/en/test_routing_checkbox_set_not_set.json
+++ b/test_schemas/en/test_routing_checkbox_set_not_set.json
@@ -207,8 +207,7 @@
                             "id": "summary"
                         }
                     ],
-                    "id": "checkboxes",
-                    "title": "Title"
+                    "id": "checkboxes"
                 }
             ]
         }

--- a/test_schemas/en/test_routing_date_equals.json
+++ b/test_schemas/en/test_routing_date_equals.json
@@ -255,8 +255,7 @@
                             "id": "summary"
                         }
                     ],
-                    "id": "group",
-                    "title": "Title"
+                    "id": "group"
                 }
             ]
         }

--- a/test_schemas/en/test_routing_date_greater_than.json
+++ b/test_schemas/en/test_routing_date_greater_than.json
@@ -161,8 +161,7 @@
                             "id": "summary"
                         }
                     ],
-                    "id": "group",
-                    "title": "Title"
+                    "id": "group"
                 }
             ]
         }

--- a/test_schemas/en/test_routing_date_less_than.json
+++ b/test_schemas/en/test_routing_date_less_than.json
@@ -101,8 +101,7 @@
                             "id": "summary"
                         }
                     ],
-                    "id": "group",
-                    "title": "Title"
+                    "id": "group"
                 }
             ]
         }

--- a/test_schemas/en/test_routing_date_not_equals.json
+++ b/test_schemas/en/test_routing_date_not_equals.json
@@ -101,8 +101,7 @@
                             "id": "summary"
                         }
                     ],
-                    "id": "group",
-                    "title": "Title"
+                    "id": "group"
                 }
             ]
         }

--- a/test_schemas/en/test_routing_not_affected_by_answers_not_on_path.json
+++ b/test_schemas/en/test_routing_not_affected_by_answers_not_on_path.json
@@ -193,8 +193,7 @@
                             "id": "summary"
                         }
                     ],
-                    "id": "group",
-                    "title": "Title"
+                    "id": "group"
                 }
             ]
         }

--- a/test_schemas/en/test_routing_number_equals.json
+++ b/test_schemas/en/test_routing_number_equals.json
@@ -121,8 +121,7 @@
                             "id": "summary"
                         }
                     ],
-                    "id": "group",
-                    "title": "Title"
+                    "id": "group"
                 }
             ]
         }

--- a/test_schemas/en/test_routing_number_greater_than.json
+++ b/test_schemas/en/test_routing_number_greater_than.json
@@ -121,8 +121,7 @@
                             "id": "summary"
                         }
                     ],
-                    "id": "group",
-                    "title": "Title"
+                    "id": "group"
                 }
             ]
         }

--- a/test_schemas/en/test_routing_number_greater_than_or_equal.json
+++ b/test_schemas/en/test_routing_number_greater_than_or_equal.json
@@ -134,7 +134,6 @@
                         }
                     ],
                     "id": "group",
-                    "title": "Title"
                 }
             ]
         }

--- a/test_schemas/en/test_routing_number_greater_than_or_equal.json
+++ b/test_schemas/en/test_routing_number_greater_than_or_equal.json
@@ -133,7 +133,7 @@
                             "id": "summary"
                         }
                     ],
-                    "id": "group",
+                    "id": "group"
                 }
             ]
         }

--- a/test_schemas/en/test_routing_number_greater_than_or_equal_single_condition.json
+++ b/test_schemas/en/test_routing_number_greater_than_or_equal_single_condition.json
@@ -121,8 +121,7 @@
                             "id": "summary"
                         }
                     ],
-                    "id": "group",
-                    "title": "Title"
+                    "id": "group"
                 }
             ]
         }

--- a/test_schemas/en/test_routing_number_less_than.json
+++ b/test_schemas/en/test_routing_number_less_than.json
@@ -121,8 +121,7 @@
                             "id": "summary"
                         }
                     ],
-                    "id": "group",
-                    "title": "Title"
+                    "id": "group"
                 }
             ]
         }

--- a/test_schemas/en/test_routing_number_less_than_or_equal.json
+++ b/test_schemas/en/test_routing_number_less_than_or_equal.json
@@ -133,8 +133,7 @@
                             "id": "summary"
                         }
                     ],
-                    "id": "group",
-                    "title": "Title"
+                    "id": "group"
                 }
             ]
         }

--- a/test_schemas/en/test_routing_number_less_than_or_equal_single_condition.json
+++ b/test_schemas/en/test_routing_number_less_than_or_equal_single_condition.json
@@ -121,8 +121,7 @@
                             "id": "summary"
                         }
                     ],
-                    "id": "group",
-                    "title": "Title"
+                    "id": "group"
                 }
             ]
         }

--- a/test_schemas/en/test_routing_number_not_equals.json
+++ b/test_schemas/en/test_routing_number_not_equals.json
@@ -121,8 +121,7 @@
                             "id": "summary"
                         }
                     ],
-                    "id": "group",
-                    "title": "Title"
+                    "id": "group"
                 }
             ]
         }

--- a/test_schemas/en/test_show_section_summary_on_completion.json
+++ b/test_schemas/en/test_show_section_summary_on_completion.json
@@ -192,8 +192,7 @@
                             "type": "Question"
                         }
                     ],
-                    "id": "checkboxes",
-                    "title": "Title"
+                    "id": "checkboxes"
                 }
             ]
         }

--- a/test_schemas/en/test_skip_condition.json
+++ b/test_schemas/en/test_skip_condition.json
@@ -101,8 +101,7 @@
                             "id": "summary"
                         }
                     ],
-                    "id": "breakfast",
-                    "title": "Title"
+                    "id": "breakfast"
                 }
             ]
         }

--- a/test_schemas/en/test_skip_condition_answer_comparison.json
+++ b/test_schemas/en/test_skip_condition_answer_comparison.json
@@ -165,12 +165,10 @@
                             ]
                         }
                     ],
-                    "id": "skip-group",
-                    "title": "Title"
+                    "id": "skip-group"
                 },
                 {
                     "id": "summary-group",
-                    "title": "Title",
                     "blocks": [
                         {
                             "type": "Summary",

--- a/test_schemas/en/test_skip_condition_block.json
+++ b/test_schemas/en/test_skip_condition_block.json
@@ -114,8 +114,7 @@
                             "id": "summary"
                         }
                     ],
-                    "id": "summary-group",
-                    "title": "Title"
+                    "id": "summary-group"
                 }
             ]
         }

--- a/test_schemas/en/test_skip_condition_not_set.json
+++ b/test_schemas/en/test_skip_condition_not_set.json
@@ -100,8 +100,7 @@
                             "id": "summary"
                         }
                     ],
-                    "id": "breakfast",
-                    "title": "Title"
+                    "id": "breakfast"
                 }
             ]
         }

--- a/test_schemas/en/test_skip_condition_set.json
+++ b/test_schemas/en/test_skip_condition_set.json
@@ -100,8 +100,7 @@
                             "id": "summary"
                         }
                     ],
-                    "id": "breakfast",
-                    "title": "Title"
+                    "id": "breakfast"
                 }
             ]
         }

--- a/test_schemas/en/test_summary.json
+++ b/test_schemas/en/test_summary.json
@@ -111,8 +111,7 @@
                             }
                         }
                     ],
-                    "id": "summary-group",
-                    "title": "Title"
+                    "id": "summary-group"
                 },
                 {
                     "blocks": [

--- a/test_schemas/en/test_textarea.json
+++ b/test_schemas/en/test_textarea.json
@@ -62,8 +62,7 @@
                             "id": "textarea-summary"
                         }
                     ],
-                    "id": "textarea-group",
-                    "title": "Title"
+                    "id": "textarea-group"
                 }
             ]
         }

--- a/test_schemas/en/test_textfield.json
+++ b/test_schemas/en/test_textfield.json
@@ -57,8 +57,7 @@
                             "id": "summary"
                         }
                     ],
-                    "id": "group",
-                    "title": "Title"
+                    "id": "group"
                 }
             ]
         }

--- a/test_schemas/en/test_textfield_suggestions.json
+++ b/test_schemas/en/test_textfield_suggestions.json
@@ -51,8 +51,7 @@
                             "id": "summary"
                         }
                     ],
-                    "id": "group",
-                    "title": "Title"
+                    "id": "group"
                 }
             ]
         }

--- a/test_schemas/en/test_title.json
+++ b/test_schemas/en/test_title.json
@@ -27,7 +27,6 @@
             "groups": [
                 {
                     "id": "group",
-                    "title": "Title",
                     "blocks": [
                         {
                             "type": "Question",

--- a/test_schemas/en/test_titles_radio_and_checkbox.json
+++ b/test_schemas/en/test_titles_radio_and_checkbox.json
@@ -26,7 +26,6 @@
             "groups": [
                 {
                     "id": "radio-checkbox-group",
-                    "title": "Title",
                     "blocks": [
                         {
                             "id": "preamble-block",

--- a/test_schemas/en/test_unit_patterns.json
+++ b/test_schemas/en/test_unit_patterns.json
@@ -226,8 +226,7 @@
                             }
                         }
                     ],
-                    "id": "test",
-                    "title": "Title"
+                    "id": "test"
                 },
                 {
                     "blocks": [


### PR DESCRIPTION
### What is the context of this PR?
Group titles are no longer required in validator and all places where default text was used can now be removed. ("title": "Title") There was no need to update summary/summary.html as it already dealt with groups not having titles, although it wasn't exercised

N.B The validator branch which goes with this PR is remove-redundant-group-titles

### How to review 
Check I haven't missed any

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
