### PR TITLE
Adjust interviwer note text

### DIFF
--- a/app/translations/messages.pot
+++ b/app/translations/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-07-16 12:25+0100\n"
+"POT-Creation-Date: 2020-07-17 12:19+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -628,7 +628,7 @@ msgid "Sign out"
 msgstr ""
 
 #: templates/macros/helpers.html:32
-msgid "Interviewer Note:"
+msgid "Interviewer note:"
 msgstr ""
 
 #: templates/partials/answer-guidance.html:13

--- a/templates/macros/helpers.html
+++ b/templates/macros/helpers.html
@@ -29,5 +29,5 @@
 {%- endmacro -%}
 
 {%- macro interviewer_note(title=None) -%}
-<mark class="instruction">{{_("Interviewer Note:")}}</mark>{{ title }}
+<mark class="instruction">{{_("Interviewer note:")}}</mark>{{ title }}
 {%- endmacro -%}

--- a/tests/functional/spec/interviewer_note.spec.js
+++ b/tests/functional/spec/interviewer_note.spec.js
@@ -9,20 +9,20 @@ describe("Given I start a survey", () => {
   });
 
   it("When I view interstitial page and the interviewer_note is set to true then I should be able to see interviewer note", () => {
-    expect($(InitialInterstitialPage.questionText()).getText()).to.contain("Interviewer Note");
+    expect($(InitialInterstitialPage.questionText()).getText()).to.contain("Interviewer note");
   });
   it("When I view question page and the interviewer_note is set to true then I should be able to see interviewer note", () => {
     $(InitialInterstitialPage.submit()).click();
-    expect($(FavouriteTeamPage.questionText()).getText()).to.contain("Interviewer Note");
+    expect($(FavouriteTeamPage.questionText()).getText()).to.contain("Interviewer note");
   });
   it("When I view question page and the interviewer_note is set to false then I should not be able to see interviewer note", () => {
     $(FavouriteTeamPage.favouriteTeam()).setValue("TNS");
     $(FavouriteTeamPage.submit()).click();
-    expect($(ConfirmPage.questionText()).getText()).to.not.contain("Interviewer Note");
+    expect($(ConfirmPage.questionText()).getText()).to.not.contain("Interviewer note");
   });
   it("When I view interstitial page and the interviewer_note is not set then I should not be able to see interviewer note", () => {
     $(ConfirmPage.yes()).click();
     $(ConfirmPage.submit()).click();
-    expect($(FinalInterstitialPage.questionText()).getText()).to.not.contain("Interviewer Note");
+    expect($(FinalInterstitialPage.questionText()).getText()).to.not.contain("Interviewer note");
   });
 });


### PR DESCRIPTION
### What is the context of this PR?
Adjusting the case on `Interviewer Note:` to be `Interviewer note:`

### How to review 
Check that interviewer notes are being displayed with `Interviewer note:`

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
