### PR TITLE
Spike using ListCollector actions

### DIFF
--- a/app/views/handlers/list_collector.py
+++ b/app/views/handlers/list_collector.py
@@ -7,6 +7,7 @@ from app.views.contexts import ListContext
 class ListCollector(Question):
     def __init__(self, *args):
         self._is_adding = False
+
         super().__init__(*args)
 
     def get_next_location_url(self):
@@ -41,14 +42,23 @@ class ListCollector(Question):
             ),
         }
 
+    def get_add_answer_option(self):
+        for answer_option in self.rendered_block["question"]["answers"][0]["options"]:
+            if (
+                answer_option.get("action", {}).get("type")
+                == "RedirectToListAddQuestion"
+            ):
+                return answer_option
+        return None
+
     def handle_post(self):
-        if (
-            self.form.data[self.rendered_block["add_answer"]["id"]]
-            == self.rendered_block["add_answer"]["value"]
-        ):
+        add_answer_option = self.get_add_answer_option()
+
+        answer_id = self.rendered_block["question"]["answers"][0]["id"]
+
+        if self.form.data[answer_id] == add_answer_option["value"]:
             self._is_adding = True
             self.questionnaire_store_updater.update_answers(self.form.data)
-
             self.questionnaire_store_updater.save()
         else:
             return super().handle_post()

--- a/app/views/handlers/list_collector.py
+++ b/app/views/handlers/list_collector.py
@@ -42,21 +42,11 @@ class ListCollector(Question):
             ),
         }
 
-    def get_add_answer_option(self):
-        for answer_option in self.rendered_block["question"]["answers"][0]["options"]:
-            if (
-                answer_option.get("action", {}).get("type")
-                == "RedirectToListAddQuestion"
-            ):
-                return answer_option
-        return None
-
     def handle_post(self):
-        add_answer_option = self.get_add_answer_option()
+        answer_action = self._get_answer_action()
+        action_type = answer_action['type'] if answer_action else None
 
-        answer_id = self.rendered_block["question"]["answers"][0]["id"]
-
-        if self.form.data[answer_id] == add_answer_option["value"]:
+        if action_type == "RedirectToListAddQuestion":
             self._is_adding = True
             self.questionnaire_store_updater.update_answers(self.form.data)
             self.questionnaire_store_updater.save()

--- a/app/views/handlers/list_collector.py
+++ b/app/views/handlers/list_collector.py
@@ -44,7 +44,7 @@ class ListCollector(Question):
 
     def handle_post(self):
         answer_action = self._get_answer_action()
-        action_type = answer_action['type'] if answer_action else None
+        action_type = answer_action["type"] if answer_action else None
 
         if action_type == "RedirectToListAddQuestion":
             self._is_adding = True

--- a/app/views/handlers/list_remove_question.py
+++ b/app/views/handlers/list_remove_question.py
@@ -21,7 +21,7 @@ class ListRemoveQuestion(ListAction):
 
     def handle_post(self):
         answer_action = self._get_answer_action()
-        action_type = answer_action['type'] if answer_action else None
+        action_type = answer_action["type"] if answer_action else None
 
         if action_type == "RemoveAnswersForListItem":
             list_name = self.parent_block["for_list"]

--- a/app/views/handlers/list_remove_question.py
+++ b/app/views/handlers/list_remove_question.py
@@ -19,22 +19,11 @@ class ListRemoveQuestion(ListAction):
             return False
         return True
 
-    def get_remove_answer_option(self):
-        for answer_option in self.rendered_block["question"]["answers"][0]["options"]:
-            if (
-                answer_option.get("action", {}).get("type")
-                == "RemoveAnswersForListItem"
-            ):
-                return answer_option
-        return None
-
     def handle_post(self):
-        remove_answer_option = self.get_remove_answer_option()
-        remove_answer_id = self.parent_block["remove_block"]["question"]["answers"][0][
-            "id"
-        ]
+        answer_action = self._get_answer_action()
+        action_type = answer_action['type'] if answer_action else None
 
-        if self.form.data[remove_answer_id] == remove_answer_option["value"]:
+        if action_type == "RemoveAnswersForListItem":
             list_name = self.parent_block["for_list"]
             self.questionnaire_store_updater.remove_list_item_and_answers(
                 list_name, self._current_location.list_item_id

--- a/app/views/handlers/list_remove_question.py
+++ b/app/views/handlers/list_remove_question.py
@@ -19,11 +19,22 @@ class ListRemoveQuestion(ListAction):
             return False
         return True
 
+    def get_remove_answer_option(self):
+        for answer_option in self.rendered_block["question"]["answers"][0]["options"]:
+            if (
+                answer_option.get("action", {}).get("type")
+                == "RemoveAnswersForListItem"
+            ):
+                return answer_option
+        return None
+
     def handle_post(self):
-        if (
-            self.form.data[self.parent_block["remove_answer"]["id"]]
-            == self.parent_block["remove_answer"]["value"]
-        ):
+        remove_answer_option = self.get_remove_answer_option()
+        remove_answer_id = self.parent_block["remove_block"]["question"]["answers"][0][
+            "id"
+        ]
+
+        if self.form.data[remove_answer_id] == remove_answer_option["value"]:
             list_name = self.parent_block["for_list"]
             self.questionnaire_store_updater.remove_list_item_and_answers(
                 list_name, self._current_location.list_item_id

--- a/scripts/run_validator.sh
+++ b/scripts/run_validator.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-tag=latest
+tag=spike-using-listcollector-actions
 docker pull onsdigital/eq-questionnaire-validator:$tag
 docker run -d -p 5001:5000 "onsdigital/eq-questionnaire-validator:$tag"

--- a/test_schemas/en/test_answer_action_redirect_to_list_add_question_checkbox.json
+++ b/test_schemas/en/test_answer_action_redirect_to_list_add_question_checkbox.json
@@ -78,14 +78,6 @@
                             "id": "anyone-else-live-at",
                             "type": "ListCollector",
                             "for_list": "people",
-                            "add_answer": {
-                                "id": "anyone-else-live-at-answer",
-                                "value": "Yes"
-                            },
-                            "remove_answer": {
-                                "id": "remove-confirmation",
-                                "value": "Yes"
-                            },
                             "question": {
                                 "id": "confirmation-question",
                                 "type": "General",
@@ -98,7 +90,10 @@
                                         "options": [
                                             {
                                                 "label": "Yes",
-                                                "value": "Yes"
+                                                "value": "Yes",
+                                                "action": {
+                                                    "type": "RedirectToListAddQuestion"
+                                                }
                                             },
                                             {
                                                 "label": "No",
@@ -180,7 +175,10 @@
                                             "options": [
                                                 {
                                                     "label": "Yes",
-                                                    "value": "Yes"
+                                                    "value": "Yes",
+                                                    "action": {
+                                                        "type": "RemoveAnswersForListItem"
+                                                    }
                                                 },
                                                 {
                                                     "label": "No",

--- a/test_schemas/en/test_answer_action_redirect_to_list_add_question_radio.json
+++ b/test_schemas/en/test_answer_action_redirect_to_list_add_question_radio.json
@@ -78,14 +78,6 @@
                             "id": "anyone-else-live-at",
                             "type": "ListCollector",
                             "for_list": "people",
-                            "add_answer": {
-                                "id": "anyone-else-live-at-answer",
-                                "value": "Yes"
-                            },
-                            "remove_answer": {
-                                "id": "remove-confirmation",
-                                "value": "Yes"
-                            },
                             "question": {
                                 "id": "confirmation-question",
                                 "type": "General",
@@ -98,7 +90,10 @@
                                         "options": [
                                             {
                                                 "label": "Yes",
-                                                "value": "Yes"
+                                                "value": "Yes",
+                                                "action": {
+                                                    "type": "RedirectToListAddQuestion"
+                                                }
                                             },
                                             {
                                                 "label": "No",
@@ -180,7 +175,10 @@
                                             "options": [
                                                 {
                                                     "label": "Yes",
-                                                    "value": "Yes"
+                                                    "value": "Yes",
+                                                    "action": {
+                                                        "type": "RemoveAnswersForListItem"
+                                                    }
                                                 },
                                                 {
                                                     "label": "No",

--- a/test_schemas/en/test_confirmation_question_within_repeating_section.json
+++ b/test_schemas/en/test_confirmation_question_within_repeating_section.json
@@ -41,14 +41,6 @@
                             "id": "list-collector",
                             "type": "ListCollector",
                             "for_list": "people",
-                            "add_answer": {
-                                "id": "anyone-else",
-                                "value": "Yes"
-                            },
-                            "remove_answer": {
-                                "id": "remove-confirmation",
-                                "value": "Yes"
-                            },
                             "question": {
                                 "id": "confirmation-question",
                                 "type": "General",
@@ -61,7 +53,10 @@
                                         "options": [
                                             {
                                                 "label": "Yes",
-                                                "value": "Yes"
+                                                "value": "Yes",
+                                                "action": {
+                                                    "type": "RedirectToListAddQuestion"
+                                                }
                                             },
                                             {
                                                 "label": "No",
@@ -132,7 +127,10 @@
                                             "options": [
                                                 {
                                                     "label": "Yes",
-                                                    "value": "Yes"
+                                                    "value": "Yes",
+                                                    "action": {
+                                                        "type": "RemoveAnswersForListItem"
+                                                    }
                                                 },
                                                 {
                                                     "label": "No",

--- a/test_schemas/en/test_individual_response.json
+++ b/test_schemas/en/test_individual_response.json
@@ -130,14 +130,6 @@
                             "id": "list-collector",
                             "type": "ListCollector",
                             "for_list": "household",
-                            "add_answer": {
-                                "id": "anyone-else",
-                                "value": "Yes"
-                            },
-                            "remove_answer": {
-                                "id": "remove-confirmation",
-                                "value": "Yes"
-                            },
                             "question": {
                                 "id": "confirmation-question",
                                 "type": "General",
@@ -150,7 +142,10 @@
                                         "options": [
                                             {
                                                 "label": "Yes",
-                                                "value": "Yes"
+                                                "value": "Yes",
+                                                "action": {
+                                                    "type": "RedirectToListAddQuestion"
+                                                }
                                             },
                                             {
                                                 "label": "No",
@@ -221,7 +216,10 @@
                                             "options": [
                                                 {
                                                     "label": "Yes",
-                                                    "value": "Yes"
+                                                    "value": "Yes",
+                                                    "action": {
+                                                        "type": "RemoveAnswersForListItem"
+                                                    }
                                                 },
                                                 {
                                                     "label": "No",

--- a/test_schemas/en/test_last_viewed_question_guidance.json
+++ b/test_schemas/en/test_last_viewed_question_guidance.json
@@ -207,14 +207,6 @@
                             "id": "list-collector",
                             "type": "ListCollector",
                             "for_list": "people",
-                            "add_answer": {
-                                "id": "anyone-else",
-                                "value": "Yes"
-                            },
-                            "remove_answer": {
-                                "id": "remove-confirmation",
-                                "value": "Yes"
-                            },
                             "question": {
                                 "id": "confirmation-question",
                                 "type": "General",
@@ -227,7 +219,10 @@
                                         "options": [
                                             {
                                                 "label": "Yes",
-                                                "value": "Yes"
+                                                "value": "Yes",
+                                                "action": {
+                                                    "type": "RedirectToListAddQuestion"
+                                                }
                                             },
                                             {
                                                 "label": "No",
@@ -316,7 +311,10 @@
                                             "options": [
                                                 {
                                                     "label": "Yes",
-                                                    "value": "Yes"
+                                                    "value": "Yes",
+                                                    "action": {
+                                                        "type": "RemoveAnswersForListItem"
+                                                    }
                                                 },
                                                 {
                                                     "label": "No",

--- a/test_schemas/en/test_list_change_evaluates_sections.json
+++ b/test_schemas/en/test_list_change_evaluates_sections.json
@@ -91,14 +91,6 @@
                             "id": "list-collector",
                             "type": "ListCollector",
                             "for_list": "people",
-                            "add_answer": {
-                                "id": "anyone-else",
-                                "value": "Yes"
-                            },
-                            "remove_answer": {
-                                "id": "remove-confirmation",
-                                "value": "Yes"
-                            },
                             "question": {
                                 "id": "confirmation-question",
                                 "type": "General",
@@ -111,7 +103,10 @@
                                         "options": [
                                             {
                                                 "label": "Yes",
-                                                "value": "Yes"
+                                                "value": "Yes",
+                                                "action": {
+                                                    "type": "RedirectToListAddQuestion"
+                                                }
                                             },
                                             {
                                                 "label": "No",
@@ -182,7 +177,10 @@
                                             "options": [
                                                 {
                                                     "label": "Yes",
-                                                    "value": "Yes"
+                                                    "value": "Yes",
+                                                    "action": {
+                                                        "type": "RemoveAnswersForListItem"
+                                                    }
                                                 },
                                                 {
                                                     "label": "No",

--- a/test_schemas/en/test_list_collector.json
+++ b/test_schemas/en/test_list_collector.json
@@ -46,14 +46,6 @@
                             "id": "list-collector",
                             "type": "ListCollector",
                             "for_list": "people",
-                            "add_answer": {
-                                "id": "anyone-else",
-                                "value": "Yes"
-                            },
-                            "remove_answer": {
-                                "id": "remove-confirmation",
-                                "value": "Yes"
-                            },
                             "question": {
                                 "id": "confirmation-question",
                                 "type": "General",
@@ -66,7 +58,10 @@
                                         "options": [
                                             {
                                                 "label": "Yes",
-                                                "value": "Yes"
+                                                "value": "Yes",
+                                                "action": {
+                                                    "type": "RedirectToListAddQuestion"
+                                                }
                                             },
                                             {
                                                 "label": "No",
@@ -141,7 +136,10 @@
                                             "options": [
                                                 {
                                                     "label": "Yes",
-                                                    "value": "Yes"
+                                                    "value": "Yes",
+                                                    "action": {
+                                                        "type": "RemoveAnswersForListItem"
+                                                    }
                                                 },
                                                 {
                                                     "label": "No",
@@ -198,14 +196,6 @@
                             "id": "another-list-collector-block",
                             "type": "ListCollector",
                             "for_list": "people",
-                            "add_answer": {
-                                "id": "another-anyone-else",
-                                "value": "Yes"
-                            },
-                            "remove_answer": {
-                                "id": "another-remove-confirmation",
-                                "value": "Yes"
-                            },
                             "question": {
                                 "id": "another-confirmation-question",
                                 "type": "General",
@@ -218,7 +208,10 @@
                                         "options": [
                                             {
                                                 "label": "Yes",
-                                                "value": "Yes"
+                                                "value": "Yes",
+                                                "action": {
+                                                    "type": "RedirectToListAddQuestion"
+                                                }
                                             },
                                             {
                                                 "label": "No",
@@ -289,7 +282,10 @@
                                             "options": [
                                                 {
                                                     "label": "Yes",
-                                                    "value": "Yes"
+                                                    "value": "Yes",
+                                                    "action": {
+                                                        "type": "RemoveAnswersForListItem"
+                                                    }
                                                 },
                                                 {
                                                     "label": "No",

--- a/test_schemas/en/test_list_collector_driving_checkbox.json
+++ b/test_schemas/en/test_list_collector_driving_checkbox.json
@@ -257,14 +257,6 @@
                             "id": "list-collector",
                             "type": "ListCollector",
                             "for_list": "people",
-                            "add_answer": {
-                                "id": "anyone-else",
-                                "value": "Yes, I need to add a person"
-                            },
-                            "remove_answer": {
-                                "id": "remove-confirmation",
-                                "value": "Yes"
-                            },
                             "question": {
                                 "id": "confirmation-question",
                                 "type": "General",
@@ -277,7 +269,10 @@
                                         "options": [
                                             {
                                                 "label": "Yes, I need to add a person",
-                                                "value": "Yes, I need to add a person"
+                                                "value": "Yes, I need to add a person",
+                                                "action": {
+                                                    "type": "RedirectToListAddQuestion"
+                                                }
                                             },
                                             {
                                                 "label": "No, I do not need to add a person",
@@ -405,7 +400,10 @@
                                             "options": [
                                                 {
                                                     "label": "Yes",
-                                                    "value": "Yes"
+                                                    "value": "Yes",
+                                                    "action": {
+                                                        "type": "RemoveAnswersForListItem"
+                                                    }
                                                 },
                                                 {
                                                     "label": "No",
@@ -444,14 +442,6 @@
                             "id": "list-collector-temporary-away-stay",
                             "type": "ListCollector",
                             "for_list": "people",
-                            "add_answer": {
-                                "id": "anyone-else-temporary-away-stay",
-                                "value": "Yes, I need to add someone"
-                            },
-                            "remove_answer": {
-                                "id": "remove-confirmation-temporary-away-stay",
-                                "value": "Yes"
-                            },
                             "question": {
                                 "id": "confirmation-question-temporary-away-stay",
                                 "type": "General",
@@ -484,7 +474,10 @@
                                         "options": [
                                             {
                                                 "label": "Yes, I need to add someone",
-                                                "value": "Yes, I need to add someone"
+                                                "value": "Yes, I need to add someone",
+                                                "action": {
+                                                    "type": "RedirectToListAddQuestion"
+                                                }
                                             },
                                             {
                                                 "label": {
@@ -632,7 +625,10 @@
                                             "options": [
                                                 {
                                                     "label": "Yes",
-                                                    "value": "Yes"
+                                                    "value": "Yes",
+                                                    "action": {
+                                                        "type": "RemoveAnswersForListItem"
+                                                    }
                                                 },
                                                 {
                                                     "label": "No",

--- a/test_schemas/en/test_list_collector_driving_question.json
+++ b/test_schemas/en/test_list_collector_driving_question.json
@@ -114,14 +114,6 @@
                             "id": "anyone-else-live-at",
                             "type": "ListCollector",
                             "for_list": "people",
-                            "add_answer": {
-                                "id": "anyone-else-live-at-answer",
-                                "value": "Yes"
-                            },
-                            "remove_answer": {
-                                "id": "remove-confirmation",
-                                "value": "Yes"
-                            },
                             "question": {
                                 "id": "confirmation-question",
                                 "type": "General",
@@ -134,7 +126,10 @@
                                         "options": [
                                             {
                                                 "label": "Yes",
-                                                "value": "Yes"
+                                                "value": "Yes",
+                                                "action": {
+                                                    "type": "RedirectToListAddQuestion"
+                                                }
                                             },
                                             {
                                                 "label": "No",
@@ -205,7 +200,10 @@
                                             "options": [
                                                 {
                                                     "label": "Yes",
-                                                    "value": "Yes"
+                                                    "value": "Yes",
+                                                    "action": {
+                                                        "type": "RemoveAnswersForListItem"
+                                                    }
                                                 },
                                                 {
                                                     "label": "No",

--- a/test_schemas/en/test_list_collector_primary_person.json
+++ b/test_schemas/en/test_list_collector_primary_person.json
@@ -169,14 +169,6 @@
                             "id": "list-collector",
                             "type": "ListCollector",
                             "for_list": "people",
-                            "add_answer": {
-                                "id": "anyone-else",
-                                "value": "Yes"
-                            },
-                            "remove_answer": {
-                                "id": "remove-confirmation",
-                                "value": "Yes"
-                            },
                             "question": {
                                 "id": "confirmation-question",
                                 "type": "General",
@@ -189,7 +181,10 @@
                                         "options": [
                                             {
                                                 "label": "Yes",
-                                                "value": "Yes"
+                                                "value": "Yes",
+                                                "action": {
+                                                    "type": "RedirectToListAddQuestion"
+                                                }
                                             },
                                             {
                                                 "label": "No",
@@ -278,7 +273,10 @@
                                             "options": [
                                                 {
                                                     "label": "Yes",
-                                                    "value": "Yes"
+                                                    "value": "Yes",
+                                                    "action": {
+                                                        "type": "RemoveAnswersForListItem"
+                                                    }
                                                 },
                                                 {
                                                     "label": "No",

--- a/test_schemas/en/test_list_collector_section_summary.json
+++ b/test_schemas/en/test_list_collector_section_summary.json
@@ -172,14 +172,6 @@
                             "id": "list-collector",
                             "type": "ListCollector",
                             "for_list": "people",
-                            "add_answer": {
-                                "id": "anyone-else",
-                                "value": "Yes"
-                            },
-                            "remove_answer": {
-                                "id": "remove-confirmation",
-                                "value": "Yes"
-                            },
                             "question": {
                                 "id": "confirmation-question",
                                 "type": "General",
@@ -203,7 +195,10 @@
                                         "options": [
                                             {
                                                 "label": "Yes",
-                                                "value": "Yes"
+                                                "value": "Yes",
+                                                "action": {
+                                                    "type": "RedirectToListAddQuestion"
+                                                }
                                             },
                                             {
                                                 "label": "No",
@@ -274,7 +269,10 @@
                                             "options": [
                                                 {
                                                     "label": "Yes",
-                                                    "value": "Yes"
+                                                    "value": "Yes",
+                                                    "action": {
+                                                        "type": "RemoveAnswersForListItem"
+                                                    }
                                                 },
                                                 {
                                                     "label": "No",
@@ -338,14 +336,6 @@
                             "id": "visitor-list-collector",
                             "type": "ListCollector",
                             "for_list": "visitors",
-                            "add_answer": {
-                                "id": "any-more-visitors",
-                                "value": "Yes"
-                            },
-                            "remove_answer": {
-                                "id": "remove-visitor-confirmation",
-                                "value": "Yes"
-                            },
                             "question": {
                                 "id": "confirmation-visitor-question",
                                 "type": "General",
@@ -369,7 +359,10 @@
                                         "options": [
                                             {
                                                 "label": "Yes",
-                                                "value": "Yes"
+                                                "value": "Yes",
+                                                "action": {
+                                                    "type": "RedirectToListAddQuestion"
+                                                }
                                             },
                                             {
                                                 "label": "No",
@@ -440,7 +433,10 @@
                                             "options": [
                                                 {
                                                     "label": "Yes",
-                                                    "value": "Yes"
+                                                    "value": "Yes",
+                                                    "action": {
+                                                        "type": "RemoveAnswersForListItem"
+                                                    }
                                                 },
                                                 {
                                                     "label": "No",

--- a/test_schemas/en/test_list_collector_variants.json
+++ b/test_schemas/en/test_list_collector_variants.json
@@ -59,14 +59,6 @@
                             "id": "list-collector",
                             "type": "ListCollector",
                             "for_list": "people",
-                            "add_answer": {
-                                "id": "anyone-else",
-                                "value": "Yes"
-                            },
-                            "remove_answer": {
-                                "id": "remove-confirmation",
-                                "value": "Yes"
-                            },
                             "question_variants": [
                                 {
                                     "question": {
@@ -81,7 +73,10 @@
                                                 "options": [
                                                     {
                                                         "label": "Yes",
-                                                        "value": "Yes"
+                                                        "value": "Yes",
+                                                        "action": {
+                                                            "type": "RedirectToListAddQuestion"
+                                                        }
                                                     },
                                                     {
                                                         "label": "No",
@@ -112,7 +107,10 @@
                                                 "options": [
                                                     {
                                                         "label": "Yes",
-                                                        "value": "Yes"
+                                                        "value": "Yes",
+                                                        "action": {
+                                                            "type": "RedirectToListAddQuestion"
+                                                        }
                                                     },
                                                     {
                                                         "label": "No",
@@ -272,7 +270,10 @@
                                                     "options": [
                                                         {
                                                             "label": "Yes",
-                                                            "value": "Yes"
+                                                            "value": "Yes",
+                                                            "action": {
+                                                                "type": "RemoveAnswersForListItem"
+                                                            }
                                                         },
                                                         {
                                                             "label": "No",
@@ -303,7 +304,10 @@
                                                     "options": [
                                                         {
                                                             "label": "Yes",
-                                                            "value": "Yes"
+                                                            "value": "Yes",
+                                                            "action": {
+                                                                "type": "RemoveAnswersForListItem"
+                                                            }
                                                         },
                                                         {
                                                             "label": "No",

--- a/test_schemas/en/test_list_collector_variants_primary_person.json
+++ b/test_schemas/en/test_list_collector_variants_primary_person.json
@@ -194,14 +194,6 @@
                             "id": "list-collector",
                             "type": "ListCollector",
                             "for_list": "people",
-                            "add_answer": {
-                                "id": "anyone-else",
-                                "value": "Yes"
-                            },
-                            "remove_answer": {
-                                "id": "remove-confirmation",
-                                "value": "Yes"
-                            },
                             "question": {
                                 "id": "confirmation-question",
                                 "type": "General",
@@ -214,7 +206,10 @@
                                         "options": [
                                             {
                                                 "label": "Yes",
-                                                "value": "Yes"
+                                                "value": "Yes",
+                                                "action": {
+                                                    "type": "RedirectToListAddQuestion"
+                                                }
                                             },
                                             {
                                                 "label": "No",
@@ -303,7 +298,10 @@
                                             "options": [
                                                 {
                                                     "label": "Yes",
-                                                    "value": "Yes"
+                                                    "value": "Yes",
+                                                    "action": {
+                                                        "type": "RemoveAnswersForListItem"
+                                                    }
                                                 },
                                                 {
                                                     "label": "No",

--- a/test_schemas/en/test_list_summary_on_question.json
+++ b/test_schemas/en/test_list_summary_on_question.json
@@ -46,14 +46,6 @@
                             "id": "list-collector",
                             "type": "ListCollector",
                             "for_list": "people",
-                            "add_answer": {
-                                "id": "anyone-else",
-                                "value": "Yes"
-                            },
-                            "remove_answer": {
-                                "id": "remove-confirmation",
-                                "value": "Yes"
-                            },
                             "question": {
                                 "id": "confirmation-question",
                                 "type": "General",
@@ -66,7 +58,10 @@
                                         "options": [
                                             {
                                                 "label": "Yes",
-                                                "value": "Yes"
+                                                "value": "Yes",
+                                                "action": {
+                                                    "type": "RedirectToListAddQuestion"
+                                                }
                                             },
                                             {
                                                 "label": "No",
@@ -137,7 +132,10 @@
                                             "options": [
                                                 {
                                                     "label": "Yes",
-                                                    "value": "Yes"
+                                                    "value": "Yes",
+                                                    "action": {
+                                                        "type": "RemoveAnswersForListItem"
+                                                    }
                                                 },
                                                 {
                                                     "label": "No",
@@ -194,14 +192,6 @@
                             "id": "another-list-collector-block",
                             "type": "ListCollector",
                             "for_list": "people",
-                            "add_answer": {
-                                "id": "another-anyone-else",
-                                "value": "Yes"
-                            },
-                            "remove_answer": {
-                                "id": "another-remove-confirmation",
-                                "value": "Yes"
-                            },
                             "question": {
                                 "id": "another-confirmation-question",
                                 "type": "General",
@@ -214,7 +204,10 @@
                                         "options": [
                                             {
                                                 "label": "Yes",
-                                                "value": "Yes"
+                                                "value": "Yes",
+                                                "action": {
+                                                    "type": "RedirectToListAddQuestion"
+                                                }
                                             },
                                             {
                                                 "label": "No",
@@ -285,7 +278,10 @@
                                             "options": [
                                                 {
                                                     "label": "Yes",
-                                                    "value": "Yes"
+                                                    "value": "Yes",
+                                                    "action": {
+                                                        "type": "RemoveAnswersForListItem"
+                                                    }
                                                 },
                                                 {
                                                     "label": "No",

--- a/test_schemas/en/test_placeholder_based_on_first_item_in_list.json
+++ b/test_schemas/en/test_placeholder_based_on_first_item_in_list.json
@@ -37,14 +37,6 @@
                             "id": "list-collector",
                             "type": "ListCollector",
                             "for_list": "people",
-                            "add_answer": {
-                                "id": "anyone-else",
-                                "value": "Yes"
-                            },
-                            "remove_answer": {
-                                "id": "remove-confirmation",
-                                "value": "Yes"
-                            },
                             "question": {
                                 "id": "confirmation-question",
                                 "type": "General",
@@ -57,7 +49,10 @@
                                         "options": [
                                             {
                                                 "label": "Yes",
-                                                "value": "Yes"
+                                                "value": "Yes",
+                                                "action": {
+                                                    "type": "RedirectToListAddQuestion"
+                                                }
                                             },
                                             {
                                                 "label": "No",
@@ -128,7 +123,10 @@
                                             "options": [
                                                 {
                                                     "label": "Yes",
-                                                    "value": "Yes"
+                                                    "value": "Yes",
+                                                    "action": {
+                                                        "type": "RemoveAnswersForListItem"
+                                                    }
                                                 },
                                                 {
                                                     "label": "No",

--- a/test_schemas/en/test_relationships.json
+++ b/test_schemas/en/test_relationships.json
@@ -46,14 +46,6 @@
                             "id": "list-collector",
                             "type": "ListCollector",
                             "for_list": "people",
-                            "add_answer": {
-                                "id": "anyone-else",
-                                "value": "Yes"
-                            },
-                            "remove_answer": {
-                                "id": "remove-confirmation",
-                                "value": "Yes"
-                            },
                             "question": {
                                 "id": "confirmation-question",
                                 "type": "General",
@@ -66,7 +58,10 @@
                                         "options": [
                                             {
                                                 "label": "Yes",
-                                                "value": "Yes"
+                                                "value": "Yes",
+                                                "action": {
+                                                    "type": "RedirectToListAddQuestion"
+                                                }
                                             },
                                             {
                                                 "label": "No",
@@ -137,7 +132,10 @@
                                             "options": [
                                                 {
                                                     "label": "Yes",
-                                                    "value": "Yes"
+                                                    "value": "Yes",
+                                                    "action": {
+                                                        "type": "RemoveAnswersForListItem"
+                                                    }
                                                 },
                                                 {
                                                     "label": "No",

--- a/test_schemas/en/test_relationships_primary.json
+++ b/test_schemas/en/test_relationships_primary.json
@@ -87,14 +87,6 @@
                             "id": "list-collector",
                             "type": "ListCollector",
                             "for_list": "people",
-                            "add_answer": {
-                                "id": "anyone-else",
-                                "value": "Yes"
-                            },
-                            "remove_answer": {
-                                "id": "remove-confirmation",
-                                "value": "Yes"
-                            },
                             "question": {
                                 "id": "confirmation-question",
                                 "type": "General",
@@ -107,7 +99,10 @@
                                         "options": [
                                             {
                                                 "label": "Yes",
-                                                "value": "Yes"
+                                                "value": "Yes",
+                                                "action": {
+                                                    "type": "RedirectToListAddQuestion"
+                                                }
                                             },
                                             {
                                                 "label": "No",
@@ -196,7 +191,10 @@
                                             "options": [
                                                 {
                                                     "label": "Yes",
-                                                    "value": "Yes"
+                                                    "value": "Yes",
+                                                    "action": {
+                                                        "type": "RemoveAnswersForListItem"
+                                                    }
                                                 },
                                                 {
                                                     "label": "No",

--- a/test_schemas/en/test_repeating_section_summaries.json
+++ b/test_schemas/en/test_repeating_section_summaries.json
@@ -91,14 +91,6 @@
                             "id": "list-collector",
                             "type": "ListCollector",
                             "for_list": "people",
-                            "add_answer": {
-                                "id": "anyone-else",
-                                "value": "Yes"
-                            },
-                            "remove_answer": {
-                                "id": "remove-confirmation",
-                                "value": "Yes"
-                            },
                             "question": {
                                 "id": "confirmation-question",
                                 "type": "General",
@@ -111,7 +103,10 @@
                                         "options": [
                                             {
                                                 "label": "Yes",
-                                                "value": "Yes"
+                                                "value": "Yes",
+                                                "action": {
+                                                    "type": "RedirectToListAddQuestion"
+                                                }
                                             },
                                             {
                                                 "label": "No",
@@ -182,7 +177,10 @@
                                             "options": [
                                                 {
                                                     "label": "Yes",
-                                                    "value": "Yes"
+                                                    "value": "Yes",
+                                                    "action": {
+                                                        "type": "RemoveAnswersForListItem"
+                                                    }
                                                 },
                                                 {
                                                     "label": "No",

--- a/test_schemas/en/test_repeating_sections_with_hub_and_spoke.json
+++ b/test_schemas/en/test_repeating_sections_with_hub_and_spoke.json
@@ -91,14 +91,6 @@
                             "id": "list-collector",
                             "type": "ListCollector",
                             "for_list": "people",
-                            "add_answer": {
-                                "id": "anyone-else",
-                                "value": "Yes"
-                            },
-                            "remove_answer": {
-                                "id": "remove-confirmation",
-                                "value": "Yes"
-                            },
                             "question": {
                                 "id": "confirmation-question",
                                 "type": "General",
@@ -111,7 +103,10 @@
                                         "options": [
                                             {
                                                 "label": "Yes",
-                                                "value": "Yes"
+                                                "value": "Yes",
+                                                "action": {
+                                                    "type": "RedirectToListAddQuestion"
+                                                }
                                             },
                                             {
                                                 "label": "No",
@@ -182,7 +177,10 @@
                                             "options": [
                                                 {
                                                     "label": "Yes",
-                                                    "value": "Yes"
+                                                    "value": "Yes",
+                                                    "action": {
+                                                        "type": "RemoveAnswersForListItem"
+                                                    }
                                                 },
                                                 {
                                                     "label": "No",
@@ -239,14 +237,6 @@
                             "id": "another-list-collector-block",
                             "type": "ListCollector",
                             "for_list": "people",
-                            "add_answer": {
-                                "id": "another-anyone-else",
-                                "value": "Yes"
-                            },
-                            "remove_answer": {
-                                "id": "another-remove-confirmation",
-                                "value": "Yes"
-                            },
                             "question": {
                                 "id": "another-confirmation-question",
                                 "type": "General",
@@ -259,7 +249,10 @@
                                         "options": [
                                             {
                                                 "label": "Yes",
-                                                "value": "Yes"
+                                                "value": "Yes",
+                                                "action": {
+                                                    "type": "RedirectToListAddQuestion"
+                                                }
                                             },
                                             {
                                                 "label": "No",
@@ -330,7 +323,10 @@
                                             "options": [
                                                 {
                                                     "label": "Yes",
-                                                    "value": "Yes"
+                                                    "value": "Yes",
+                                                    "action": {
+                                                        "type": "RemoveAnswersForListItem"
+                                                    }
                                                 },
                                                 {
                                                     "label": "No",
@@ -375,14 +371,6 @@
                             "id": "visitors-block",
                             "type": "ListCollector",
                             "for_list": "visitor",
-                            "add_answer": {
-                                "id": "visitors-anyone-else",
-                                "value": "Yes"
-                            },
-                            "remove_answer": {
-                                "id": "visitors-remove-confirmation",
-                                "value": "Yes"
-                            },
                             "question": {
                                 "id": "visitors-confirmation-question",
                                 "type": "General",
@@ -395,7 +383,10 @@
                                         "options": [
                                             {
                                                 "label": "Yes",
-                                                "value": "Yes"
+                                                "value": "Yes",
+                                                "action": {
+                                                    "type": "RedirectToListAddQuestion"
+                                                }
                                             },
                                             {
                                                 "label": "No",
@@ -466,7 +457,10 @@
                                             "options": [
                                                 {
                                                     "label": "Yes",
-                                                    "value": "Yes"
+                                                    "value": "Yes",
+                                                    "action": {
+                                                        "type": "RemoveAnswersForListItem"
+                                                    }
                                                 },
                                                 {
                                                     "label": "No",

--- a/test_schemas/en/test_skip_condition_list.json
+++ b/test_schemas/en/test_skip_condition_list.json
@@ -45,14 +45,6 @@
                             "id": "list-collector",
                             "type": "ListCollector",
                             "for_list": "people",
-                            "add_answer": {
-                                "id": "anyone-else",
-                                "value": "Yes"
-                            },
-                            "remove_answer": {
-                                "id": "remove-confirmation",
-                                "value": "Yes"
-                            },
                             "question": {
                                 "id": "confirmation-question",
                                 "type": "General",
@@ -65,7 +57,10 @@
                                         "options": [
                                             {
                                                 "label": "Yes",
-                                                "value": "Yes"
+                                                "value": "Yes",
+                                                "action": {
+                                                    "type": "RedirectToListAddQuestion"
+                                                }
                                             },
                                             {
                                                 "label": "No",
@@ -136,7 +131,10 @@
                                             "options": [
                                                 {
                                                     "label": "Yes",
-                                                    "value": "Yes"
+                                                    "value": "Yes",
+                                                    "action": {
+                                                        "type": "RemoveAnswersForListItem"
+                                                    }
                                                 },
                                                 {
                                                     "label": "No",

--- a/test_schemas/en/test_variants_first_item_in_list.json
+++ b/test_schemas/en/test_variants_first_item_in_list.json
@@ -37,14 +37,6 @@
                             "id": "list-collector",
                             "type": "ListCollector",
                             "for_list": "people",
-                            "add_answer": {
-                                "id": "anyone-else",
-                                "value": "Yes"
-                            },
-                            "remove_answer": {
-                                "id": "remove-confirmation",
-                                "value": "Yes"
-                            },
                             "question": {
                                 "id": "confirmation-question",
                                 "type": "General",
@@ -57,7 +49,10 @@
                                         "options": [
                                             {
                                                 "label": "Yes",
-                                                "value": "Yes"
+                                                "value": "Yes",
+                                                "action": {
+                                                    "type": "RedirectToListAddQuestion"
+                                                }
                                             },
                                             {
                                                 "label": "No",
@@ -128,7 +123,10 @@
                                             "options": [
                                                 {
                                                     "label": "Yes",
-                                                    "value": "Yes"
+                                                    "value": "Yes",
+                                                    "action": {
+                                                        "type": "RemoveAnswersForListItem"
+                                                    }
                                                 },
                                                 {
                                                     "label": "No",


### PR DESCRIPTION
### What is the context of this PR?

Removes the use of add_answer and remove_answer from list collectors and migrates them to instead use actions. Adds a "RemoveAnswersForListItem" action to support new answer removal action.

Migrating schemas is fairly simple - just adding the appropriate action to the block/answer option in question. Test schemas have been migrated as part of this PR, census schemas are likely to be easier due to duplication simplified by use of jsonnet. I had started working on a script to do this, but it was simpler in the end to migrate manually.

Most of the work here is likely in updating validator to migrate to these new actions and updating the logic in the list collector validator. Update - Added a quick validator branch https://github.com/ONSdigital/eq-questionnaire-validator/pull/53

### How to review 

Check approach, see if you agree with implementation. 
