### PR TITLE
Use question title in error message

### DIFF
--- a/app/forms/error_messages.py
+++ b/app/forms/error_messages.py
@@ -8,9 +8,11 @@ error_messages = {
     "MANDATORY_TEXTFIELD": lazy_gettext("Enter an answer to continue"),
     "MANDATORY_NUMBER": lazy_gettext("Enter an answer to continue"),
     "MANDATORY_TEXTAREA": lazy_gettext("Enter an answer to continue"),
-    "MANDATORY_RADIO": lazy_gettext("Select an answer to continue"),
+    "MANDATORY_RADIO": lazy_gettext("Select an answer to ‘%(question_title)s’"),
     "MANDATORY_DROPDOWN": lazy_gettext("Select an answer to continue"),
-    "MANDATORY_CHECKBOX": lazy_gettext("Select all that apply to continue"),
+    "MANDATORY_CHECKBOX": lazy_gettext(
+        "Select at least one answer to ‘%(question_title)s’"
+    ),
     "MANDATORY_DATE": lazy_gettext("Enter a date to continue"),
     "MANDATORY_DURATION": lazy_gettext("Enter a duration to continue"),
     "NUMBER_TOO_SMALL": lazy_gettext("Enter an answer more than or equal to %(min)s"),

--- a/app/translations/messages.pot
+++ b/app/translations/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-08-13 21:29+0100\n"
+"POT-Creation-Date: 2020-08-18 09:12+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -46,118 +46,124 @@ msgstr ""
 msgid "Enter an answer to continue"
 msgstr ""
 
-#: app/forms/error_messages.py:11 app/forms/error_messages.py:12
+#: app/forms/error_messages.py:11
+#, python-format
+msgid "Select an answer to ‘%(question_title)s’"
+msgstr ""
+
+#: app/forms/error_messages.py:12
 msgid "Select an answer to continue"
 msgstr ""
 
 #: app/forms/error_messages.py:13
-msgid "Select all that apply to continue"
-msgstr ""
-
-#: app/forms/error_messages.py:14
-msgid "Enter a date to continue"
-msgstr ""
-
-#: app/forms/error_messages.py:15
-msgid "Enter a duration to continue"
+#, python-format
+msgid "Select at least one answer to ‘%(question_title)s’"
 msgstr ""
 
 #: app/forms/error_messages.py:16
-#, python-format
-msgid "Enter an answer more than or equal to %(min)s"
+msgid "Enter a date to continue"
 msgstr ""
 
 #: app/forms/error_messages.py:17
-#, python-format
-msgid "Enter an answer less than or equal to %(max)s"
+msgid "Enter a duration to continue"
 msgstr ""
 
 #: app/forms/error_messages.py:18
 #, python-format
-msgid "Enter an answer more than %(min)s"
+msgid "Enter an answer more than or equal to %(min)s"
 msgstr ""
 
 #: app/forms/error_messages.py:19
 #, python-format
-msgid "Enter an answer less than %(max)s"
+msgid "Enter an answer less than or equal to %(max)s"
 msgstr ""
 
 #: app/forms/error_messages.py:20
 #, python-format
-msgid "Enter answers that add up to %(total)s"
+msgid "Enter an answer more than %(min)s"
 msgstr ""
 
 #: app/forms/error_messages.py:21
 #, python-format
+msgid "Enter an answer less than %(max)s"
+msgstr ""
+
+#: app/forms/error_messages.py:22
+#, python-format
+msgid "Enter answers that add up to %(total)s"
+msgstr ""
+
+#: app/forms/error_messages.py:23
+#, python-format
 msgid "Enter answers that add up to or are less than %(total)s"
 msgstr ""
 
-#: app/forms/error_messages.py:24
+#: app/forms/error_messages.py:26
 #, python-format
 msgid "Enter answers that add up to less than %(total)s"
 msgstr ""
 
-#: app/forms/error_messages.py:27
+#: app/forms/error_messages.py:29
 #, python-format
 msgid "Enter answers that add up to greater than %(total)s"
 msgstr ""
 
-#: app/forms/error_messages.py:30
+#: app/forms/error_messages.py:32
 #, python-format
 msgid "Enter answers that add up to or are greater than %(total)s"
 msgstr ""
 
-#: app/forms/error_messages.py:33
+#: app/forms/error_messages.py:35
 msgid "Enter a number"
 msgstr ""
 
-#: app/forms/error_messages.py:34
+#: app/forms/error_messages.py:36
 msgid "Enter a whole number"
 msgstr ""
 
-#: app/forms/error_messages.py:35
+#: app/forms/error_messages.py:37
 #, python-format
 msgid "Enter a number rounded to %(max)d decimal places"
 msgstr ""
 
-#: app/forms/error_messages.py:36
+#: app/forms/error_messages.py:38
 #, python-format
 msgid "You have entered too many characters. Enter up to %(max)d characters"
 msgstr ""
 
-#: app/forms/error_messages.py:39
+#: app/forms/error_messages.py:41
 msgid "Enter a valid date"
 msgstr ""
 
-#: app/forms/error_messages.py:40
+#: app/forms/error_messages.py:42
 msgid "Enter a 'period to' date later than the 'period from' date"
 msgstr ""
 
-#: app/forms/error_messages.py:43
+#: app/forms/error_messages.py:45
 msgid "Enter a valid duration"
 msgstr ""
 
-#: app/forms/error_messages.py:44
+#: app/forms/error_messages.py:46
 #, python-format
 msgid "Enter a reporting period greater than or equal to %(min)s"
 msgstr ""
 
-#: app/forms/error_messages.py:47
+#: app/forms/error_messages.py:49
 #, python-format
 msgid "Enter a reporting period less than or equal to %(max)s"
 msgstr ""
 
-#: app/forms/error_messages.py:50
+#: app/forms/error_messages.py:52
 #, python-format
 msgid "Enter a date after %(min)s"
 msgstr ""
 
-#: app/forms/error_messages.py:51
+#: app/forms/error_messages.py:53
 #, python-format
 msgid "Enter a date before %(max)s"
 msgstr ""
 
-#: app/forms/error_messages.py:52
+#: app/forms/error_messages.py:54
 msgid "Remove an answer to continue"
 msgstr ""
 

--- a/test_schemas/en/test_question_title_in_error.json
+++ b/test_schemas/en/test_question_title_in_error.json
@@ -70,12 +70,7 @@
                                                 }
                                             }
                                         ],
-                                        "type": "Checkbox",
-                                        "validation": {
-                                            "messages": {
-                                                "MANDATORY_CHECKBOX": "Select an answer to ‘%(question_title)s’ to continue"
-                                            }
-                                        }
+                                        "type": "Checkbox"
                                     }
                                 ],
                                 "id": "mandatory-checkbox-question",

--- a/tests/functional/spec/checkbox.spec.js
+++ b/tests/functional/spec/checkbox.spec.js
@@ -39,6 +39,13 @@ describe('Checkbox with "other" option', () => {
     expect($(MandatoryCheckboxPage.error()).isDisplayed()).to.be.true;
   });
 
+  it("Given a mandatory checkbox answer, When I leave the input field empty and submit, Then an error containing the question text should be displayed.", () => {
+    // When
+    $(MandatoryCheckboxPage.submit()).click();
+    // Then
+    expect($(MandatoryCheckboxPage.error()).getText()).to.contain("Select at least one answer to ‘Which pizza toppings would you like?’");
+  });
+
   it("Given a mandatory checkbox answer, when there is an error on the page for other field and I enter valid value and submit page, then the error is cleared and I navigate to next page.s", () => {
     $(MandatoryCheckboxPage.other()).click();
     $(MandatoryCheckboxPage.submit()).click();

--- a/tests/functional/spec/components/radio/radio.js
+++ b/tests/functional/spec/components/radio/radio.js
@@ -30,6 +30,17 @@ describe("Component: Radio", () => {
     });
   });
 
+  describe("Given I start a Mandatory Radio survey  ", () => {
+    before(() => {
+      browser.openQuestionnaire("test_radio_mandatory.json");
+    });
+
+    it("When I have submitted the page without any option, Then the question text is displayed in the error message", () => {
+      $(RadioMandatoryOverriddenPage.submit()).click();
+      expect($(RadioMandatoryOverriddenPage.errorNumber(1)).getText()).to.contain("Select an answer to ‘What do you prefer for breakfast?’");
+    });
+  });
+
   describe("Given I start a Mandatory Radio Other survey", () => {
     before(() => {
       browser.openQuestionnaire("test_radio_mandatory_with_mandatory_other.json");


### PR DESCRIPTION
### What is the context of this PR?
By default question titles should be in error messages for checkbox and radio questions

### How to review 
Check that error messages for checbox and radio questions contain the question title and that other features aren't impacted.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
