### PR TITLE
Extend schemas to resolve suggestions url language

### DIFF
--- a/app/questionnaire/placeholder_transforms.py
+++ b/app/questionnaire/placeholder_transforms.py
@@ -185,6 +185,4 @@ class PlaceholderTransforms:
         return ""
 
     def format_suggestions_url(self, url, list_json):
-        if self.language == "en":
-            return url + list_json
-        return ""
+        return "{}{}".format(url, list_json) if self.language is "en" else ""

--- a/app/questionnaire/placeholder_transforms.py
+++ b/app/questionnaire/placeholder_transforms.py
@@ -183,3 +183,8 @@ class PlaceholderTransforms:
             return item
 
         return ""
+
+    def format_suggestions_url(self, url, list_json):
+        if self.language == "en":
+            return url + list_json
+        return ""

--- a/app/questionnaire/placeholder_transforms.py
+++ b/app/questionnaire/placeholder_transforms.py
@@ -185,4 +185,4 @@ class PlaceholderTransforms:
         return ""
 
     def format_suggestions_url(self, url, list_json):
-        return "{}{}".format(url, list_json) if self.language is "en" else ""
+        return "{}{}".format(url, list_json) if self.language == "en" else ""

--- a/app/questionnaire/placeholder_transforms.py
+++ b/app/questionnaire/placeholder_transforms.py
@@ -185,5 +185,5 @@ class PlaceholderTransforms:
 
         return ""
 
-    def format_suggestions_url(self, url, list_json):
+    def format_nisra_suggestions_url(self, url, list_json):
         return "{}{}".format(url, list_json) if self.language == "en" else ""

--- a/tests/app/questionnaire/test_placeholder_transforms.py
+++ b/tests/app/questionnaire/test_placeholder_transforms.py
@@ -206,7 +206,7 @@ class TestPlaceholderParser(unittest.TestCase):
 
     def test_nisra_english_suggestions_url(self):
         assert (
-            self.transforms.format_suggestions_url(
+            self.transforms.format_nira_suggestions_url(
                 "https://cdn.eq.census-gcp.onsdigital.uk/data/v3.0.0/ni/en/",
                 "countries-of-birth.json",
             )
@@ -217,7 +217,7 @@ class TestPlaceholderParser(unittest.TestCase):
     def test_nisra_non_english_suggestions_url():
         gaelic_transforms = PlaceholderTransforms(language="ga")
         assert (
-            gaelic_transforms.format_suggestions_url(
+            gaelic_transforms.format_nisra_suggestions_url(
                 "https://cdn.eq.census-gcp.onsdigital.uk/data/v3.0.0/ni/en/",
                 "countries-of-birth.json",
             )

--- a/tests/app/questionnaire/test_placeholder_transforms.py
+++ b/tests/app/questionnaire/test_placeholder_transforms.py
@@ -203,3 +203,23 @@ class TestPlaceholderParser(unittest.TestCase):
         list_to_filter = [None, None]
 
         assert self.transforms.first_non_empty_item(list_to_filter) == ""
+
+    def test_nisra_english_suggestions_url(self):
+        assert (
+            self.transforms.format_suggestions_url(
+                "https://cdn.eq.census-gcp.onsdigital.uk/data/v3.0.0/ni/en/",
+                "countries-of-birth.json",
+            )
+            == "https://cdn.eq.census-gcp.onsdigital.uk/data/v3.0.0/ni/en/countries-of-birth.json"
+        )
+
+    @staticmethod
+    def test_nisra_non_english_suggestions_url():
+        gaelic_transforms = PlaceholderTransforms(language="ga")
+        assert (
+            gaelic_transforms.format_suggestions_url(
+                "https://cdn.eq.census-gcp.onsdigital.uk/data/v3.0.0/ni/en/",
+                "countries-of-birth.json",
+            )
+            == ""
+        )

--- a/tests/app/questionnaire/test_placeholder_transforms.py
+++ b/tests/app/questionnaire/test_placeholder_transforms.py
@@ -206,7 +206,7 @@ class TestPlaceholderParser(unittest.TestCase):
 
     def test_nisra_english_suggestions_url(self):
         assert (
-            self.transforms.format_nira_suggestions_url(
+            self.transforms.format_nisra_suggestions_url(
                 "https://cdn.eq.census-gcp.onsdigital.uk/data/v3.0.0/ni/en/",
                 "countries-of-birth.json",
             )


### PR DESCRIPTION
### What is the context of this PR?
This adds new transform to help resolving suggestions urls language for NISRA schemas. It needs merging before [this schemas PR](https://github.com/ONSdigital/eq-questionnaire-schemas/pull/152) and after [validator PR](https://github.com/ONSdigital/eq-questionnaire-validator/pull/60).

### How to review 
Two unit tests has been added to support this and reach 100% test coverage.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
