### PR TITLE
Fix Welsh ordinals over 20

### DIFF
--- a/app/questionnaire/placeholder_transforms.py
+++ b/app/questionnaire/placeholder_transforms.py
@@ -154,7 +154,7 @@ class PlaceholderTransforms:
             return "ú"
 
         if self.language == "cy":
-            if number_to_format in range(21, 39):
+            if number_to_format > 20:
                 return "ain"
             return {
                 1: "af",

--- a/tests/app/questionnaire/test_placeholder_transforms.py
+++ b/tests/app/questionnaire/test_placeholder_transforms.py
@@ -183,7 +183,7 @@ class TestPlaceholderParser(unittest.TestCase):
         assert welsh_transforms.format_ordinal(13) == "13eg"
         assert welsh_transforms.format_ordinal(18) == "18fed"
         assert welsh_transforms.format_ordinal(21) == "21ain"
-        assert welsh_transforms.format_ordinal(40) == "40fed"
+        assert welsh_transforms.format_ordinal(40) == "40ain"
 
     def test_remove_empty_from_list(self):
         list_to_filter = [None, 0, False, "", "String"]


### PR DESCRIPTION
### What is the context of this PR?
This changes how Welsh ordinals are generated. All ordinals over 20 have the "ain" suffix now. Change is described on this [Trello card](https://trello.com/c/7cBfYDWn).

### How to review 
Run `test_placeholder_transforms` unit test.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
