### PR TITLE
Override _resolve_custom_page_title_vars for add blocks

### DIFF
--- a/app/views/handlers/list_add_question.py
+++ b/app/views/handlers/list_add_question.py
@@ -1,3 +1,5 @@
+from typing import MutableMapping
+
 from app.views.handlers.list_action import ListAction
 
 
@@ -13,3 +15,14 @@ class ListAddQuestion(ListAction):
         )
         self.questionnaire_store_updater.update_answers(self.form.data, list_item_id)
         return super().handle_post()
+
+    def _resolve_custom_page_title_vars(self) -> MutableMapping:
+        # For list add blocks, no list item id is yet available. Any custom `page_title`
+        # `list_item_position` string formatter is instead resolved to the length of
+        # the list identified by the `list_name` attribute of the current Location
+        # object.
+        list_length = len(
+            self._questionnaire_store.list_store[self._current_location.list_name]
+        )
+
+        return {"list_item_position": list_length + 1}

--- a/app/views/handlers/list_add_question.py
+++ b/app/views/handlers/list_add_question.py
@@ -17,7 +17,7 @@ class ListAddQuestion(ListAction):
         return super().handle_post()
 
     def _resolve_custom_page_title_vars(self) -> MutableMapping:
-        # For list add blocks, no list item id is yet available. Instead, we resolve 
+        # For list add blocks, no list item id is yet available. Instead, we resolve
         # `list_item_position` to the position in the list it would be if added.
         list_length = len(
             self._questionnaire_store.list_store[self._current_location.list_name]

--- a/test_schemas/en/test_custom_page_titles.json
+++ b/test_schemas/en/test_custom_page_titles.json
@@ -80,7 +80,7 @@
                             "add_block": {
                                 "id": "add-person",
                                 "type": "ListAddQuestion",
-                                "page_title": "Custom add page title",
+                                "page_title": "Person {list_item_position}",
                                 "question": {
                                     "id": "add-question",
                                     "type": "General",

--- a/test_schemas/en/test_custom_page_titles.json
+++ b/test_schemas/en/test_custom_page_titles.json
@@ -80,7 +80,7 @@
                             "add_block": {
                                 "id": "add-person",
                                 "type": "ListAddQuestion",
-                                "page_title": "Person {list_item_position}",
+                                "page_title": "Add person {list_item_position}",
                                 "question": {
                                     "id": "add-question",
                                     "type": "General",
@@ -104,7 +104,7 @@
                             "edit_block": {
                                 "id": "edit-person",
                                 "type": "ListEditQuestion",
-                                "page_title": "Custom edit page title",
+                                "page_title": "Edit person {list_item_position}",
                                 "question": {
                                     "id": "edit-question",
                                     "type": "General",
@@ -128,7 +128,7 @@
                             "remove_block": {
                                 "id": "remove-person",
                                 "type": "ListRemoveQuestion",
-                                "page_title": "Custom remove page title",
+                                "page_title": "Remove person {list_item_position}",
                                 "question": {
                                     "id": "remove-question",
                                     "type": "General",

--- a/tests/functional/spec/custom-page-titles.spec.js
+++ b/tests/functional/spec/custom-page-titles.spec.js
@@ -20,12 +20,20 @@ describe("Feature: Custom Page Titles", () => {
       expect(expectedPageTitle).to.equal("Custom page title");
     });
 
-    it("When I navigate to the add person page, Then I should see the custom page title", () => {
+    it("When I navigate to the add person pages, Then I should see the custom page titles", () => {
       $(HubPage.submit()).click();
       $(ListCollectorPage.yes()).click();
       $(ListCollectorPage.submit()).click();
-      const expectedPageTitle = browser.getTitle();
-      expect(expectedPageTitle).to.equal("Custom add page title");
+      let expectedPageTitle = browser.getTitle();
+      expect(expectedPageTitle).to.equal("Person 1");
+
+      $(ListCollectorAddPage.firstName()).setValue("Marcus");
+      $(ListCollectorAddPage.lastName()).setValue("Twin");
+      $(ListCollectorAddPage.submit()).click();
+      $(ListCollectorPage.yes()).click();
+      $(ListCollectorPage.submit()).click();
+      expectedPageTitle = browser.getTitle();
+      expect(expectedPageTitle).to.equal("Person 2");
     });
 
     it("When I navigate to relationship collector pages, Then I should see the custom page titles", () => {

--- a/tests/functional/spec/custom-page-titles.spec.js
+++ b/tests/functional/spec/custom-page-titles.spec.js
@@ -25,7 +25,7 @@ describe("Feature: Custom Page Titles", () => {
       $(ListCollectorPage.yes()).click();
       $(ListCollectorPage.submit()).click();
       let expectedPageTitle = browser.getTitle();
-      expect(expectedPageTitle).to.equal("Person 1");
+      expect(expectedPageTitle).to.equal("Add person 1");
 
       $(ListCollectorAddPage.firstName()).setValue("Marcus");
       $(ListCollectorAddPage.lastName()).setValue("Twin");
@@ -33,7 +33,7 @@ describe("Feature: Custom Page Titles", () => {
       $(ListCollectorPage.yes()).click();
       $(ListCollectorPage.submit()).click();
       expectedPageTitle = browser.getTitle();
-      expect(expectedPageTitle).to.equal("Person 2");
+      expect(expectedPageTitle).to.equal("Add person 2");
     });
 
     it("When I navigate to relationship collector pages, Then I should see the custom page titles", () => {
@@ -120,12 +120,12 @@ describe("Feature: Custom Page Titles", () => {
       $(ListCollectorAddPage.submit()).click();
       $(ListCollectorPage.listEditLink(1)).click();
       let expectedPageTitle = browser.getTitle();
-      expect(expectedPageTitle).to.equal("Custom edit page title");
+      expect(expectedPageTitle).to.equal("Edit person 1");
 
       $(ListCollectorEditPage.previous()).click();
       $(ListCollectorPage.listRemoveLink(1)).click();
       expectedPageTitle = browser.getTitle();
-      expect(expectedPageTitle).to.equal("Custom remove page title");
+      expect(expectedPageTitle).to.equal("Remove person 1");
     });
   });
 });

--- a/tests/integration/questionnaire/test_questionnaire_custom_page_titles.py
+++ b/tests/integration/questionnaire/test_questionnaire_custom_page_titles.py
@@ -8,11 +8,11 @@ class TestQuestionnaireCustomPageTitles(QuestionnaireTestCase):
         self.assertEqualPageTitle("Custom page title")
 
         self.post({"anyone-else": "Yes"})
-        self.assertEqualPageTitle("Person 1")
+        self.assertEqualPageTitle("Add person 1")
 
         self.post({"first-name": "Marie", "last-name": "Doe"})
         self.post({"anyone-else": "Yes"})
-        self.assertEqualPageTitle("Person 2")
+        self.assertEqualPageTitle("Add person 2")
 
         self.post({"first-name": "John", "last-name": "Doe"})
         self.add_person("Susan", "Doe")

--- a/tests/integration/questionnaire/test_questionnaire_custom_page_titles.py
+++ b/tests/integration/questionnaire/test_questionnaire_custom_page_titles.py
@@ -8,10 +8,13 @@ class TestQuestionnaireCustomPageTitles(QuestionnaireTestCase):
         self.assertEqualPageTitle("Custom page title")
 
         self.post({"anyone-else": "Yes"})
-        self.assertEqualPageTitle("Custom add page title")
+        self.assertEqualPageTitle("Person 1")
 
         self.post({"first-name": "Marie", "last-name": "Doe"})
-        self.add_person("John", "Doe")
+        self.post({"anyone-else": "Yes"})
+        self.assertEqualPageTitle("Person 2")
+
+        self.post({"first-name": "John", "last-name": "Doe"})
         self.add_person("Susan", "Doe")
         self.post({"anyone-else": "No"})
 


### PR DESCRIPTION
### What is the context of this PR?
List add blocks cannot use the list item id, as it does not exist. Instead, this PR overrides the _resolv_custom_page_title_vars method to return the length of the list defined by the current Location object, plus one.

### How to review 
Test the custom page titles for add blocks render correctly.

