### PR TITLE
Add transforms to support users with matching names

### DIFF
--- a/app/questionnaire/placeholder_parser.py
+++ b/app/questionnaire/placeholder_parser.py
@@ -63,7 +63,14 @@ class PlaceholderParser:
         if value_source["source"] == "metadata":
             return self._resolve_metadata_value(value_source["identifier"])
         if value_source["source"] == "list":
+            if value_source.get("id_selector") == "same_name_items":
+                return self._list_store[value_source["identifier"]].same_name_items
             return len(self._list_store[value_source["identifier"]])
+        if (
+            value_source["source"] == "location"
+            and value_source["identifier"] == "list_item_id"
+        ):
+            return self._list_item_id
 
     def _resolve_answer_value(self, value_source):
         list_item_id = self._get_list_item_id_from_value_source(value_source)

--- a/app/questionnaire/placeholder_transforms.py
+++ b/app/questionnaire/placeholder_transforms.py
@@ -186,12 +186,12 @@ class PlaceholderTransforms:
         return ""
 
     @staticmethod
-    def name_is_duplicate(same_name_item_ids, list_item_id):
-        return list_item_id in same_name_item_ids
+    def contains(list_to_check, value):
+        return value in list_to_check
 
     @staticmethod
-    def list_has_duplicates(same_name_item_ids):
-        return len(same_name_item_ids) > 0
+    def list_has_items(list_to_check):
+        return len(list_to_check) > 0
 
     @staticmethod
     def format_name(first_name, middle_names, last_name, include_middle_name=False):

--- a/app/questionnaire/placeholder_transforms.py
+++ b/app/questionnaire/placeholder_transforms.py
@@ -194,9 +194,9 @@ class PlaceholderTransforms:
         return len(list_to_check) > 0
 
     @staticmethod
-    def format_name(first_name, middle_names, last_name, include_middle_name=False):
+    def format_name(first_name, middle_names, last_name, include_middle_names=False):
         return (
             f"{first_name} {middle_names} {last_name}"
-            if include_middle_name
+            if include_middle_names
             else f"{first_name} {last_name}"
         )

--- a/app/questionnaire/placeholder_transforms.py
+++ b/app/questionnaire/placeholder_transforms.py
@@ -184,3 +184,19 @@ class PlaceholderTransforms:
             return item
 
         return ""
+
+    @staticmethod
+    def name_is_duplicate(same_name_item_ids, list_item_id):
+        return list_item_id in same_name_item_ids
+
+    @staticmethod
+    def list_has_duplicates(same_name_item_ids):
+        return len(same_name_item_ids) > 0
+
+    @staticmethod
+    def format_name(first_name, middle_names, last_name, include_middle_name=False):
+        return (
+            f"{first_name} {middle_names} {last_name}"
+            if include_middle_name
+            else f"{first_name} {last_name}"
+        )

--- a/scripts/run_validator.sh
+++ b/scripts/run_validator.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-tag=resolve-name-display
+tag=latest
 docker pull onsdigital/eq-questionnaire-validator:$tag
 docker run -d -p 5001:5000 "onsdigital/eq-questionnaire-validator:$tag"

--- a/scripts/run_validator.sh
+++ b/scripts/run_validator.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-tag=latest
+tag=resolve-name-display
 docker pull onsdigital/eq-questionnaire-validator:$tag
 docker run -d -p 5001:5000 "onsdigital/eq-questionnaire-validator:$tag"

--- a/test_schemas/en/test_list_collector_same_name_items.json
+++ b/test_schemas/en/test_list_collector_same_name_items.json
@@ -315,14 +315,36 @@
                                             "placeholder": "person_name",
                                             "transforms": [
                                                 {
+                                                    "transform": "name_is_duplicate",
                                                     "arguments": {
-                                                        "delimiter": " ",
-                                                        "list_to_concatenate": {
-                                                            "identifier": ["first-name", "last-name"],
-                                                            "source": "answers"
+                                                        "same_name_item_ids": {
+                                                            "source": "list",
+                                                            "id_selector": "same_name_items",
+                                                            "identifier": "people"
+                                                        },
+                                                        "list_item_id": {
+                                                            "source": "location",
+                                                            "identifier": "list_item_id"
                                                         }
-                                                    },
-                                                    "transform": "concatenate_list"
+                                                    }
+                                                },
+                                                {
+                                                    "transform": "format_name",
+                                                    "arguments": {
+                                                        "include_middle_name": { "source": "previous_transform" },
+                                                        "first_name": {
+                                                            "source": "answers",
+                                                            "identifier": "first-name"
+                                                        },
+                                                        "middle_names": {
+                                                            "source": "answers",
+                                                            "identifier": "middle-names"
+                                                        },
+                                                        "last_name": {
+                                                            "source": "answers",
+                                                            "identifier": "last-name"
+                                                        }
+                                                    }
                                                 }
                                             ]
                                         }

--- a/test_schemas/en/test_list_collector_same_name_items.json
+++ b/test_schemas/en/test_list_collector_same_name_items.json
@@ -237,21 +237,44 @@
                                     "id": "edit-question",
                                     "type": "General",
                                     "title": {
-                                        "text": "Change details for {first_name} {last_name}",
+                                        "text": "Change details for {person_name}",
                                         "placeholders": [
                                             {
-                                                "placeholder": "first_name",
-                                                "value": {
-                                                    "source": "answers",
-                                                    "identifier": "first-name"
-                                                }
-                                            },
-                                            {
-                                                "placeholder": "last_name",
-                                                "value": {
-                                                    "source": "answers",
-                                                    "identifier": "last-name"
-                                                }
+                                                "placeholder": "person_name",
+                                                "transforms": [
+                                                    {
+                                                        "transform": "contains",
+                                                        "arguments": {
+                                                            "list_to_check": {
+                                                                "source": "list",
+                                                                "id_selector": "same_name_items",
+                                                                "identifier": "people"
+                                                            },
+                                                            "value": {
+                                                                "source": "location",
+                                                                "identifier": "list_item_id"
+                                                            }
+                                                        }
+                                                    },
+                                                    {
+                                                        "transform": "format_name",
+                                                        "arguments": {
+                                                            "include_middle_names": { "source": "previous_transform" },
+                                                            "first_name": {
+                                                                "source": "answers",
+                                                                "identifier": "first-name"
+                                                            },
+                                                            "middle_names": {
+                                                                "source": "answers",
+                                                                "identifier": "middle-names"
+                                                            },
+                                                            "last_name": {
+                                                                "source": "answers",
+                                                                "identifier": "last-name"
+                                                            }
+                                                        }
+                                                    }
+                                                ]
                                             }
                                         ]
                                     },
@@ -315,16 +338,12 @@
                                             "placeholder": "person_name",
                                             "transforms": [
                                                 {
-                                                    "transform": "contains",
+                                                    "transform": "list_has_items",
                                                     "arguments": {
                                                         "list_to_check": {
                                                             "source": "list",
                                                             "id_selector": "same_name_items",
                                                             "identifier": "people"
-                                                        },
-                                                        "value": {
-                                                            "source": "location",
-                                                            "identifier": "list_item_id"
                                                         }
                                                     }
                                                 },

--- a/test_schemas/en/test_list_collector_same_name_items.json
+++ b/test_schemas/en/test_list_collector_same_name_items.json
@@ -331,7 +331,7 @@
                                                 {
                                                     "transform": "format_name",
                                                     "arguments": {
-                                                        "include_middle_name": { "source": "previous_transform" },
+                                                        "include_middle_names": { "source": "previous_transform" },
                                                         "first_name": {
                                                             "source": "answers",
                                                             "identifier": "first-name"

--- a/test_schemas/en/test_list_collector_same_name_items.json
+++ b/test_schemas/en/test_list_collector_same_name_items.json
@@ -315,14 +315,14 @@
                                             "placeholder": "person_name",
                                             "transforms": [
                                                 {
-                                                    "transform": "name_is_duplicate",
+                                                    "transform": "contains",
                                                     "arguments": {
-                                                        "same_name_item_ids": {
+                                                        "list_to_check": {
                                                             "source": "list",
                                                             "id_selector": "same_name_items",
                                                             "identifier": "people"
                                                         },
-                                                        "list_item_id": {
+                                                        "value": {
                                                             "source": "location",
                                                             "identifier": "list_item_id"
                                                         }

--- a/tests/app/questionnaire/test_placeholder_parser.py
+++ b/tests/app/questionnaire/test_placeholder_parser.py
@@ -429,3 +429,245 @@ def test_placeholder_resolves_answer_value_based_on_first_item_in_list():
 
     placeholders = parser(placeholder_list)
     assert str(placeholders["answer"]) == "Coffee"
+
+
+def test_placeholder_resolves_same_name_items():
+    list_store = ListStore(
+        [
+            {
+                "items": ["abc123", "cde456", "fgh789"],
+                "same_name_items": ["abc123", "fgh789"],
+                "name": "people",
+            }
+        ]
+    )
+    placeholder_list = [
+        {
+            "placeholder": "answer",
+            "value": {
+                "source": "list",
+                "id_selector": "same_name_items",
+                "identifier": "people",
+            },
+        },
+    ]
+
+    parser = PlaceholderParser(
+        language="en",
+        list_store=list_store,
+        list_item_id="abc123",
+    )
+
+    placeholders = parser(placeholder_list)
+
+    assert placeholders["answer"] == ["abc123", "fgh789"]
+
+
+def test_placeholder_resolves_name_is_duplicate_chain():
+    list_store = ListStore(
+        [
+            {
+                "items": ["abc123", "cde456", "fgh789"],
+                "same_name_items": ["abc123", "fgh789"],
+                "name": "people",
+            }
+        ]
+    )
+    answer_store = AnswerStore(
+        [
+            {
+                "answer_id": "first-name-answer",
+                "value": "Joe",
+                "list_item_id": "abc123",
+            },
+            {
+                "answer_id": "middle-names-answer",
+                "value": "Michael",
+                "list_item_id": "abc123",
+            },
+            {
+                "answer_id": "last-name-answer",
+                "value": "Smith",
+                "list_item_id": "abc123",
+            },
+            {
+                "answer_id": "first-name-answer",
+                "value": "Marie",
+                "list_item_id": "cde456",
+            },
+            {
+                "answer_id": "middle-names-answer",
+                "value": "Jane",
+                "list_item_id": "cde456",
+            },
+            {
+                "answer_id": "last-name-answer",
+                "value": "Smith",
+                "list_item_id": "cde456",
+            },
+        ]
+    )
+    placeholder_transforms = [
+        {
+            "placeholder": "persons_name",
+            "transforms": [
+                {
+                    "transform": "name_is_duplicate",
+                    "arguments": {
+                        "same_name_item_ids": {
+                            "source": "list",
+                            "id_selector": "same_name_items",
+                            "identifier": "people",
+                        },
+                        "list_item_id": {
+                            "source": "location",
+                            "identifier": "list_item_id",
+                        },
+                    },
+                },
+                {
+                    "transform": "format_name",
+                    "arguments": {
+                        "include_middle_name": {"source": "previous_transform"},
+                        "first_name": {
+                            "source": "answers",
+                            "identifier": "first-name-answer",
+                        },
+                        "middle_names": {
+                            "source": "answers",
+                            "identifier": "middle-names-answer",
+                        },
+                        "last_name": {
+                            "source": "answers",
+                            "identifier": "last-name-answer",
+                        },
+                    },
+                },
+            ],
+        }
+    ]
+
+    parser = PlaceholderParser(
+        language="en",
+        list_store=list_store,
+        answer_store=answer_store,
+        list_item_id="abc123",
+    )
+
+    placeholders = parser(placeholder_transforms)
+
+    assert placeholders["persons_name"] == "Joe Michael Smith"
+
+    parser = PlaceholderParser(
+        language="en",
+        list_store=list_store,
+        answer_store=answer_store,
+        list_item_id="cde456",
+    )
+
+    placeholders = parser(placeholder_transforms)
+
+    assert placeholders["persons_name"] == "Marie Smith"
+
+
+def test_placeholder_resolves_list_has_duplicates_chain():
+    list_store = ListStore(
+        [
+            {
+                "items": ["abc123", "cde456", "fgh789"],
+                "same_name_items": ["abc123", "fgh789"],
+                "name": "people",
+            }
+        ]
+    )
+    answer_store = AnswerStore(
+        [
+            {
+                "answer_id": "first-name-answer",
+                "value": "Joe",
+                "list_item_id": "abc123",
+            },
+            {
+                "answer_id": "middle-names-answer",
+                "value": "Michael",
+                "list_item_id": "abc123",
+            },
+            {
+                "answer_id": "last-name-answer",
+                "value": "Smith",
+                "list_item_id": "abc123",
+            },
+            {
+                "answer_id": "first-name-answer",
+                "value": "Marie",
+                "list_item_id": "cde456",
+            },
+            {
+                "answer_id": "middle-names-answer",
+                "value": "Jane",
+                "list_item_id": "cde456",
+            },
+            {
+                "answer_id": "last-name-answer",
+                "value": "Smith",
+                "list_item_id": "cde456",
+            },
+        ]
+    )
+    placeholder_transforms = [
+        {
+            "placeholder": "persons_name",
+            "transforms": [
+                {
+                    "transform": "list_has_duplicates",
+                    "arguments": {
+                        "same_name_item_ids": {
+                            "source": "list",
+                            "id_selector": "same_name_items",
+                            "identifier": "people",
+                        },
+                    },
+                },
+                {
+                    "transform": "format_name",
+                    "arguments": {
+                        "include_middle_name": {"source": "previous_transform"},
+                        "first_name": {
+                            "source": "answers",
+                            "identifier": "first-name-answer",
+                        },
+                        "middle_names": {
+                            "source": "answers",
+                            "identifier": "middle-names-answer",
+                        },
+                        "last_name": {
+                            "source": "answers",
+                            "identifier": "last-name-answer",
+                        },
+                    },
+                },
+            ],
+        }
+    ]
+
+    parser = PlaceholderParser(
+        language="en",
+        list_store=list_store,
+        answer_store=answer_store,
+        list_item_id="abc123",
+    )
+
+    placeholders = parser(placeholder_transforms)
+
+    assert placeholders["persons_name"] == "Joe Michael Smith"
+
+    parser = PlaceholderParser(
+        language="en",
+        list_store=list_store,
+        answer_store=answer_store,
+        list_item_id="cde456",
+    )
+
+    placeholders = parser(placeholder_transforms)
+
+    assert placeholders["persons_name"] == "Marie Jane Smith"

--- a/tests/app/questionnaire/test_placeholder_parser.py
+++ b/tests/app/questionnaire/test_placeholder_parser.py
@@ -512,14 +512,14 @@ def test_placeholder_resolves_name_is_duplicate_chain():
             "placeholder": "persons_name",
             "transforms": [
                 {
-                    "transform": "name_is_duplicate",
+                    "transform": "contains",
                     "arguments": {
-                        "same_name_item_ids": {
+                        "list_to_check": {
                             "source": "list",
                             "id_selector": "same_name_items",
                             "identifier": "people",
                         },
-                        "list_item_id": {
+                        "value": {
                             "source": "location",
                             "identifier": "list_item_id",
                         },
@@ -570,7 +570,7 @@ def test_placeholder_resolves_name_is_duplicate_chain():
     assert placeholders["persons_name"] == "Marie Smith"
 
 
-def test_placeholder_resolves_list_has_duplicates_chain():
+def test_placeholder_resolves_list_has_items_chain():
     list_store = ListStore(
         [
             {
@@ -619,9 +619,9 @@ def test_placeholder_resolves_list_has_duplicates_chain():
             "placeholder": "persons_name",
             "transforms": [
                 {
-                    "transform": "list_has_duplicates",
+                    "transform": "list_has_items",
                     "arguments": {
-                        "same_name_item_ids": {
+                        "list_to_check": {
                             "source": "list",
                             "id_selector": "same_name_items",
                             "identifier": "people",

--- a/tests/app/questionnaire/test_placeholder_parser.py
+++ b/tests/app/questionnaire/test_placeholder_parser.py
@@ -528,7 +528,7 @@ def test_placeholder_resolves_name_is_duplicate_chain():
                 {
                     "transform": "format_name",
                     "arguments": {
-                        "include_middle_name": {"source": "previous_transform"},
+                        "include_middle_names": {"source": "previous_transform"},
                         "first_name": {
                             "source": "answers",
                             "identifier": "first-name-answer",
@@ -631,7 +631,7 @@ def test_placeholder_resolves_list_has_items_chain():
                 {
                     "transform": "format_name",
                     "arguments": {
-                        "include_middle_name": {"source": "previous_transform"},
+                        "include_middle_names": {"source": "previous_transform"},
                         "first_name": {
                             "source": "answers",
                             "identifier": "first-name-answer",

--- a/tests/app/questionnaire/test_placeholder_transforms.py
+++ b/tests/app/questionnaire/test_placeholder_transforms.py
@@ -203,3 +203,22 @@ class TestPlaceholderParser(unittest.TestCase):
         list_to_filter = [None, None]
 
         assert self.transforms.first_non_empty_item(list_to_filter) == ""
+
+    def test_name_is_duplicate(self):
+        name_item_ids = ["abc123", "fgh789"]
+
+        assert self.transforms.name_is_duplicate(name_item_ids, "abc123")
+        assert not self.transforms.name_is_duplicate(name_item_ids, "def456")
+
+    def test_list_has_duplicates(self):
+        assert self.transforms.list_has_duplicates(["abc123", "fgh789"])
+        assert not self.transforms.list_has_duplicates([])
+
+    def test_format_name(self):
+        assert self.transforms.format_name("Joe", "Michael", "Bloggs") == "Joe Bloggs"
+        assert (
+            self.transforms.format_name(
+                "Joe", "Michael", "Bloggs", include_middle_name=True
+            )
+            == "Joe Michael Bloggs"
+        )

--- a/tests/app/questionnaire/test_placeholder_transforms.py
+++ b/tests/app/questionnaire/test_placeholder_transforms.py
@@ -204,15 +204,15 @@ class TestPlaceholderParser(unittest.TestCase):
 
         assert self.transforms.first_non_empty_item(list_to_filter) == ""
 
-    def test_name_is_duplicate(self):
-        name_item_ids = ["abc123", "fgh789"]
+    def test_contains(self):
+        list_to_check = ["abc123", "fgh789"]
 
-        assert self.transforms.name_is_duplicate(name_item_ids, "abc123")
-        assert not self.transforms.name_is_duplicate(name_item_ids, "def456")
+        assert self.transforms.contains(list_to_check, "abc123")
+        assert not self.transforms.contains(list_to_check, "def456")
 
-    def test_list_has_duplicates(self):
-        assert self.transforms.list_has_duplicates(["abc123", "fgh789"])
-        assert not self.transforms.list_has_duplicates([])
+    def test_list_has_items(self):
+        assert self.transforms.list_has_items(["abc123", "fgh789"])
+        assert not self.transforms.list_has_items([])
 
     def test_format_name(self):
         assert self.transforms.format_name("Joe", "Michael", "Bloggs") == "Joe Bloggs"

--- a/tests/app/questionnaire/test_placeholder_transforms.py
+++ b/tests/app/questionnaire/test_placeholder_transforms.py
@@ -218,7 +218,7 @@ class TestPlaceholderParser(unittest.TestCase):
         assert self.transforms.format_name("Joe", "Michael", "Bloggs") == "Joe Bloggs"
         assert (
             self.transforms.format_name(
-                "Joe", "Michael", "Bloggs", include_middle_name=True
+                "Joe", "Michael", "Bloggs", include_middle_names=True
             )
             == "Joe Michael Bloggs"
         )


### PR DESCRIPTION
### What is the context of this PR?

Adds a number of transforms to placeholders for displaying middle names when first and last name match.

Changes to the `test_list_collector_same_name_items` now demonstrate both transforms at work. Full names for all householders will be displayed on the summary page if any householder has duplicate names to another, the edit page will show middle names only if that person shares their first/last name with someone else in the household.

NB. Originally I had used a new source of "list_item_id" to return the list_Item_id, but this seemed very specific and after discussion felt it better we add a "location" source. The renderer already takes both a list_item_id and location and we actually return that of list_item_id in the new transforms - to use location requires significant change to the existing context design (as they don't always have the property) which didn't seem required for this feature. If we ever have a need for other location properties in transforms, then we can perhaps look at refactoring contexts to support them.

### How to review 

Describe the steps required to test the changes (include screenshots if appropriate).
