### PR TITLE
Update node-forge to 0.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "jsrsasign": "^8.0.19",
     "lint-staged": "^10.2.7",
     "livereload": "^0.9.1",
+    "node-forge": "^0.10.0",
     "node-jose": "^1.1.4",
     "prettier": "^2.0.5",
     "uuid": "^3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3210,6 +3210,11 @@ node-environment-flags@1.0.6:
     object.getownpropertydescriptors "^2.0.3"
     semver "^5.7.0"
 
+node-forge@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.10.0.tgz#32dea2afb3e9926f02ee5ce8794902691a676bf3"
+  integrity sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==
+
 node-forge@^0.8.5:
   version "0.8.5"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.8.5.tgz#57906f07614dc72762c84cef442f427c0e1b86ee"


### PR DESCRIPTION
### What is the context of this PR?
Updates `package.json` to use node-forge >= 0.10.0

Closes https://github.com/ONSdigital/eq-questionnaire-runner/network/alert/yarn.lock/node-forge/open