### PR TITLE
Update section summary title on final summary

### DIFF
--- a/templates/partials/summary/summary.html
+++ b/templates/partials/summary/summary.html
@@ -9,7 +9,7 @@
       {
         "groups": [
           {
-            "groupTitle": '<div id="' + group.id +'">' + group.title + '</div>' if group.title else None,
+            "groupTitle": '<div id="' + group.id +'">' + group.title + '</div>' if group.title else '',
             "rows": map_summary_item_config(
                       group,
                       content.summary.summary_type,


### PR DESCRIPTION
### What is the context of this PR?
This prevents section summary title in final summary page from displaying `None` instead of no section title when no section title is present in schema's final summary. It's a requirement [on this Trello card](https://trello.com/c/7LiItQka) to have section title removed. Related [custom summary page PR in schemas repo](https://github.com/ONSdigital/eq-questionnaire-schemas/pull/173).

### How to review 
Run CE schema using [this schema's PR branch](https://github.com/ONSdigital/eq-questionnaire-schemas/pull/173) and check if `Personal details` title is not displayed on final summary.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
