### PR TITLE
Ensure middle name exists when formatting name

### DIFF
--- a/app/questionnaire/placeholder_transforms.py
+++ b/app/questionnaire/placeholder_transforms.py
@@ -197,6 +197,6 @@ class PlaceholderTransforms:
     def format_name(first_name, middle_names, last_name, include_middle_names=False):
         return (
             f"{first_name} {middle_names} {last_name}"
-            if include_middle_names
+            if include_middle_names and middle_names
             else f"{first_name} {last_name}"
         )

--- a/tests/app/questionnaire/test_placeholder_transforms.py
+++ b/tests/app/questionnaire/test_placeholder_transforms.py
@@ -215,6 +215,13 @@ class TestPlaceholderParser(unittest.TestCase):
         assert not self.transforms.list_has_items([])
 
     def test_format_name(self):
+        assert self.transforms.format_name("Joe", None, "Bloggs") == "Joe Bloggs"
+        assert (
+            self.transforms.format_name(
+                "Joe", None, "Bloggs", include_middle_names=True
+            )
+            == "Joe Bloggs"
+        )
         assert self.transforms.format_name("Joe", "Michael", "Bloggs") == "Joe Bloggs"
         assert (
             self.transforms.format_name(


### PR DESCRIPTION
### What is the context of this PR?

Resolved an issue where the format_name transform incorrectly displayed 'None' for middle names when peoples first and last names matched.

### How to review 
Using `test_list_collector_same_name_items`, enter 2 people with the same name but don't enter a middle name for either. Go to the list summary and see the result.
