### PR TITLE
Update telephone number for IR confirmation

### DIFF
--- a/app/forms/validators.py
+++ b/app/forms/validators.py
@@ -428,7 +428,7 @@ class MutuallyExclusiveCheck:
 
 def sanitise_mobile_number(data):
     data = re.sub(r"[\s.,\t\-{}\[\]()/]", "", data)
-    return re.sub(r"^(044|\+44|0)", "", data)
+    return re.sub(r"^(0044|044|\+44|0)", "", data)
 
 
 class MobileNumberCheck:

--- a/app/forms/validators.py
+++ b/app/forms/validators.py
@@ -428,7 +428,7 @@ class MutuallyExclusiveCheck:
 
 def sanitise_mobile_number(data):
     data = re.sub(r"[\s.,\t\-{}\[\]()/]", "", data)
-    return re.sub(r"^(0044|044|\+44|0)", "", data)
+    return re.sub(r"^(0{1,2}44|\+44|0)", "", data)
 
 
 class MobileNumberCheck:

--- a/tests/app/forms/validation/test_mobile_number_validation.py
+++ b/tests/app/forms/validation/test_mobile_number_validation.py
@@ -15,6 +15,7 @@ class TestPhoneNumberValidator(unittest.TestCase):
         assert sanitise_mobile_number("0447700\t900222") == "7700900222"
         assert sanitise_mobile_number("07700-(900333)") == "7700900333"
         assert sanitise_mobile_number("/0770/090/0444") == "7700900444"
+        assert sanitise_mobile_number("00447700 900555") == "7700900555"
         assert sanitise_mobile_number("0447700 900555") == "7700900555"
         assert sanitise_mobile_number("+447700 900666") == "7700900666"
         assert sanitise_mobile_number("[07700] 900777") == "7700900777"


### PR DESCRIPTION
### What is the context of this PR?
This adds new prefix to mobile number validator regex, so leading '0044' can be removed. Change is described on [this trello card](https://trello.com/c/l3y9ZHKL).

### How to review 
New unit test assertion has been added. Run automated tests.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
