### PR TITLE
Set gunicorn worker class via CLI

### DIFF
--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -3,7 +3,6 @@ import os
 import gunicorn
 
 workers = os.getenv("WEB_SERVER_WORKERS")
-worker_class = os.getenv("WEB_SERVER_WORKER_CLASS")
 threads = os.getenv("WEB_SERVER_THREADS")
 keepalive = os.getenv("HTTP_KEEP_ALIVE")
 bind = "0.0.0.0:5000"

--- a/run_app.sh
+++ b/run_app.sh
@@ -3,9 +3,9 @@
 set -e
 
 if [ "$WEB_SERVER_TYPE" = "gunicorn-async" ]; then
-    run_command="WEB_SERVER_WORKER_CLASS=gevent gunicorn application:application"
+    run_command="gunicorn application:application --worker-class gevent"
 elif [ "$WEB_SERVER_TYPE" = "gunicorn-threads" ]; then
-    run_command="WEB_SERVER_WORKER_CLASS=gthread gunicorn application:application"
+    run_command="gunicorn application:application --worker-class gthread"
 elif [ "$WEB_SERVER_TYPE" = "uwsgi" ]; then
     run_command="uwsgi uwsgi.ini --workers ${WEB_SERVER_WORKERS}"
 elif [ "$WEB_SERVER_TYPE" = "uwsgi-threads" ]; then


### PR DESCRIPTION
### What is the context of this PR?
Due to the order of the env vars, when using new relic, the run commands was incorrect. To solve this, I have set the gunicorn worker class via the CLI. If this is not preferred, I can push a change to make use of an additional vars in shell script to manage the ordering.

Using `gunicorn-async`:
**Before:**
```
NEW_RELIC_CONFIG_FILE=newrelic.ini newrelic-admin run-program WEB_SERVER_WORKER_CLASS=gevent gunicorn application:application
```

**After:**
```
NEW_RELIC_CONFIG_FILE=newrelic.ini newrelic-admin run-program gunicorn application:application --worker-class gevent
```

### How to review 
Set `EQ_NEW_RELIC_ENABLED=True` in `.development.env` and ensure the app can be started up under different web servers.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
