### PR TITLE
Filter list summaries on unrelated question blocks

### DIFF
--- a/app/views/contexts/list_context.py
+++ b/app/views/contexts/list_context.py
@@ -15,6 +15,7 @@ class ListContext(Context):
         edit_block_id=None,
         remove_block_id=None,
         primary_person_edit_block_id=None,
+        for_list_item_ids=None,
     ):
         list_items = (
             list(
@@ -25,6 +26,7 @@ class ListContext(Context):
                     edit_block_id,
                     remove_block_id,
                     primary_person_edit_block_id,
+                    for_list_item_ids,
                 )
             )
             if summary_definition
@@ -46,8 +48,15 @@ class ListContext(Context):
         edit_block_id,
         remove_block_id,
         primary_person_edit_block_id,
+        for_list_item_ids,
     ):
         list_item_ids = self._list_store[for_list]
+        if for_list_item_ids:
+            list_item_ids = [
+                list_item_id
+                for list_item_id in list_item_ids
+                if list_item_id in for_list_item_ids
+            ]
         primary_person = self._list_store[for_list].primary_person
 
         for list_item_id in list_item_ids:

--- a/app/views/handlers/relationships/unrelated_question.py
+++ b/app/views/handlers/relationships/unrelated_question.py
@@ -1,17 +1,33 @@
+from functools import cached_property
+
 from app.questionnaire.location import Location
 from app.views.handlers.question import Question
 
 
 class UnrelatedQuestion(Question):
-    def _get_parent_list_name(self):
+    @cached_property
+    def list_name(self):
         parent_block_id = self._schema.parent_id_map[self.block["id"]]
         return self._schema.get_block(parent_block_id)["for_list"]
 
-    @property
+    @cached_property
     def parent_location(self):
         parent_block_id = self._schema.parent_id_map[self.block["id"]]
         return Location(
             section_id=self._current_location.section_id, block_id=parent_block_id
+        )
+
+    @cached_property
+    def remaining_relationship_list_item_ids(self):
+        list_model = self._questionnaire_store.list_store[self.list_name]
+        start = list_model.index(self._current_location.list_item_id) + 1
+        return list_model[start:]
+
+    def get_list_summary_context(self):
+        return self.list_context(
+            self.rendered_block["list_summary"]["summary"],
+            self.rendered_block["list_summary"]["for_list"],
+            for_list_item_ids=self.remaining_relationship_list_item_ids,
         )
 
     def _get_routing_path(self):
@@ -25,7 +41,7 @@ class UnrelatedQuestion(Question):
         if not can_access_parent_location:
             return False
 
-        if self.current_location.list_name != self._get_parent_list_name() or (
+        if self.current_location.list_name != self.list_name or (
             self.current_location.list_item_id
             and not self.router.is_list_item_in_list_store(
                 self.current_location.list_item_id, self.current_location.list_name

--- a/tests/app/views/contexts/test_list_context.py
+++ b/tests/app/views/contexts/test_list_context.py
@@ -91,3 +91,33 @@ def test_assert_primary_person_string_appended(
     assert list_context["list"]["list_items"][0]["primary_person"] is True
     assert list_context["list"]["list_items"][0]["item_title"] == "Toni Morrison (You)"
     assert list_context["list"]["list_items"][1]["item_title"] == "Barry Pheloung"
+
+
+@pytest.mark.usefixtures("app")
+def test_for_list_item_ids(
+    list_collector_block, people_answer_store, people_list_store
+):
+    schema = load_schema_from_name("test_list_collector_primary_person")
+
+    list_context = ListContext(
+        language=DEFAULT_LANGUAGE_CODE,
+        progress_store=ProgressStore(),
+        list_store=people_list_store,
+        schema=schema,
+        answer_store=people_answer_store,
+        metadata=None,
+    )
+    list_context = list_context(
+        list_collector_block["summary"],
+        list_collector_block["for_list"],
+        for_list_item_ids=["UHPLbX"],
+    )
+
+    expected = [
+        {
+            "item_title": "Barry Pheloung",
+            "primary_person": False,
+        }
+    ]
+
+    assert expected == list_context["list"]["list_items"]

--- a/tests/integration/questionnaire/test_questionnaire_relationships_unrelated.py
+++ b/tests/integration/questionnaire/test_questionnaire_relationships_unrelated.py
@@ -6,6 +6,7 @@ class TestQuestionnaireRelationshipsUnrelated(QuestionnaireTestCase):
         self.launchSurvey("test_relationships_unrelated", roles=["dumper"])
         self.add_person("Marie", "Doe")
         self.add_person("John", "Doe")
+        self.add_person("Jane", "Doe")
         self.post({"anyone-else": "No"})
 
     def test_is_accessible_when_list_name_and_list_item_valid(
@@ -18,8 +19,6 @@ class TestQuestionnaireRelationshipsUnrelated(QuestionnaireTestCase):
             f"/questionnaire/relationships/people/{first_list_item}/related-to-anyone-else"
         )
         self.assertInBody("Are any of these people related to you?")
-        self.assertInBody("Marie Doe")
-        self.assertInBody("John Doe")
 
     def test_is_not_accessible_when_invalid_list_item(self):
         self.launchSurvey("test_relationships_unrelated")
@@ -45,3 +44,22 @@ class TestQuestionnaireRelationshipsUnrelated(QuestionnaireTestCase):
             f"/questionnaire/relationships/people/{first_list_item}/invalid-block-id"
         )
         self.assertStatusNotFound()
+
+    def test_list_summary(self):
+        self.launch_survey_and_add_people()
+
+        first_list_item = self.dump_debug()["LISTS"][0]["items"][0]
+        self.get(
+            f"/questionnaire/relationships/people/{first_list_item}/related-to-anyone-else"
+        )
+        self.assertNotInBody("Marie Doe")
+        self.assertInBody("John Doe")
+        self.assertInBody("Jane Doe")
+
+        second_list_item = self.dump_debug()["LISTS"][0]["items"][1]
+        self.get(
+            f"/questionnaire/relationships/people/{second_list_item}/related-to-anyone-else"
+        )
+        self.assertNotInBody("Marie Doe")
+        self.assertNotInBody("John Doe")
+        self.assertInBody("Jane Doe")


### PR DESCRIPTION
### What is the context of this PR?
Filters list summaries on unrelated question blocks so that they only include people after the current person.

### How to review 
- Use the `test_relationships_unrelated` schema and add some people
- Note down some of the list item ids
- Use list item ids in the `related-to-anyone-else` url and check that the page only displays peoples names after the current person - the url format is `questionnaire/relationships/people/{list_item_id}/related-to-anyone-else`. 

Note that if you use the last list item id in the `related-to-anyone-else` url it will display all people. I did consider handling this in some way, but decided not to, as this won't be possible when the unrelated routing feature is done (the location won't be routable).

### Checklist

* [-] New static content marked up for translation
* [-] Newly defined schema content included in eq-translations repo
