### PR TITLE
Remove 'to continue' from default error messages

### DIFF
--- a/app/forms/error_messages.py
+++ b/app/forms/error_messages.py
@@ -8,20 +8,20 @@ from flask_babel import lazy_gettext
 # validators - using `.format` for non-WTForm field validation would introduce
 # inconsistency.
 error_messages = {
-    "MANDATORY_QUESTION": lazy_gettext("Enter an answer to continue"),
-    "MANDATORY_TEXTFIELD": lazy_gettext("Enter an answer to continue"),
-    "MANDATORY_NUMBER": lazy_gettext("Enter an answer to continue"),
-    "MANDATORY_TEXTAREA": lazy_gettext("Enter an answer to continue"),
+    "MANDATORY_QUESTION": lazy_gettext("Enter an answer"),
+    "MANDATORY_TEXTFIELD": lazy_gettext("Enter an answer"),
+    "MANDATORY_NUMBER": lazy_gettext("Enter an answer"),
+    "MANDATORY_TEXTAREA": lazy_gettext("Enter an answer"),
     "MANDATORY_RADIO": lazy_gettext(
         'Select an answer <span class="u-vh">to ‘%(question_title)s’</span>'
     ),
-    "MANDATORY_DROPDOWN": lazy_gettext("Select an answer to continue"),
+    "MANDATORY_DROPDOWN": lazy_gettext("Select an answer"),
     "MANDATORY_CHECKBOX": lazy_gettext(
         'Select at least one answer <span class="u-vh">to ‘%(question_title)s’</span>'
     ),
-    "MANDATORY_DATE": lazy_gettext("Enter a date to continue"),
-    "MANDATORY_ADDRESS": lazy_gettext("Enter an address to continue"),
-    "MANDATORY_DURATION": lazy_gettext("Enter a duration to continue"),
+    "MANDATORY_DATE": lazy_gettext("Enter a date"),
+    "MANDATORY_ADDRESS": lazy_gettext("Enter an address"),
+    "MANDATORY_DURATION": lazy_gettext("Enter a duration"),
     "MANDATORY_EMAIL": lazy_gettext("Enter an email address"),
     "MANDATORY_MOBILE_NUMBER": lazy_gettext("Enter a UK mobile number"),
     "NUMBER_TOO_SMALL": lazy_gettext("Enter an answer more than or equal to %(min)s"),
@@ -66,5 +66,5 @@ error_messages = {
     ),
     "SINGLE_DATE_PERIOD_TOO_EARLY": lazy_gettext("Enter a date after %(min)s"),
     "SINGLE_DATE_PERIOD_TOO_LATE": lazy_gettext("Enter a date before %(max)s"),
-    "MUTUALLY_EXCLUSIVE": lazy_gettext("Remove an answer to continue"),
+    "MUTUALLY_EXCLUSIVE": lazy_gettext("Remove an answer"),
 }

--- a/app/translations/messages.pot
+++ b/app/translations/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-10-16 08:37+0100\n"
+"POT-Creation-Date: 2020-10-19 12:54+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -43,7 +43,7 @@ msgstr ""
 
 #: app/forms/error_messages.py:11 app/forms/error_messages.py:12
 #: app/forms/error_messages.py:13 app/forms/error_messages.py:14
-msgid "Enter an answer to continue"
+msgid "Enter an answer"
 msgstr ""
 
 #: app/forms/error_messages.py:15
@@ -52,7 +52,8 @@ msgid "Select an answer <span class=\"u-vh\">to ‘%(question_title)s’</span>"
 msgstr ""
 
 #: app/forms/error_messages.py:18
-msgid "Select an answer to continue"
+#: app/forms/field_handlers/dropdown_handler.py:12
+msgid "Select an answer"
 msgstr ""
 
 #: app/forms/error_messages.py:19
@@ -63,15 +64,15 @@ msgid ""
 msgstr ""
 
 #: app/forms/error_messages.py:22
-msgid "Enter a date to continue"
+msgid "Enter a date"
 msgstr ""
 
-#: app/forms/error_messages.py:23
-msgid "Enter an address to continue"
+#: app/forms/error_messages.py:23 templates/partials/answers/address.html:53
+msgid "Enter an address"
 msgstr ""
 
 #: app/forms/error_messages.py:24
-msgid "Enter a duration to continue"
+msgid "Enter a duration"
 msgstr ""
 
 #: app/forms/error_messages.py:25
@@ -188,7 +189,7 @@ msgid "Enter a date before %(max)s"
 msgstr ""
 
 #: app/forms/error_messages.py:69
-msgid "Remove an answer to continue"
+msgid "Remove an answer"
 msgstr ""
 
 #: app/forms/validators.py:349
@@ -197,10 +198,6 @@ msgid "%(num)s day"
 msgid_plural "%(num)s days"
 msgstr[0] ""
 msgstr[1] ""
-
-#: app/forms/field_handlers/dropdown_handler.py:12
-msgid "Select an answer"
-msgstr ""
 
 #: app/forms/fields/select_field_with_detail_answer.py:35
 msgid "Not a valid choice"
@@ -1012,7 +1009,6 @@ msgid "Enter more of the address to improve results"
 msgstr ""
 
 #: templates/partials/answers/address.html:47
-#: templates/partials/answers/address.html:54
 msgid "Select an address"
 msgstr ""
 
@@ -1028,8 +1024,8 @@ msgstr ""
 msgid "Enter more of the address to get results"
 msgstr ""
 
-#: templates/partials/answers/address.html:53
-msgid "Enter an address"
+#: templates/partials/answers/address.html:54
+msgid "Select or manually enter an address"
 msgstr ""
 
 #: templates/partials/answers/address.html:55

--- a/templates/partials/answers/address.html
+++ b/templates/partials/answers/address.html
@@ -51,7 +51,7 @@
     "autocomplete": "new-password",
     "errorTitle": _("There is a problem with your answer"),
     "errorMessageEnter": _("Enter an address"),
-    "errorMessageSelect": _("Select an address"),
+    "errorMessageSelect": _("Select or manually enter an address"),
     "errorMessageAPI": _("Sorry, there was a problem loading addresses"),
     "errorMessageAPILinkText": _("Enter address manually"),
     "options": {

--- a/tests/app/forms/field_handlers/test_address_handler.py
+++ b/tests/app/forms/field_handlers/test_address_handler.py
@@ -37,7 +37,7 @@ def test_address_mandatory_line1_validator():
     validator = address_handler.validators
 
     assert isinstance(validator[0], InputRequired)
-    assert validator[0].message == "Enter an address to continue"
+    assert validator[0].message == "Enter an address"
 
 
 def test_no_validation_when_address_not_mandatory():
@@ -57,7 +57,7 @@ def test_mandatory_validation_when_address_line_1_missing():
     form = test_form_class(MultiDict({"test_field": "1"}))
     form.validate()
 
-    assert form.errors["test_field"]["line1"][0] == "Enter an address to continue"
+    assert form.errors["test_field"]["line1"][0] == "Enter an address"
 
 
 def test_address_validator_with_message_override():

--- a/tests/app/forms/test_duration_form.py
+++ b/tests/app/forms/test_duration_form.py
@@ -45,7 +45,7 @@ class TestDurationForm(AppContextTestCase):
         self._test_validation(False, "5", "4", True)
         self._test_validation(True, "5", "4", True)
         self._test_validation(False, "", "", True)
-        self._test_validation(True, "", "", False, error="Enter a duration to continue")
+        self._test_validation(True, "", "", False, error="Enter a duration")
         self._test_validation(False, "5", "", False, error="Enter a valid duration")
         self._test_validation(True, "5", "", False, error="Enter a valid duration")
         self._test_validation(False, "", "4", False, error="Enter a valid duration")
@@ -64,7 +64,7 @@ class TestDurationForm(AppContextTestCase):
         self._test_validation(True, "5", None, True)
         self._test_validation(False, "", None, True)
         self._test_validation(
-            True, "", None, False, error="Enter a duration to continue"
+            True, "", None, False, error="Enter a duration"
         )
         self._test_validation(
             False, "word", None, False, error="Enter a valid duration"
@@ -78,7 +78,7 @@ class TestDurationForm(AppContextTestCase):
         self._test_validation(True, None, "5", True)
         self._test_validation(False, None, "", True)
         self._test_validation(
-            True, None, "", False, error="Enter a duration to continue"
+            True, None, "", False, error="Enter a duration"
         )
         self._test_validation(
             False, None, "word", False, error="Enter a valid duration"

--- a/tests/app/forms/test_duration_form.py
+++ b/tests/app/forms/test_duration_form.py
@@ -63,9 +63,7 @@ class TestDurationForm(AppContextTestCase):
         self._test_validation(False, "5", None, True)
         self._test_validation(True, "5", None, True)
         self._test_validation(False, "", None, True)
-        self._test_validation(
-            True, "", None, False, error="Enter a duration"
-        )
+        self._test_validation(True, "", None, False, error="Enter a duration")
         self._test_validation(
             False, "word", None, False, error="Enter a valid duration"
         )
@@ -77,9 +75,7 @@ class TestDurationForm(AppContextTestCase):
         self._test_validation(False, None, "5", True)
         self._test_validation(True, None, "5", True)
         self._test_validation(False, None, "", True)
-        self._test_validation(
-            True, None, "", False, error="Enter a duration"
-        )
+        self._test_validation(True, None, "", False, error="Enter a duration")
         self._test_validation(
             False, None, "word", False, error="Enter a valid duration"
         )

--- a/tests/functional/spec/components/address/address.spec.js
+++ b/tests/functional/spec/components/address/address.spec.js
@@ -39,7 +39,7 @@ describe("Address Answer Type", () => {
   describe("Given the user is on an mandatory address input question", () => {
     it("When the user submits the page without entering address line 1, Then an error is displayed", () => {
       $(AddressMandatory.submit()).click();
-      expect($(AddressMandatory.error()).getText()).to.equal("Enter an address to continue");
+      expect($(AddressMandatory.error()).getText()).to.equal("Enter an address");
     });
   });
 

--- a/tests/functional/spec/components/dropdown/dropdown.spec.js
+++ b/tests/functional/spec/components/dropdown/dropdown.spec.js
@@ -19,7 +19,7 @@ describe("Component: Dropdown", () => {
 
     it("When I have not selected a dropdown option and click Continue, Then the default error message should be displayed", () => {
       $(DropdownMandatoryPage.submit()).click();
-      expect($(DropdownMandatoryPage.errorNumber(1)).getText()).to.contain("Select an answer to continue");
+      expect($(DropdownMandatoryPage.errorNumber(1)).getText()).to.contain("Select an answer");
     });
 
     it("When I have selected a dropdown option and I try to select a default (disabled) dropdown option, Then the already selected option should be displayed in summary", () => {

--- a/tests/functional/spec/durations.spec.js
+++ b/tests/functional/spec/durations.spec.js
@@ -88,6 +88,6 @@ describe("Durations", () => {
     $(DurationPage.mandatoryMonthMonths()).setValue(1);
     $(DurationPage.submit()).click();
 
-    expect($(DurationPage.errorNumber(1)).getText()).to.contain("Enter a duration to continue");
+    expect($(DurationPage.errorNumber(1)).getText()).to.contain("Enter a duration");
   });
 });

--- a/tests/integration/components/mutually_exclusive/test_checkbox_single_checkbox_override.py
+++ b/tests/integration/components/mutually_exclusive/test_checkbox_single_checkbox_override.py
@@ -48,4 +48,4 @@ class TestCheckboxSingleCheckboxOverride(IntegrationTestCase):
         )
 
         # Then
-        self.assertInBody("Remove an answer to continue")
+        self.assertInBody("Remove an answer")

--- a/tests/integration/components/mutually_exclusive/test_currency_single_checkbox_override.py
+++ b/tests/integration/components/mutually_exclusive/test_currency_single_checkbox_override.py
@@ -54,4 +54,4 @@ class TestCurrencySingleCheckboxOverride(IntegrationTestCase):
         )
 
         # Then
-        self.assertInBody("Remove an answer to continue")
+        self.assertInBody("Remove an answer")

--- a/tests/integration/components/mutually_exclusive/test_date_single_checkbox_override.py
+++ b/tests/integration/components/mutually_exclusive/test_date_single_checkbox_override.py
@@ -64,4 +64,4 @@ class TestDateSingleCheckboxOverride(IntegrationTestCase):
         )
 
         # Then
-        self.assertInBody("Remove an answer to continue")
+        self.assertInBody("Remove an answer")

--- a/tests/integration/components/mutually_exclusive/test_duration_single_checkbox_override.py
+++ b/tests/integration/components/mutually_exclusive/test_duration_single_checkbox_override.py
@@ -56,4 +56,4 @@ class TestDurationSingleCheckboxOverride(IntegrationTestCase):
         )
 
         # Then
-        self.assertInBody("Remove an answer to continue")
+        self.assertInBody("Remove an answer")

--- a/tests/integration/components/mutually_exclusive/test_month_year_date_single_checkbox_override.py
+++ b/tests/integration/components/mutually_exclusive/test_month_year_date_single_checkbox_override.py
@@ -61,4 +61,4 @@ class TestMonthYearDateSingleCheckboxOverride(IntegrationTestCase):
         )
 
         # Then
-        self.assertInBody("Remove an answer to continue")
+        self.assertInBody("Remove an answer")

--- a/tests/integration/components/mutually_exclusive/test_number_single_checkbox_override.py
+++ b/tests/integration/components/mutually_exclusive/test_number_single_checkbox_override.py
@@ -51,4 +51,4 @@ class TestNumberSingleCheckboxOverride(IntegrationTestCase):
         )
 
         # Then
-        self.assertInBody("Remove an answer to continue")
+        self.assertInBody("Remove an answer")

--- a/tests/integration/components/mutually_exclusive/test_percentage_single_checkbox_override.py
+++ b/tests/integration/components/mutually_exclusive/test_percentage_single_checkbox_override.py
@@ -54,4 +54,4 @@ class TestPercentageSingleCheckboxOverride(IntegrationTestCase):
         )
 
         # Then
-        self.assertInBody("Remove an answer to continue")
+        self.assertInBody("Remove an answer")

--- a/tests/integration/components/mutually_exclusive/test_texarea_single_checkbox_override.py
+++ b/tests/integration/components/mutually_exclusive/test_texarea_single_checkbox_override.py
@@ -54,4 +54,4 @@ class TestTextAreaSingleCheckboxOverride(IntegrationTestCase):
         )
 
         # Then
-        self.assertInBody("Remove an answer to continue")
+        self.assertInBody("Remove an answer")

--- a/tests/integration/components/mutually_exclusive/test_textfield_single_checkbox_override.py
+++ b/tests/integration/components/mutually_exclusive/test_textfield_single_checkbox_override.py
@@ -54,4 +54,4 @@ class TestTextFieldSingleCheckboxOverride(IntegrationTestCase):
         )
 
         # Then
-        self.assertInBody("Remove an answer to continue")
+        self.assertInBody("Remove an answer")

--- a/tests/integration/components/mutually_exclusive/test_unit_single_checkbox_override.py
+++ b/tests/integration/components/mutually_exclusive/test_unit_single_checkbox_override.py
@@ -46,4 +46,4 @@ class TestUnitSingleCheckboxOverride(IntegrationTestCase):
         )
 
         # Then
-        self.assertInBody("Remove an answer to continue")
+        self.assertInBody("Remove an answer")

--- a/tests/integration/components/mutually_exclusive/test_year_date_single_checkbox_override.py
+++ b/tests/integration/components/mutually_exclusive/test_year_date_single_checkbox_override.py
@@ -54,4 +54,4 @@ class TestYearDateSingleCheckboxOverride(IntegrationTestCase):
         )
 
         # Then
-        self.assertInBody("Remove an answer to continue")
+        self.assertInBody("Remove an answer")

--- a/tests/integration/components/test_address.py
+++ b/tests/integration/components/test_address.py
@@ -12,7 +12,7 @@ class TestAddressFields(IntegrationTestCase):
         self.post({})
 
         # Then
-        self.assertInBody("Enter an address to continue")
+        self.assertInBody("Enter an address")
 
     def test_empty_address_field_are_not_displayed_on_summary(self):
         # When
@@ -76,7 +76,7 @@ class TestLookupAddressFields(IntegrationTestCase):
         self.post({})
 
         # Then
-        self.assertInBody("Enter an address to continue")
+        self.assertInBody("Enter an address")
 
     def test_address_fields_are_populated_in_when_revisiting_the_page(self):
         # Given


### PR DESCRIPTION
### What is the context of this PR?
Remove `to continue` from all default error messages.

Also updates the address lookup template validation message from 'Select an address' to 'Select or manually enter an address'

### How to review 
Check nothing is broken by this change/tests still pass

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
