### PR TITLE
Add data-ga-action identifier to "Choose another section" link

### DIFF
--- a/templates/layouts/_questionnaire.html
+++ b/templates/layouts/_questionnaire.html
@@ -34,7 +34,7 @@
 
   {% block after_submit_button_content %}
     {% if content.return_to_hub_url %}
-      <p class="u-mt-xl"><a href="{{ content.return_to_hub_url }}">{{ _("Choose another section and return to this later") }}</a></p>
+      <p class="u-mt-xl"><a href="{{ content.return_to_hub_url }}" data-ga-action="Choose another section click">{{ _("Choose another section and return to this later") }}</a></p>
     {% endif %}
   {% endblock %}
 


### PR DESCRIPTION
### What is the context of this PR?
This adds a ga identifier to 'Choose another section and return to this later' link throughout the survey. Change is described in [this trello card](https://trello.com/c/xX0N3CdI).

### How to review 
Check if data-ga-action was added to questionnaire template on every page using chrome devtools.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
