### PR TITLE
Make the unrelated "No" answer more flexible

### DIFF
--- a/app/questionnaire/relationship_router.py
+++ b/app/questionnaire/relationship_router.py
@@ -88,9 +88,8 @@ class RelationshipRouter:
                 unrelated_answer = self.answer_store.get_answer(
                     self.unrelated_answer_id, from_list_item_id
                 )
-                if (
-                    unrelated_answer
-                    and unrelated_answer.value == self.UNRELATED_NO_ANSWER_VALUE
+                if unrelated_answer and unrelated_answer.value.startswith(
+                    self.UNRELATED_NO_ANSWER_VALUE
                 ):
                     return path
 

--- a/tests/app/questionnaire/test_relationship_router_unrelated.py
+++ b/tests/app/questionnaire/test_relationship_router_unrelated.py
@@ -145,6 +145,10 @@ def test_get_next_location_is_not_unrelated_question_when_less_than_two_relation
         (None, relationship_location("abc123", "jkl123")),
         ("Yes", relationship_location("abc123", "jkl123")),
         ("No", relationship_location("def123", "ghi123")),
+        (
+            "No, they are not related to anyone else",
+            relationship_location("def123", "ghi123"),
+        ),
     ],
 )
 def test_get_next_location_from_unrelated_question(


### PR DESCRIPTION
### What is the context of this PR?
The "No" answer can contain other text e.g. "No, they are not related to anyone else". This change allows that by only checking that the answer starts with "No".

### How to review 
- Review the change and updated test

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
