### PR TITLE
Update static translations

### DIFF
--- a/app/translations/cy/LC_MESSAGES/messages.po
+++ b/app/translations/cy/LC_MESSAGES/messages.po
@@ -2,22 +2,23 @@ msgid ""
 msgstr ""
 "Project-Id-Version: eq-census\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-11-08 09:50+0000\n"
-"PO-Revision-Date: 2019-11-08 11:35\n"
-"Last-Translator: ONS_Census\n"
+"POT-Creation-Date: 2020-11-04 15:27+0000\n"
+"PO-Revision-Date: 2020-11-05 14:24\n"
+"Last-Translator: \n"
 "Language-Team: Welsh\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.7.0\n"
+"Generated-By: Babel 2.8.0\n"
 "Plural-Forms: nplurals=6; plural=(n == 0) ? 0 : ((n == 1) ? 1 : ((n == 2) ? 2 : ((n == 3) ? 3 : ((n == 6) ? 4 : 5))));\n"
-"X-Generator: crowdin.com\n"
 "X-Crowdin-Project: eq-census\n"
+"X-Crowdin-Project-ID: 345379\n"
 "X-Crowdin-Language: cy\n"
 "X-Crowdin-File: messages.pot\n"
+"X-Crowdin-File-ID: 20\n"
 "Language: cy_GB\n"
 
-#: app/jinja_filters.py:79 app/validation/validators.py:340
+#: app/forms/validators.py:338 app/jinja_filters.py:86
 #, python-format
 msgid "%(num)s year"
 msgid_plural "%(num)s years"
@@ -28,7 +29,7 @@ msgstr[3] "%(num)s blwyddyn"
 msgstr[4] "%(num)s blwyddyn"
 msgstr[5] "%(num)s blwyddyn"
 
-#: app/jinja_filters.py:87 app/validation/validators.py:344
+#: app/forms/validators.py:342 app/jinja_filters.py:94
 #, python-format
 msgid "%(num)s month"
 msgid_plural "%(num)s months"
@@ -39,157 +40,164 @@ msgstr[3] "%(num)s mis"
 msgstr[4] "%(num)s mis"
 msgstr[5] "%(num)s mis"
 
-#: app/jinja_filters.py:130
+#: app/jinja_filters.py:137
 #, python-format
 msgid "%(date)s at %(time)s"
 msgstr "%(date)s am %(time)s"
 
-#: app/jinja_filters.py:141
+#: app/jinja_filters.py:148
 #, python-format
 msgid "%(from_date)s to %(to_date)s"
 msgstr "rhwng %(from_date)s a/ac %(to_date)s"
 
-#: app/forms/custom_fields.py:130
-msgid "Not a valid choice"
-msgstr "Ddim yn ddewis dilys"
+#: app/forms/error_messages.py:11 app/forms/error_messages.py:12
+#: app/forms/error_messages.py:13 app/forms/error_messages.py:14
+msgid "Enter an answer"
+msgstr "Rhowch ateb"
 
-#: app/forms/fields.py:231
+#: app/forms/error_messages.py:15
+#, python-format
+msgid "Select an answer <span class=\"u-vh\">to ‘%(question_title)s’</span>"
+msgstr ""
+
+#: app/forms/error_messages.py:18
+#: app/forms/field_handlers/dropdown_handler.py:12
 msgid "Select an answer"
 msgstr "Dewiswch ateb"
 
-#: app/helpers/template_helper.py:19
-msgid "Office for National Statistics logo"
-msgstr "logo Swyddfa Ystadegau Gwladol"
+#: app/forms/error_messages.py:19
+#, python-format
+msgid "Select at least one answer <span class=\"u-vh\">to ‘%(question_title)s’</span>"
+msgstr "Dewiswch o leiaf un ateb <span class=\"u-vh\">to ‘%(question_title)s’</span>"
 
-#: app/helpers/template_helper.py:28 app/helpers/template_helper.py:36
-msgid "Census 2021"
-msgstr "Cyfrifiad 2021"
-
-#: app/helpers/template_helper.py:32
-msgid "Northern Ireland Statistics and Research Agency logo"
+#: app/forms/error_messages.py:22
+msgid "Enter a date"
 msgstr ""
 
-#: app/validation/error_messages.py:7 app/validation/error_messages.py:8
-#: app/validation/error_messages.py:9 app/validation/error_messages.py:10
-msgid "Enter an answer to continue."
-msgstr "Nodwch ateb i barhau."
+#: app/forms/error_messages.py:23 templates/partials/answers/address.html:54
+msgid "Enter an address"
+msgstr "Rhowch gyfeiriad"
 
-#: app/validation/error_messages.py:11 app/validation/error_messages.py:12
-msgid "Select an answer to continue."
-msgstr "Dewiswch ateb i barhau."
+#: app/forms/error_messages.py:24
+msgid "Enter a duration"
+msgstr ""
 
-#: app/validation/error_messages.py:13
-msgid "Select all that apply to continue."
-msgstr "Dewiswch bopeth sy'n gymwys i barhau."
+#: app/forms/error_messages.py:25
+msgid "Enter an email address"
+msgstr ""
 
-#: app/validation/error_messages.py:14
-msgid "Enter a date to continue."
-msgstr "Nodwch ddyddiad i barhau."
+#: app/forms/error_messages.py:26
+msgid "Enter a UK mobile number"
+msgstr "Rhowch rif ffôn symudol yn y Deyrnas Unedig"
 
-#: app/validation/error_messages.py:15
-msgid "Enter a duration to continue."
-msgstr "Nodwch gyfnod o amser i barhau."
-
-#: app/validation/error_messages.py:16
+#: app/forms/error_messages.py:27
 #, python-format
-msgid "Enter an answer more than or equal to %(min)s."
-msgstr "Nodwch ateb mwy na neu'n hafal i %(min)s."
+msgid "Enter an answer more than or equal to %(min)s"
+msgstr ""
 
-#: app/validation/error_messages.py:17
+#: app/forms/error_messages.py:28
 #, python-format
-msgid "Enter an answer less than or equal to %(max)s."
-msgstr "Nodwch ateb llai na neu'n hafal i %(max)s."
+msgid "Enter an answer less than or equal to %(max)s"
+msgstr "Nodwch ateb sy'n llai nag 20 neu'n hafal iddo %(max)s"
 
-#: app/validation/error_messages.py:18
+#: app/forms/error_messages.py:29
 #, python-format
-msgid "Enter an answer more than %(min)s."
-msgstr "Nodwch ateb mwy na %(min)s."
+msgid "Enter an answer more than %(min)s"
+msgstr ""
 
-#: app/validation/error_messages.py:19
+#: app/forms/error_messages.py:30
 #, python-format
-msgid "Enter an answer less than %(max)s."
-msgstr "Rhowch ateb o dan %(max)s."
+msgid "Enter an answer less than %(max)s"
+msgstr ""
 
-#: app/validation/error_messages.py:20
+#: app/forms/error_messages.py:31
 #, python-format
 msgid "Enter answers that add up to %(total)s"
 msgstr "Nodwch atebion sy'n creu cyfanswm o %(total)s."
 
-#: app/validation/error_messages.py:21
+#: app/forms/error_messages.py:32
 #, python-format
 msgid "Enter answers that add up to or are less than %(total)s"
 msgstr "Nodwch atebion sy'n creu cyfanswm o neu sydd o dan %(total)s"
 
-#: app/validation/error_messages.py:24
+#: app/forms/error_messages.py:35
 #, python-format
 msgid "Enter answers that add up to less than %(total)s"
 msgstr "Nodwch atebion sy'n creu cyfanswm sydd o dan %(total)s"
 
-#: app/validation/error_messages.py:27
+#: app/forms/error_messages.py:38
 #, python-format
 msgid "Enter answers that add up to greater than %(total)s"
 msgstr "Nodwch atebion sy'n creu cyfanswm sydd dros %(total)s"
 
-#: app/validation/error_messages.py:30
+#: app/forms/error_messages.py:41
 #, python-format
 msgid "Enter answers that add up to or are greater than %(total)s"
 msgstr "Nodwch atebion sy'n creu cyfanswm o neu sydd dros %(total)s"
 
-#: app/validation/error_messages.py:33
-msgid "Enter a number."
-msgstr "Nodwch rif."
+#: app/forms/error_messages.py:44
+msgid "Enter an email in a valid format, for example name@example.com"
+msgstr ""
 
-#: app/validation/error_messages.py:34
-msgid "Enter a whole number."
-msgstr "Nodwch gyfanrif."
+#: app/forms/error_messages.py:47
+msgid "Enter a number"
+msgstr "Nodwch rif"
 
-#: app/validation/error_messages.py:35
+#: app/forms/error_messages.py:48
+msgid "Enter a whole number"
+msgstr ""
+
+#: app/forms/error_messages.py:49
 #, python-format
-msgid "Enter a number rounded to %(max)d decimal places."
-msgstr "Nodwch rif wedi'i dalgrynnu i %(max)d lle degol."
+msgid "Enter a number rounded to %(max)d decimal places"
+msgstr ""
 
-#: app/validation/error_messages.py:38
+#: app/forms/error_messages.py:50
 #, python-format
-msgid "Your answer is too long, it has to be less than %(max)d characters."
-msgstr "Mae eich ateb yn rhy hir, rhaid iddo fod o dan %(max)d llythyren "
+msgid "You have entered too many characters. Enter up to %(max)d characters"
+msgstr "You have entered too many characters. Enter up to %(max)d characters"
 
-#: app/validation/error_messages.py:41
-msgid "Enter a valid date."
-msgstr "Nodwch ddyddiad dilys."
+#: app/forms/error_messages.py:53
+msgid "Enter a valid date"
+msgstr "Nodwch ddyddiad dilys"
 
-#: app/validation/error_messages.py:42
-msgid "Enter a 'period to' date later than the 'period from' date."
-msgstr "Nodwch ddyddiad 'cyfnod i' sy'n hwyrach na'r dyddiad 'cyfnod o'."
+#: app/forms/error_messages.py:54
+msgid "Enter a 'period to' date later than the 'period from' date"
+msgstr ""
 
-#: app/validation/error_messages.py:45
-msgid "Enter a valid duration."
-msgstr "Nodwch gyfnod o amser dilys."
+#: app/forms/error_messages.py:57
+msgid "Enter a valid duration"
+msgstr ""
 
-#: app/validation/error_messages.py:46
+#: app/forms/error_messages.py:58
+msgid "Enter a UK mobile number in a valid format, for example, 07700 900345 or +44 7700 900345"
+msgstr "Rhowch rif ffôn symudol yn y Deyrnas Unedig mewn fformat dilys, er enghraifft, 07700 912345 neu +44 7700 912345"
+
+#: app/forms/error_messages.py:61
 #, python-format
-msgid "Enter a reporting period greater than or equal to %(min)s."
-msgstr "Nodwch gyfnod adrodd sy'n fwy na neu'n hafal i %(min)s."
+msgid "Enter a reporting period greater than or equal to %(min)s"
+msgstr ""
 
-#: app/validation/error_messages.py:49
+#: app/forms/error_messages.py:64
 #, python-format
-msgid "Enter a reporting period less than or equal to %(max)s."
-msgstr "Nodwch gyfnod adrodd sy'n llai na neu'n hafal i %(max)s."
+msgid "Enter a reporting period less than or equal to %(max)s"
+msgstr ""
 
-#: app/validation/error_messages.py:52
+#: app/forms/error_messages.py:67
 #, python-format
-msgid "Enter a date after %(min)s."
-msgstr "Nodwch ddyddiad ar ôl %(min)s."
+msgid "Enter a date after %(min)s"
+msgstr "Nodwch ddyddiad ar ôl %(min)s"
 
-#: app/validation/error_messages.py:53
+#: app/forms/error_messages.py:68
 #, python-format
-msgid "Enter a date before %(max)s."
-msgstr "Nodwch ddyddiad cyn %(max)s."
+msgid "Enter a date before %(max)s"
+msgstr "Nodwch ddyddiad cyn %(max)s"
 
-#: app/validation/error_messages.py:54
-msgid "Remove an answer to continue."
-msgstr "Dilëwch ateb i barhau."
+#: app/forms/error_messages.py:69
+msgid "Remove an answer"
+msgstr ""
 
-#: app/validation/validators.py:351
+#: app/forms/validators.py:349
 #, python-format
 msgid "%(num)s day"
 msgid_plural "%(num)s days"
@@ -200,95 +208,483 @@ msgstr[3] "%(num)s diwrnod"
 msgstr[4] "%(num)s diwrnod"
 msgstr[5] "%(num)s diwrnod"
 
-#: app/views/contexts/hub_context.py:15 app/views/contexts/hub_context.py:17
-msgid "Submit survey"
-msgstr "Cyflwyno'r arolwg"
+#: app/forms/fields/select_field_with_detail_answer.py:35
+msgid "Not a valid choice"
+msgstr "Ddim yn ddewis dilys"
 
-#: app/views/contexts/hub_context.py:16 templates/summary.html:17
-msgid "Please submit this survey to complete it"
-msgstr "Cyflwynwch yr arolwg hwn i'w gwblhau"
+#: app/helpers/template_helpers.py:20
+msgid "Office for National Statistics logo"
+msgstr "logo Swyddfa Ystadegau Gwladol"
 
-#: app/views/contexts/hub_context.py:20
-msgid "Choose another section to complete"
-msgstr "Dewiswch adran arall i'w chwblhau"
+#: app/helpers/template_helpers.py:29 app/helpers/template_helpers.py:38
+#: app/helpers/template_helpers.py:59 templates/signed-out.html:3
+msgid "Census 2021"
+msgstr "Cyfrifiad 2021"
 
-#: app/views/contexts/hub_context.py:21
-msgid "You must complete all sections in order to submit this survey"
-msgstr "Rhaid i chi gwblhau pob adran er mwyn cyflwyno'r arolwg hwn"
+#: app/helpers/template_helpers.py:34
+msgid "Northern Ireland Statistics and Research Agency logo"
+msgstr ""
 
-#: app/views/contexts/hub_context.py:24 templates/confirmation.html:12
-#: templates/interstitial.html:5
-msgid "Continue"
-msgstr "Parhau"
+#: app/questionnaire/placeholder_transforms.py:92
+msgid "{number_of_years} year"
+msgid_plural "{number_of_years} years"
+msgstr[0] "{number_of_years} oed"
+msgstr[1] "{number_of_years} oed"
+msgstr[2] "{number_of_years} oed"
+msgstr[3] "{number_of_years} oed"
+msgstr[4] "{number_of_years} oed"
+msgstr[5] "{number_of_years} oed"
 
-#: app/views/contexts/hub_context.py:30
+#: app/questionnaire/placeholder_transforms.py:98
+msgid "{number_of_months} month"
+msgid_plural "{number_of_months} months"
+msgstr[0] "{number_of_months} mis oed"
+msgstr[1] "{number_of_months} mis oed"
+msgstr[2] "{number_of_months} fis oed"
+msgstr[3] "{number_of_months} mis oed"
+msgstr[4] "{number_of_months} mis oed"
+msgstr[5] "{number_of_months} mis oed"
+
+#: app/questionnaire/placeholder_transforms.py:103
+msgid "{number_of_days} day"
+msgid_plural "{number_of_days} days"
+msgstr[0] "{number_of_days} diwrnod oed"
+msgstr[1] "{number_of_days} diwrnod oed"
+msgstr[2] "{number_of_days} ddiwrnod oed"
+msgstr[3] "{number_of_days} diwrnod oed"
+msgstr[4] "{number_of_days} diwrnod oed"
+msgstr[5] "{number_of_days} diwrnod oed"
+
+#: app/routes/errors.py:107
+msgid "You have reached the maximum number of individual access codes"
+msgstr "Rydych wedi cyrraedd y nifer fwyaf o godau mynediad unigol"
+
+#: app/routes/errors.py:110
+msgid "If you need more individual access codes, please <a href='{contact_us_url}'>contact us</a>."
+msgstr ""
+
+#: app/routes/errors.py:126
+msgid "You have reached the maximum number of times for submitting feedback"
+msgstr "Ni allwch gyflwyno rhagor o adborth"
+
+#: app/routes/errors.py:129
+msgid "If you need to give more feedback, please <a href='{contact_us_url}'>contact us</a>."
+msgstr "<a href='{contact_us_url}'>Cysylltwch â ni </a>os bydd angen i chi roi adborth."
+
+#: app/routes/errors.py:161
+msgid "Sorry, there was a problem sending the access code"
+msgstr "Mae'n ddrwg gennym, roedd problem wrth anfon y cod"
+
+#: app/routes/errors.py:167
+msgid "You can try to <a href='{retry_url}'>request a new access code again</a>."
+msgstr ""
+
+#: app/routes/errors.py:170 app/routes/errors.py:192
+msgid "If this problem keeps happening, please <a href='{contact_us_url}'>contact us</a> for help."
+msgstr ""
+
+#: app/routes/errors.py:188
+msgid "Sorry, there was a problem sending the confirmation email"
+msgstr ""
+
+#: app/routes/errors.py:189
+msgid "You can try to <a href='{retry_url}'>send the email again</a>."
+msgstr ""
+
+#: app/routes/individual_response.py:160
+msgid "An individual access code has been sent by post"
+msgstr ""
+
+#: app/routes/individual_response.py:252
+msgid "An individual access code has been sent by text"
+msgstr ""
+
+#: app/views/contexts/hub_context.py:15
 msgid "Completed"
 msgstr "Cwblhawyd"
 
-#: app/views/contexts/hub_context.py:32
+#: app/views/contexts/hub_context.py:17
 msgid "View answers"
 msgstr "Gweld yr atebion"
 
-#: app/views/contexts/hub_context.py:33
+#: app/views/contexts/hub_context.py:18
 msgid "View answers for {section_name}"
 msgstr "Gweld yr atebion ar gyfer {section_name}"
 
-#: app/views/contexts/hub_context.py:37
+#: app/views/contexts/hub_context.py:22
 msgid "Partially completed"
-msgstr "Cwblhawyd yn rhannol"
+msgstr "Wedi’i chwblhau’n rhannol"
 
-#: app/views/contexts/hub_context.py:39
+#: app/views/contexts/hub_context.py:24
 msgid "Continue with section"
 msgstr "Parhau â'r adran"
 
-#: app/views/contexts/hub_context.py:40
+#: app/views/contexts/hub_context.py:25
 msgid "Continue with {section_name} section"
-msgstr "Parhau ag adran {section_name}"
+msgstr "Parhau â’r adran {section_name}"
 
-#: app/views/contexts/hub_context.py:44
+#: app/views/contexts/hub_context.py:29
 msgid "Not started"
 msgstr "Heb ddechrau"
 
-#: app/views/contexts/hub_context.py:46
+#: app/views/contexts/hub_context.py:31
 msgid "Start section"
 msgstr "Dechrau'r adran"
 
-#: app/views/contexts/hub_context.py:47
+#: app/views/contexts/hub_context.py:32
 msgid "Start {section_name} section"
 msgstr "Dechrau adran {section_name}"
 
-#: app/views/contexts/list_collector.py:12
+#: app/views/contexts/hub_context.py:36
+msgid "Separate census requested"
+msgstr "Cais am gyfrifiad ar wahân"
+
+#: app/views/contexts/hub_context.py:38 app/views/contexts/hub_context.py:39
+msgid "Change or resend"
+msgstr "Newid neu ailanfon"
+
+#: app/views/contexts/hub_context.py:49 app/views/contexts/hub_context.py:50
+msgid "Submit survey"
+msgstr "Cyflwyno'r arolwg"
+
+#: app/views/contexts/hub_context.py:54
+msgid "You must submit this survey to complete it"
+msgstr ""
+
+#: app/views/contexts/hub_context.py:61
+msgid "Choose another section to complete"
+msgstr "Dewiswch adran arall i'w chwblhau"
+
+#: app/views/contexts/hub_context.py:62
+#: templates/individual_response/confirmation-post.html:21
+#: templates/individual_response/confirmation-text-message.html:31
+#: templates/individual_response/question.html:5 templates/interstitial.html:8
+#: templates/sectionsummary.html:11 templates/sectionsummary.html:53
+msgid "Continue"
+msgstr "Parhau"
+
+#: app/views/contexts/list_context.py:104
 msgid " (You)"
 msgstr " (Chi)"
 
-#: templates/confirmation.html:6 templates/confirmation.html:37
+#: app/views/contexts/questionnaire_summary_context.py:15
+msgid "Check your answers and submit"
+msgstr "Gwiriwch eich atebion a'u cyflwyno"
+
+#: app/views/contexts/questionnaire_summary_context.py:18
+#: templates/confirmation.html:6 templates/confirmation.html:27
 msgid "Submit answers"
 msgstr "Cyflwyno atebion"
 
-#: templates/confirmation.html:22
+#: app/views/contexts/questionnaire_summary_context.py:21
+msgid "Please submit this survey to complete it"
+msgstr "Cyflwynwch yr arolwg hwn i'w gwblhau"
+
+#: app/views/handlers/confirmation_email.py:18
+msgid "Confirmation email"
+msgstr ""
+
+#: app/views/handlers/confirmation_email.py:34
+#: app/views/handlers/feedback.py:110 app/views/handlers/question.py:149
+msgid "Error: {page_title}"
+msgstr ""
+
+#: app/views/handlers/feedback.py:23
+msgid "Feedback"
+msgstr ""
+
+#: app/views/handlers/feedback.py:27
+msgid "Give feedback about this service"
+msgstr "Rhoi adborth ar y gwasanaeth hwn"
+
+#: app/views/handlers/feedback.py:28 app/views/handlers/feedback.py:53
+msgid "Select what your feedback is about"
+msgstr "Dewiswch am beth mae eich adborth yn sôn"
+
+#: app/views/handlers/feedback.py:36 app/views/handlers/feedback.py:37
+msgid "The census questions"
+msgstr "Cwestiynau’r cyfrifiad"
+
+#: app/views/handlers/feedback.py:38
+msgid "For example, question not clear, answer option not relevant"
+msgstr "Er enghraifft, nid yw’r cwestiynau’n glir, opsiynau ddim yn berthnasol"
+
+#: app/views/handlers/feedback.py:43 app/views/handlers/feedback.py:44
+msgid "Page design and structure"
+msgstr "Dyluniad a strwythur tudalen"
+
+#: app/views/handlers/feedback.py:47 app/views/handlers/feedback.py:48
+msgid "General feedback about this service"
+msgstr "Adborth cyffredinol ar y gwasanaeth hwn"
+
+#: app/views/handlers/feedback.py:61 app/views/handlers/feedback.py:71
+msgid "Enter your feedback"
+msgstr "Rhowch eich adborth"
+
+#: app/views/handlers/feedback.py:62
+msgid "Do not include confidential information, such as your contact details."
+msgstr "Peidiwch â chynnwys gwybodaeth gyfrinachol, fel eich manylion cyswllt."
+
+#: app/views/handlers/individual_response.py:125
+msgid "Person {list_item_position}"
+msgstr ""
+
+#: app/views/handlers/individual_response.py:231
+msgid "Cannot answer questions for others in your household"
+msgstr ""
+
+#: app/views/handlers/individual_response.py:297
+msgid "How would you like <em>{person_name}</em> to receive a separate census?"
+msgstr "Sut hoffech chi i <em>{person_name}</em> gael cyfrifiad ar wahân?"
+
+#: app/views/handlers/individual_response.py:305
+msgid "For someone to complete a separate census, we need to send them an individual access code."
+msgstr "Er mwyn i rywun allu cwblhau cyfrifiad ar wahân, bydd angen i ni anfon cod mynediad unigol ato."
+
+#: app/views/handlers/individual_response.py:308
+msgid "Select how to send access code"
+msgstr "Dewiswch sut i anfon y cod mynediad"
+
+#: app/views/handlers/individual_response.py:318
+msgid "Text message"
+msgstr "Neges destun"
+
+#: app/views/handlers/individual_response.py:320
+msgid "We will need their mobile number for this"
+msgstr "Bydd angen rhif ffôn symudol yr unigolyn arnom ar gyfer hyn"
+
+#: app/views/handlers/individual_response.py:325
+msgid "Post"
+msgstr "Post"
+
+#: app/views/handlers/individual_response.py:327
+msgid "We can only send this to an unnamed resident at the registered household address"
+msgstr "Dim ond i gyfeiriad cofrestredig y cartref y gallwn anfon hwn"
+
+#: app/views/handlers/individual_response.py:377
+msgid "Send individual access code"
+msgstr ""
+
+#: app/views/handlers/individual_response.py:408
+msgid "How would you like to answer <em>{person_name_possessive}</em> questions?"
+msgstr "Sut hoffech chi ateb cwestiynau<em>{person_name_possessive}</em>?"
+
+#: app/views/handlers/individual_response.py:423
+msgid "I would like to request a separate census for them to complete"
+msgstr "Hoffwn i wneud cais am gyfrifiad ar wahân i’r unigolyn ei gwblhau"
+
+#: app/views/handlers/individual_response.py:429
+msgid "I will ask them to answer their own questions"
+msgstr "Byddaf yn gofyn i’r unigolyn ateb ei gwestiynau ei hun"
+
+#: app/views/handlers/individual_response.py:433
+msgid "They will need the household access code from the letter we sent you"
+msgstr "Bydd angen cod mynediad y cartref ar yr unigolyn o’r llythyr y gwnaethom ei anfon atoch"
+
+#: app/views/handlers/individual_response.py:439
+msgid "I will answer for {person_name}"
+msgstr "Byddaf yn ateb ar ran{person_name}"
+
+#: app/views/handlers/individual_response.py:540
+msgid "Do you want to send an individual access code for {person_name} by post?"
+msgstr "Ydych chi am anfon cod mynediad unigol at{person_name} drwy’r post?"
+
+#: app/views/handlers/individual_response.py:548
+msgid "A letter with an individual access code will be sent to your registered household address"
+msgstr "Bydd llythyr â chod mynediad unigol yn cael ei anfon i gyfeiriad cofrestredig eich cartref"
+
+#: app/views/handlers/individual_response.py:555
+msgid "The letter will be addressed to <strong>Individual Resident</strong> instead of the name provided"
+msgstr "Bydd y llythyr wedi'i gyfeirio at y<strong> Preswylydd Unigol</strong> yn hytrach na'r enw a gafodd ei roi"
+
+#: app/views/handlers/individual_response.py:568
+msgid "Yes, send the access code by post"
+msgstr "Ydw, anfonwch y cod mynediad drwy'r post"
+
+#: app/views/handlers/individual_response.py:574
+msgid "No, send it another way"
+msgstr "Nac ydw, anfonwch y cod mynediad mewn ffordd arall"
+
+#: app/views/handlers/individual_response.py:607
+msgid "Confirm address"
+msgstr ""
+
+#: app/views/handlers/individual_response.py:662
+#: app/views/handlers/individual_response.py:700
+msgid "Separate Census"
+msgstr ""
+
+#: app/views/handlers/individual_response.py:666
+msgid "Who do you need to request a separate census for?"
+msgstr "Ar gyfer pwy y mae angen i chi wneud cais am gyfrifiad ar wahân?"
+
+#: app/views/handlers/individual_response.py:724
+msgid "What is <em>{person_name_possessive}</em> mobile number?"
+msgstr "Beth yw rhif ffôn symudol<em>{person_name_possessive}</em>?"
+
+#: app/views/handlers/individual_response.py:736
+msgid "UK mobile number"
+msgstr "Rhif ffôn symudol"
+
+#: app/views/handlers/individual_response.py:737
+msgid "This will not be stored and only used once to send the access code"
+msgstr "Ni chaiff ei storio a bydd ond yn cael ei ddefnyddio unwaith i anfon y cod mynediad"
+
+#: app/views/handlers/individual_response.py:770
+msgid "Mobile number"
+msgstr ""
+
+#: app/views/handlers/individual_response.py:816
+msgid "Is this mobile number correct?"
+msgstr "Ydy’r rhif ffôn symudol hwn yn gywir?"
+
+#: app/views/handlers/individual_response.py:825
+msgid "Yes, send the text"
+msgstr "Ydy, anfonwch y neges destun nawr"
+
+#: app/views/handlers/individual_response.py:829
+msgid "No, I need to change it"
+msgstr "Nac ydy, mae angen i mi ei newid"
+
+#: app/views/handlers/individual_response.py:863
+msgid "Confirm mobile number"
+msgstr ""
+
+#: app/views/handlers/thank_you.py:19 templates/census-thank-you.html:24
+msgid "Thank you for completing the census"
+msgstr "Diolch am gwblhau'r cyfrifiad"
+
+#: templates/census-thank-you.html:9 templates/confirmation-email.html:8
+msgid "There is a problem with this page"
+msgstr ""
+
+#: templates/census-thank-you.html:22
+msgid "Thank you for completing your census"
+msgstr "Diolch am gwblhau'r cyfrifiad"
+
+#: templates/census-thank-you.html:26
+msgid "Thank you for completing the survey"
+msgstr ""
+
+#: templates/census-thank-you.html:32
+msgid "Your individual census has been submitted for <strong>{display_address}</strong>."
+msgstr "Mae eich cyfrifiad unigol wedi cael ei gyflwyno ar gyfer <strong>{display_address}</strong>."
+
+#: templates/census-thank-you.html:34
+msgid "Your census has been submitted for the household at <strong>{display_address}</strong>."
+msgstr "Mae eich cyfrifiad wedi cael ei gyflwyno ar gyfer y cartref yn <strong>{display_address}</strong>."
+
+#: templates/census-thank-you.html:36
+msgid "Your census has been submitted for the accommodation at <strong>{display_address}</strong>."
+msgstr "Mae eich cyfrifiad wedi cael ei gyflwyno ar gyfer y llety yn {display_address}."
+
+#: templates/census-thank-you.html:37
+msgid "Anyone staying at this accommodation for at least 6 months needs to fill in their own individual census, including staff. Your Census Officer will provide you with census forms for your residents."
+msgstr "Bydd angen i unrhyw un sy'n aros yn y llety hwn am o leiaf 6 mis lenwi ei gyfrifiad unigol ei hun, gan gynnwys y staff. Bydd Swyddog y Cyfrifiad yn dosbarthu ffurflenni'r cyfrifiad i'ch preswylwyr."
+
+#: templates/census-thank-you.html:49
+msgid "Your personal information is protected by law and will be kept confidential."
+msgstr "Mae eich gwybodaeth bersonol wedi'i diogelu gan y gyfraith a chaiff ei chadw'n gyfrinachol."
+
+#: templates/census-thank-you.html:55
+msgid "Get confirmation email"
+msgstr "Cael e-bost cadarnhau"
+
+#: templates/census-thank-you.html:56
+msgid "If you would like to be sent confirmation that you have completed your census enter your email address."
+msgstr "Os hoffech gael cadarnhad eich bod wedi cwblhau eich cyfrifiad, nodwch eich cyfeiriad e-bost."
+
+#: templates/confirmation-email-sent.html:3
+msgid "Confirmation email sent"
+msgstr ""
+
+#: templates/confirmation-email-sent.html:16
+msgid "A confirmation email has been sent to {email}"
+msgstr "Mae e-bost cadarnhau wedi cael ei anfon i {email}"
+
+#: templates/confirmation-email-sent.html:25
+msgid "The email will be sent from <em>census.2021@notifications.service.gov.uk</em>"
+msgstr "Caiff yr e-bost ei anfon gan <em>census.2021@notifications.service.gov.uk</em>"
+
+#: templates/confirmation-email-sent.html:29
+msgid "Didn't receive an email?"
+msgstr "Heb gael e-bost?"
+
+#: templates/confirmation-email-sent.html:30
+msgid "It can take a few minutes for the email to arrive. If it doesn't arrive, check your junk mail, or you can <a href='{send_confirmation_email_url}' id='send-another-email'>send another confirmation email</a>."
+msgstr "Gall gymryd ychydig funudau i’r e-bost gyrraedd. Os na fydd yn cyrraedd, edrychwch yn eich ffolder post sothach, neu gallwch<a href='{send_confirmation_email_url}' id='send-another-email'> anfon e-bost cadarnhau arall</a>."
+
+#: templates/confirmation-email.html:12
+msgid "Send another confirmation email"
+msgstr ""
+
+#: templates/confirmation.html:12
 msgid "Yes, I confirm these are correct"
 msgstr "Ydw, rwy'n cadarnhau bod y rhain yn gywir"
 
-#: templates/confirmation.html:42
+#: templates/confirmation.html:32
 msgid "Submitting"
 msgstr "Yn cyflwyno"
 
-#: templates/introduction.html:15
+#: templates/feedback-sent.html:6
+msgid "Feedback sent"
+msgstr ""
+
+#: templates/feedback-sent.html:19
+msgid "Thank you for your feedback"
+msgstr "Diolch am eich adborth"
+
+#: templates/feedback-sent.html:20
+msgid "Your comments will help us make improvements to our surveys. We are not able to reply to comments, but we appreciate your feedback"
+msgstr "Bydd eich sylwadau yn ein helpu ni i wella ein harolygon. Ni allwn ymateb i sylwadau, ond rydym yn gwerthfawrogi eich adborth"
+
+#: templates/feedback.html:15
+msgid "Back"
+msgstr "Yn ôl"
+
+#: templates/feedback.html:28
+#, python-format
+msgid "There is a problem with your feedback"
+msgid_plural "There are %(num)s problems with your feedback"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+msgstr[4] ""
+msgstr[5] ""
+
+#: templates/feedback.html:41
+msgid "Send feedback"
+msgstr "Anfon adborth"
+
+#: templates/hub.html:39
+msgid "If you can’t answer someone else’s questions"
+msgstr "Os na allwch chi ateb cwestiynau rhywun arall"
+
+#: templates/interstitial.html:23 templates/partials/question.html:25
+msgid "If you can’t answer questions for this person"
+msgstr "Os na allwch ateb cwestiynau ar ran y person hwn"
+
+#: templates/introduction.html:10
+msgid "Introduction"
+msgstr ""
+
+#: templates/introduction.html:17
 #, python-format
 msgid "You are completing this for <span>%(ru_name)s</span> (%(trading_as_name)s)"
 msgstr "Rydych chi'n cwblhau hwn ar gyfer <span>%(ru_name)s</span> (%(trading_as_name)s)"
 
-#: templates/introduction.html:19
+#: templates/introduction.html:21
 #, python-format
 msgid "You are completing this for <span>%(ru_name)s</span>"
 msgstr "Rydych chi'n cwblhau hwn ar gyfer <span>%(ru_name)s</span>"
 
-#: templates/introduction.html:23
+#: templates/introduction.html:25
 #, python-format
 msgid "If the company details or structure have changed contact us on %(telephone_number)s or email %(email_address)s"
 msgstr "Os yw manylion neu strwythur y cwmni wedi newid, cysylltwch â ni ar %(telephone_number)s neu e-bost % (email_address)s"
 
-#: templates/introduction.html:38
+#: templates/introduction.html:40
 msgid "Your response is legally required"
 msgstr "Mae eich ymateb yn ofynnol yn gyfreithiol"
 
@@ -304,26 +700,16 @@ msgstr "Yn anffodus, dim ond un arolwg y gallwch chi ei gwblhau ar y tro"
 msgid "Close this window to continue with your current survey"
 msgstr "Caewch y ffenestr hon i barhau â'ch arolwg presennol"
 
-#: templates/question.html:16
+#: templates/partials/answers/address.html:53 templates/question.html:10
 #, python-format
-msgid "This page has an error"
-msgid_plural "This page has %(num)s errors"
-msgstr[0] "Mae gwall ar y dudalen hon"
-msgstr[1] "Mae %(num)s gwall ar y dudalen hon"
-msgstr[2] "Mae %(num)s wall ar y dudalen hon"
-msgstr[3] "Mae %(num)s wall ar y dudalen hon"
-msgstr[4] "Mae %(num)s wall ar y dudalen hon"
-msgstr[5] "Mae %(num)s wall ar y dudalen hon"
-
-#: templates/question.html:22
-msgid "This <strong>must be corrected</strong> to continue"
-msgid_plural "These <strong>must be corrected</strong> to continue"
-msgstr[0] "Mae'n <strong>rhaid cywiro</strong> hwn cyn parhau"
-msgstr[1] "Mae'n <strong>rhaid cywiro'r</strong> rhain cyn parhau"
-msgstr[2] "Mae'n <strong>rhaid cywiro'r</strong> rhain cyn parhau"
-msgstr[3] "Mae'n <strong>rhaid cywiro'r</strong> rhain cyn parhau"
-msgstr[4] "Mae'n <strong>rhaid cywiro'r</strong> rhain cyn parhau"
-msgstr[5] "Mae'n <strong>rhaid cywiro'r</strong> rhain cyn parhau"
+msgid "There is a problem with your answer"
+msgid_plural "There are %(num)s problems with your answer"
+msgstr[0] "Mae problem gyda'ch ateb"
+msgstr[1] "Mae problem gyda'ch ateb"
+msgstr[2] "Mae %(num)s broblem gyda'ch ateb"
+msgstr[3] "Mae %(num)s broblem gyda'ch ateb"
+msgstr[4] "Mae %(num)s broblem gyda'ch ateb"
+msgstr[5] "Mae %(num)s broblem gyda'ch ateb"
 
 #: templates/signed-out.html:3
 msgid "Signed out"
@@ -337,98 +723,73 @@ msgstr "Mae eich atebion i'r arolwg wedi'u cadw. Rydych chi nawr wedi'ch allgofn
 msgid "Return to your account"
 msgstr "Dychwelyd i'ch cyfrif"
 
-#: templates/summary.html:6
-msgid "Summary"
-msgstr "Crynodeb"
-
-#: templates/summary.html:11
-msgid "Check your answers and submit"
-msgstr "Gwiriwch eich atebion a'u cyflwyno"
-
-#: templates/summary.html:17
-msgid "Check your answers before submitting"
-msgstr "Gwiriwch eich atebion cyn eu cyflwyno"
-
-#: templates/summary.html:26
-msgid "Check your answers before continuing to the next section"
-msgstr "Gwiriwch eich atebion cyn parhau i'r adran nesaf"
-
-#: templates/summary.html:35
+#: templates/summary.html:28
 msgid "Please review your answers and confirm these are correct"
 msgstr "Adolygwch eich atebion a chadarnhewch fod y rhain yn gywir"
 
-#: templates/summary.html:64
-msgid "You will have the opportunity to view and print a copy of your answers after submitting this survey"
-msgstr "Byddwch yn cael y cyfle i weld ac argraffu copi o'ch atebion ar ôl cyflwyno'r arolwg hwn"
-
-#: templates/thank-you.html:3
-msgid "We've received your answers"
-msgstr "Rydym wedi derbyn eich atebion"
-
-#: templates/thank-you.html:7
-msgid "Thank you for submitting your census"
-msgstr "Diolch am gyflwyno eich cyfrifiad"
+#: templates/thank-you.html:4
+msgid "We’ve received your answers"
+msgstr ""
 
 #: templates/thank-you.html:9
-msgid "We have received your answers and you do not need to do anything else."
-msgstr "Rydym ni wedi cael eich atebion ac nid oes angen i chi wneud unrhyw beth arall."
+msgid "Submission successful"
+msgstr ""
 
-#: templates/view-submission.html:7
-msgid "Submission"
-msgstr "Cyflwyno"
+#: templates/thank-you.html:21
+msgid "Your answers were submitted for <span>{ru_name}</span> ({trading_as_name}) on {submitted_date_time}"
+msgstr ""
 
-#: templates/view-submission.html:10
-msgid "Submitted answers"
-msgstr "Atebion a gyflwynwyd"
+#: templates/thank-you.html:26
+msgid "Your answers were submitted for <span>{ru_name}</span> on {submitted_date_time}"
+msgstr ""
 
-#: templates/view-submission.html:19
-#, python-format
-msgid "Your answers were submitted for <span>%(ru_name)s</span> (%(trading_as_name)s) on %(submitted_time)s"
-msgstr "Cyflwynwyd eich atebion ar gyfer <span>%(ru_name)s</span> (%(trading_as_name)s) ar %(submitted_time)s"
+#: templates/thank-you.html:32
+msgid "Transaction ID: <b>{transaction_id}</b>"
+msgstr ""
 
-#: templates/view-submission.html:24
-#, python-format
-msgid "Your answers were submitted for <span>%(ru_name)s</span> on %(submitted_time)s"
-msgstr "Cyflwynwyd eich atebion ar gyfer <span>%(ru_name)s</span> ar %(submitted_time)s"
+#: templates/thank-you.html:35
+msgid "Your answers will be processed in the next few weeks."
+msgstr ""
 
-#: templates/view-submission.html:29
-msgid "Transaction ID"
-msgstr "Rhif Adnabod y Trafodiad"
+#: templates/thank-you.html:36
+msgid "We may contact you to query your answers via phone or secure message."
+msgstr ""
 
-#: templates/view-submission.html:36
-msgid "Print this page"
-msgstr "Argraffu'r dudalen hon"
+#: templates/thank-you.html:37
+msgid "For more information on how we use this data."
+msgstr ""
 
-#: templates/errors/403.html:3
-msgid "Authorisation refused"
-msgstr "Awdurdodiad wedi'i wrthod"
-
-#: templates/errors/403.html:3 templates/errors/404.html:3
-#: templates/errors/500.html:3
-msgid "Office for National Statistics"
-msgstr "Swyddfa Ystadegau Gwladol"
-
-#: templates/errors/403.html:6
+#: templates/errors/403.html:3 templates/errors/403.html:6
+#: templates/errors/submission-failed.html:5
+#: templates/errors/submission-failed.html:8
 msgid "Sorry, there is a problem"
 msgstr "Mae'n ddrwg gennym, mae problem wedi codi"
 
 #: templates/errors/403.html:7
-msgid "To access this page you need to <a href='#'>enter your unique access code.</a>"
-msgstr "I fynd i'r dudalen hon, mae angen i chi <a href='#'>roi eich cod mynediad unigryw.</a>"
+msgid "You may need to update your browser to a newer version."
+msgstr "Efallai y bydd angen i chi ddiweddaru eich porwr i fersiwn fwy newydd."
 
-#: templates/errors/404.html:3 templates/errors/404.html:13
+#: templates/errors/403.html:8
+msgid "If the problem still occurs, try using a different browser or device."
+msgstr "Os bydd y broblem yn parhau, rhowch gynnig ar ddefnyddio porwr neu ddyfais wahanol."
+
+#: templates/errors/403.html:9
+msgid "For further help, please <a href='{url}'>contact us</a>."
+msgstr "I gael mwy o help, <a href='{url}'>cysylltwch â ni </a>."
+
+#: templates/errors/404.html:3 templates/errors/404.html:6
 msgid "Page not found"
 msgstr "Heb ddod o hyd i'r dudalen"
 
-#: templates/errors/404.html:14
+#: templates/errors/404.html:7
 msgid "If you entered a web address, check it is correct."
 msgstr "Os gwnaethoch chi roi cyfeiriad gwe, gwnewch yn siŵr ei fod yn gywir."
 
-#: templates/errors/404.html:15
+#: templates/errors/404.html:8
 msgid "If you pasted the web address, check you copied the whole address."
 msgstr "Os gwnaethoch chi ludo'r cyfeiriad gwe, gwnewch yn siŵr eich bod wedi copïo'r cyfeiriad cyfan."
 
-#: templates/errors/404.html:16
+#: templates/errors/404.html:9
 msgid "If the web address is correct or you selected a link or button, <a href='{url}'>contact us</a> for more help."
 msgstr "Os yw'r cyfeiriad gwe yn gywir, neu os gwnaethoch chi ddewis dolen neu fotwm, <a href='{url}'>cysylltwch â ni</a> am fwy o help."
 
@@ -436,98 +797,132 @@ msgstr "Os yw'r cyfeiriad gwe yn gywir, neu os gwnaethoch chi ddewis dolen neu f
 msgid "An error has occurred"
 msgstr "Mae gwall wedi digwydd"
 
-#: templates/errors/500.html:13
+#: templates/errors/500.html:6
 msgid "Sorry, there is a problem with this service"
 msgstr "Mae'n ddrwg gennym, mae problem gyda'r gwasanaeth hwn"
 
-#: templates/errors/500.html:14
+#: templates/errors/500.html:7
 msgid "Try again later."
 msgstr "Rhowch gynnig arall arni yn nes ymlaen."
 
-#: templates/errors/500.html:15
+#: templates/errors/500.html:8
 msgid "If you have started a survey, your answers have been saved."
 msgstr "Os ydych chi wedi dechrau arolwg, mae eich atebion wedi cael eu cadw."
 
-#: templates/errors/500.html:16
+#: templates/errors/500.html:9
 msgid "<a href='{url}'>Contact us</a> if you need to speak to someone about your survey."
 msgstr "<a href='{url}'>Cysylltwch â ni</a> os oes angen i chi siarad â rhywun am eich arolwg."
 
+#: templates/errors/no-cookie.html:3
+msgid "Page is not available"
+msgstr ""
+
+#: templates/errors/no-cookie.html:6
+msgid "Sorry there is a problem"
+msgstr "Mae'n ddrwg gennym, mae problem wedi codi"
+
+#: templates/errors/no-cookie.html:7
+msgid "To access this page you need to <a href='{url}'>enter your 16-character access code</a>."
+msgstr "I fynd i'r dudalen hon, bydd angen i chi <a href='{url}'> roi eich cod mynediad 16 nod</a>."
+
+#: templates/errors/session-expired.html:3
+msgid "Session timed out"
+msgstr ""
+
 #: templates/errors/session-expired.html:6
-msgid "Session expired"
-msgstr "Daeth y sesiwn i ben"
+msgid "Your session has timed out due to inactivity"
+msgstr "Mae eich sesiwn wedi cyrraedd y terfyn amser oherwydd anweithgarwch"
 
-#: templates/errors/session-expired.html:10
-msgid "Your session has expired"
-msgstr "Mae eich sesiwn wedi dod i ben"
+#: templates/errors/session-expired.html:7
+msgid "To help protect your information we have timed you out"
+msgstr "I ddiogelu eich gwybodaeth, rydyn ni wedi rhoi terfyn amser ar eich sesiwn"
 
-#: templates/errors/session-expired.html:18
-msgid "To help protect your information we have signed you out"
-msgstr "Er mwyn helpu i ddiogelu eich gwybodaeth rydym wedi'ch allgofnodi"
+#: templates/errors/session-expired.html:8
+msgid "You will need to <a href='{url}'>enter your 16-character access code</a> again to continue your census."
+msgstr "Bydd angen i chi <a href='{url}'> roi eich cod mynediad 16 nod </a> i barhau â'ch cyfrifiad."
 
-#: templates/errors/session-expired.html:20
-#, python-format
-msgid "We have saved your progress and you will need to <a href=\"%(account_service_link)s\">enter your unique code</a> to access the survey again."
-msgstr "Rydym wedi cadw eich cynnydd a bydd angen i chi <a href=\"%(account_service_link)s\">roi eich cod unigryw</a> i gael mynediad at yr arolwg eto."
+#: templates/errors/submission-complete.html:3
+msgid "Submission Complete"
+msgstr ""
 
-#: templates/layouts/_base.html:33
-msgid "We use cookies to improve your experience of census.gov.uk"
-msgstr "Rydym yn defnyddio cwcis i wella eich profiad o cyfrifiad.gov.uk"
+#: templates/errors/submission-complete.html:6
+msgid "This page is no longer available"
+msgstr "Nid yw'r dudalen hon ar gael mwyach"
 
-#: templates/layouts/_questionnaire.html:12
+#: templates/errors/submission-complete.html:7
+msgid "Your census has been submitted"
+msgstr "Mae eich cyfrifiad wedi cael ei gyflwyno"
+
+#: templates/errors/submission-failed.html:9
+msgid "You can try to <a href='{url}'>submit your census again</a>"
+msgstr "Gallwch geisio <a href='{url}'>cyflwyno eich cyfrifiad eto</a>"
+
+#: templates/errors/submission-failed.html:10
+msgid "If this problem keeps happening, please <a href='{url}'>contact us</a> for help."
+msgstr "Os bydd y broblem hon yn parhau, <a href='{url}'>cysylltwch â ni </a>i gael help."
+
+#: templates/individual_response/confirmation-post.html:17
+msgid "The letter with an individual access code should arrive soon for them to complete their own census"
+msgstr "Dylai’r llythyr â chod mynediad unigol gyrraedd yn fuan er mwyn i’r unigolyn allu llenwi ei gyfrifiad ei hun"
+
+#: templates/individual_response/confirmation-text-message.html:17
+msgid "The text message with an individual access code should arrive soon for them to complete their own census"
+msgstr "Dylai’r neges destun â chod mynediad unigol gyrraedd yn fuan er mwyn i’r unigolyn allu llenwi ei gyfrifiad ei hun"
+
+#: templates/individual_response/confirmation-text-message.html:26
+msgid "The text will be sent from <em>Census2021</em>"
+msgstr "Caiff y testun ei anfon gan <em>Census2021</em>"
+
+#: templates/individual_response/interstitial.html:8
+msgid "If you can't answer questions for others in your household"
+msgstr ""
+
+#: templates/individual_response/interstitial.html:9
+msgid "You can ask the people you live with to answer their own questions by sharing the household access code with them."
+msgstr "Gallwch ofyn i’r bobl rydych chi’n byw gyda nhw ateb eu cwestiynau eu hunain drwy rannu cod mynediad y cartref â nhw."
+
+#: templates/individual_response/interstitial.html:10
+msgid "If this is not possible, you can request a separate census for them to complete."
+msgstr "Os nad yw hyn yn bosibl, gallwch chi wneud cais am gyfrifiad ar wahân iddynt ei lenwi."
+
+#: templates/individual_response/interstitial.html:13
+msgid "Request separate census"
+msgstr "Gwneud cais am gyfrifiad ar wahân"
+
+#: templates/layouts/_base.html:18
 msgid "Previous"
 msgstr "Blaenorol"
 
-#: templates/layouts/_questionnaire.html:27
+#: templates/layouts/_base.html:59
+msgid "We use cookies to improve your experience of census.gov.uk"
+msgstr "Rydym yn defnyddio cwcis i wella eich profiad o cyfrifiad.gov.uk"
+
+#: templates/layouts/_questionnaire.html:26
 msgid "Save and continue"
 msgstr "Cadw a pharhau"
 
-#: templates/layouts/_questionnaire.html:38
-msgid "Can't complete this question?"
-msgstr "Methu cwblhau'r cwestiwn hwn?"
-
-#: templates/layouts/_questionnaire.html:39
+#: templates/layouts/_questionnaire.html:37
 msgid "Choose another section and return to this later"
 msgstr "Dewiswch adran arall a dewch yn ôl yn nes ymlaen"
 
-#: templates/layouts/configs/_feedback.html:3
-msgid "Give us feedback and help us improve this service"
-msgstr "Rhowch adborth i ni a helpwch ni i wella'r gwasanaeth hwn"
-
-#: templates/layouts/configs/_feedback.html:12
-msgid "Tell us what you think of this service by emailing"
-msgstr "Rhannwch eich barn am y wefan hon â ni drwy e-bostio"
-
-#: templates/layouts/configs/_feedback.html:13
-msgid "If you need help with your census, get in touch with our contact centre."
-msgstr "Os oes angen help arnoch chi gyda’ch cyfrifiad, cysylltwch â’n canolfan gyswllt."
-
-#: templates/layouts/configs/_feedback.html:14
-msgid "Census 2021 feedback: "
-msgstr "Adborth Cyfrifiad 2021: "
-
-#: templates/layouts/configs/_feedback.html:15
-msgid "This email is for feedback on the census rehearsal, which will help us to improve Census 2021.\n"
-"If you need help with your census, visit https://www.census.gov.uk/contact-us."
-msgstr "Mae’r cyfeiriad e-bost hwn ar gyfer rhoi adborth ar ymarfer y cyfrifiad, a fydd yn ein helpu ni i wella Cyfrifiad 2021.\n"
-"Os oes angen help arnoch chi gyda’ch cyfrifiad, ewch i https://cyfrifiad.gov.uk/cysylltu-a-ni/."
-
-#: templates/layouts/configs/_footer.html:34
+#: templates/layouts/configs/_footer.html:31
 msgid "Contact us"
 msgstr "Cysylltu â ni"
 
-#: templates/layouts/configs/_footer.html:39
+#: templates/layouts/configs/_footer.html:36
 msgid "Help"
 msgstr "Help"
 
-#: templates/layouts/configs/_footer.html:48
+#: templates/layouts/configs/_footer.html:45
 msgid "Cookies"
 msgstr "Cwcis"
 
-#: templates/layouts/configs/_footer.html:52 templates/static/privacy.html:9
+#: templates/layouts/configs/_footer.html:49 templates/static/privacy.html:4
+#: templates/static/privacy.html:10
 msgid "Privacy and data protection"
 msgstr "Preifatrwydd a diogelu data"
 
-#: templates/layouts/configs/_footer.html:57
+#: templates/layouts/configs/_footer.html:54
 msgid "Accessibility"
 msgstr "Hygyrchedd"
 
@@ -535,40 +930,169 @@ msgstr "Hygyrchedd"
 msgid "Save and sign out"
 msgstr "Cadw ac allgofnodi"
 
-#: templates/layouts/configs/_save-sign-out-button.html:18
-msgid "Sign out"
-msgstr "Allgofnodi"
-
-#: templates/layouts/configs/_save-sign-out-button.html:32
+#: templates/layouts/configs/_save-sign-out-button.html:7
 msgid "Save and complete later"
 msgstr "Cadw a chwblhau yn nes ymlaen"
 
-#: templates/partials/answer-guidance.html:13
-#: templates/partials/question-definition.html:14
+#: templates/layouts/configs/_save-sign-out-button.html:25
+msgid "Exit"
+msgstr "Cau"
+
+#: templates/macros/helpers.html:29
+msgid "Interviewer note:"
+msgstr ""
+
+#: templates/partials/answer-guidance.html:18
+#: templates/partials/definition.html:18
+#: templates/partials/individual-response-guidance.html:13
 msgid "Hide this"
 msgstr "Cuddio hwn"
 
-#: templates/partials/question.html:39
+#: templates/partials/email-form.html:25
+msgid "Email address"
+msgstr "Cyfeiriad e-bost"
+
+#: templates/partials/email-form.html:26
+msgid "This will not be stored and only used once to send your confirmation"
+msgstr "Ni fydd hwn yn cael ei storio a bydd ond yn cael ei ddefnyddio unwaith er mwyn anfon eich cadarnhad"
+
+#: templates/partials/email-form.html:39
+msgid "Send confirmation"
+msgstr "Anfon cadarnhad"
+
+#: templates/partials/feedback-call-to-action.html:6
+msgid "What do you think about this service?"
+msgstr "Beth yw eich barn chi am y gwasanaeth hwn?"
+
+#: templates/partials/feedback-call-to-action.html:7
+msgid "Your comments will help us make improvements"
+msgstr "Bydd eich sylwadau yn ein helpu ni i wella"
+
+#: templates/partials/feedback-call-to-action.html:9
+msgid "Give feedback"
+msgstr "Rhoi adborth"
+
+#: templates/partials/individual-response-guidance.html:24
+msgid "You can <em>share your household access code</em> with the people you live with so they can complete their own sections."
+msgstr "Gallwch<em> rannu cod mynediad eich cartref</em> â’r bobl rydych chi’n byw gyda nhw fel y gallant gwblhau eu hadrannau eu hunain."
+
+#: templates/partials/last_viewed_question_guidance.html:7
+msgid "This is the last viewed question in this section"
+msgstr ""
+
+#: templates/partials/last_viewed_question_guidance.html:10
+msgid "You can also <a id='section-start-link' href='{url}'>go back to the start of the section</a>"
+msgstr ""
+
+#: templates/partials/question.html:60
 msgid "Selecting this will clear your answer"
 msgstr "Bydd dewis hwn yn clirio eich ateb"
 
-#: templates/partials/question.html:40
+#: templates/partials/question.html:61
 msgid "cleared"
 msgstr "wedi'i glirio"
 
-#: templates/partials/question.html:43
+#: templates/partials/question.html:64
 msgid "Selecting this will deselect any selected options"
 msgstr "Bydd dewis hwn yn dad-ddewis unrhyw opsiynau sydd wedi'u dewis"
 
-#: templates/partials/question.html:44 templates/partials/question.html:52
+#: templates/partials/question.html:65 templates/partials/question.html:73
 msgid "deselected"
 msgstr "dad-ddewiswyd"
 
-#: templates/partials/question.html:48
+#: templates/partials/question.html:69
 msgid "Or"
 msgstr "Neu"
 
-#: templates/partials/answers/checkbox.html:7
+#: templates/partials/sign-out-pre-footer-panel.html:8
+msgid "Make sure you <a href='{sign_out_url}'>leave this page</a> or close your browser if using a shared device"
+msgstr "Cofiwch <a href='{sign_out_url}'> adael y dudalen hon </a> neu gau eich porwr os ydych chi'n defnyddio dyfais sy'n cael ei rhannu"
+
+#: templates/partials/answers/address.html:10
+msgid "Address line 1"
+msgstr "Llinell cyfeiriad 1"
+
+#: templates/partials/answers/address.html:15
+msgid "Address line 2"
+msgstr "Llinell cyfeiriad 2"
+
+#: templates/partials/answers/address.html:19
+msgid "Town or city"
+msgstr "Tref neu ddinas"
+
+#: templates/partials/answers/address.html:23
+msgid "Postcode"
+msgstr "Cod post"
+
+#: templates/partials/answers/address.html:29
+msgid "Search for an address"
+msgstr "Chwilio am gyfeiriad"
+
+#: templates/partials/answers/address.html:30
+msgid "Manually enter address"
+msgstr "Nodwch y cyfeiriad â llaw"
+
+#: templates/partials/answers/address.html:36
+msgid "Enter address or postcode and select from results"
+msgstr "Nodwch y cyfeiriad neu'r cod post a dewiswch o'r canlyniadau"
+
+#: templates/partials/answers/address.html:41
+msgid "Use up and down keys to navigate suggestions once you’ve typed more than two characters. Use the enter key to select a suggestion. Touch device users, explore by touch or with swipe gestures."
+msgstr ""
+
+#: templates/partials/answers/address.html:42
+msgid "You have selected"
+msgstr ""
+
+#: templates/partials/answers/address.html:43
+msgid "Enter 3 or more characters for suggestions."
+msgstr ""
+
+#: templates/partials/answers/address.html:44
+msgid "There is one suggestion available."
+msgstr ""
+
+#: templates/partials/answers/address.html:45
+msgid "There are {n} suggestions available."
+msgstr ""
+
+#: templates/partials/answers/address.html:46
+msgid "Results have been limited to 10 suggestions. Type more characters to improve your search"
+msgstr ""
+
+#: templates/partials/answers/address.html:47
+msgid "Enter more of the address to improve results"
+msgstr ""
+
+#: templates/partials/answers/address.html:48
+msgid "Select an address"
+msgstr ""
+
+#: templates/partials/answers/address.html:49
+msgid "No results found. Try entering a different part of the address"
+msgstr ""
+
+#: templates/partials/answers/address.html:50
+msgid "{n} results found. Enter more of the address to improve results"
+msgstr ""
+
+#: templates/partials/answers/address.html:51
+msgid "Enter more of the address to get results"
+msgstr ""
+
+#: templates/partials/answers/address.html:55
+msgid "Select or manually enter an address"
+msgstr "Dewiswch gyfeiriad neu nodwch â llaw"
+
+#: templates/partials/answers/address.html:56
+msgid "Sorry, there was a problem loading addresses"
+msgstr ""
+
+#: templates/partials/answers/address.html:57
+msgid "Enter address manually"
+msgstr ""
+
+#: templates/partials/answers/checkbox.html:8
 msgid "Select all that apply"
 msgstr "Dewiswch bob un sy'n berthnasol"
 
@@ -584,13 +1108,45 @@ msgstr "Mis"
 msgid "Year"
 msgstr "Blwyddyn"
 
-#: templates/partials/answers/textarea.html:14
+#: templates/partials/answers/radio.html:14
+msgid "Clear selection"
+msgstr "Clirio’r dewis"
+
+#: templates/partials/answers/textarea.html:16
 msgid "You have {x} character remaining"
 msgstr "Mae gennych {x} nod ar ôl"
 
-#: templates/partials/answers/textarea.html:15
+#: templates/partials/answers/textarea.html:17
 msgid "You have {x} characters remaining"
-msgstr "Mae gennych {x} o nodau ar ôl"
+msgstr "Mae gennych chi {x} o nodau ar ôl"
+
+#: templates/partials/answers/textfield.html:26
+msgid "{x} character too many"
+msgstr ""
+
+#: templates/partials/answers/textfield.html:27
+msgid "{x} characters too many"
+msgstr "{x} nod yn ormod"
+
+#: templates/partials/answers/textfield.html:33
+msgid "Use up and down keys to navigate suggestions once you've typed more than two characters. Use the enter key to select a suggestion. Touch device users, explore by touch or with swipe gestures."
+msgstr ""
+
+#: templates/partials/answers/textfield.html:34
+msgid "Continue entering to improve suggestions"
+msgstr ""
+
+#: templates/partials/answers/textfield.html:35
+msgid "Suggestions"
+msgstr ""
+
+#: templates/partials/answers/textfield.html:36
+msgid "No results found"
+msgstr ""
+
+#: templates/partials/answers/textfield.html:37
+msgid "Continue entering to get suggestions"
+msgstr ""
 
 #: templates/partials/introduction/preview.html:29
 #: templates/partials/summary/collapsible-summary.html:13
@@ -603,12 +1159,12 @@ msgid "Hide"
 msgstr "Cuddio"
 
 #: templates/partials/introduction/preview.html:48
-#: templates/partials/summary/collapsible-summary.html:41
+#: templates/partials/summary/collapsible-summary.html:57
 msgid "Show all"
 msgstr "Dangos popeth"
 
 #: templates/partials/introduction/preview.html:49
-#: templates/partials/summary/collapsible-summary.html:42
+#: templates/partials/summary/collapsible-summary.html:58
 msgid "Hide all"
 msgstr "Cuddio popeth"
 
@@ -616,531 +1172,527 @@ msgstr "Cuddio popeth"
 msgid "Start survey"
 msgstr "Cychwyn yr arolwg"
 
-#: templates/partials/summary/collapsible-summary.html:27
-#: templates/partials/summary/summary.html:9
+#: templates/partials/summary/collapsible-summary.html:35
+#: templates/partials/summary/summary.html:17
 msgid "No answer provided"
 msgstr "Ni roddwyd ateb"
 
-#: templates/partials/summary/collapsible-summary.html:27
-#: templates/partials/summary/list-summary.html:9
-#: templates/partials/summary/summary.html:9
+#: templates/partials/summary/collapsible-summary.html:36
+#: templates/partials/summary/list-summary.html:13
+#: templates/partials/summary/summary.html:18
 msgid "Change"
 msgstr "Newid"
 
-#: templates/partials/summary/collapsible-summary.html:27
-#: templates/partials/summary/summary.html:9
+#: templates/partials/summary/collapsible-summary.html:37
+#: templates/partials/summary/summary.html:19
 msgid "Change your answer for:"
 msgstr "Newidiwch eich ateb ar gyfer:"
 
-#: templates/partials/summary/list-summary.html:10
+#: templates/partials/summary/list-summary.html:14
 msgid "Change details for {item_name}"
 msgstr "Newid manylion ar gyfer {item_name}"
 
-#: templates/partials/summary/list-summary.html:11
+#: templates/partials/summary/list-summary.html:15
 msgid "Remove"
 msgstr "Dileu"
 
-#: templates/partials/summary/list-summary.html:12
+#: templates/partials/summary/list-summary.html:16
 msgid "Remove {item_name}"
 msgstr "Tynnu {item_name}"
 
-#: templates/static/accessibility.html:19
+#: templates/static/accessibility.html:4 templates/static/accessibility.html:10
 msgid "Accessibility statement"
 msgstr "Datganiad hygyrchedd"
 
-#: templates/static/accessibility.html:21
+#: templates/static/accessibility.html:12
 msgid "This census is run by the Office for National Statistics. We want as many people as possible to be able to do the census online. For example, that means you should be able to:"
 msgstr "Cynhelir y cyfrifiad hwn gan y Swyddfa Ystadegau Gwladol. Rydym am i gynifer o bobl â phosibl allu gwneud y cyfrifiad ar lein. Er enghraifft, mae hynny'n golygu y dylech fod yn gallu:"
 
-#: templates/static/accessibility.html:24
+#: templates/static/accessibility.html:15
 msgid "change colours, contrast levels and fonts"
 msgstr "newid lliwiau, lefelau cyferbyniad a ffontiau"
 
-#: templates/static/accessibility.html:25
+#: templates/static/accessibility.html:16
 #, python-format
 msgid "zoom in up to 300%% without the text spilling off the screen"
 msgstr "chwyddo'r testun hyd at 300%% heb iddo ddiflannu oddi ar y sgrin"
 
-#: templates/static/accessibility.html:26
+#: templates/static/accessibility.html:17
 msgid "navigate most of the questionnaire using just a keyboard"
 msgstr "defnyddio'r rhan fwyaf o'r holiadur â bysellfwrdd yn unig"
 
-#: templates/static/accessibility.html:27
+#: templates/static/accessibility.html:18
 msgid "navigate most of the questionnaire using speech recognition software"
 msgstr "defnyddio'r rhan fwyaf o'r holiadur â meddalwedd adnabod lleferydd"
 
-#: templates/static/accessibility.html:28
+#: templates/static/accessibility.html:19
 msgid "listen to most of the questionnaire using a screen reader (including the most recent versions of JAWS, NVDA and VoiceOver)"
 msgstr "gwrando ar y rhan fwyaf o'r holiadur gan ddefnyddio rhaglen darllen sgrin (gan gynnwys fersiynau diweddaraf JAWS, NVDA a VoiceOver)"
 
-#: templates/static/accessibility.html:31
+#: templates/static/accessibility.html:22
 msgid "We’ve used simple language as much as possible."
 msgstr "Rydym wedi defnyddio iaith syml cymaint â phosibl."
 
-#: templates/static/accessibility.html:33
+#: templates/static/accessibility.html:24
 msgid "<a href='{url}'>AbilityNet</a> has advice on making your device easier to use if you have a disability."
 msgstr "Mae gan <a href='{url}'>AbilityNet</a> gyngor ar wneud eich dyfais yn haws i'w defnyddio os oes gennych chi anabledd."
 
-#: templates/static/accessibility.html:35
+#: templates/static/accessibility.html:26
 msgid "How accessible is this questionnaire?"
 msgstr "Pa mor hygyrch yw'r holiadur hwn?"
 
-#: templates/static/accessibility.html:37
+#: templates/static/accessibility.html:28
 msgid "We know that the following parts of this questionnaire are not fully accessible:"
 msgstr "Rydym yn gwybod nad yw'r rhannau canlynol o'r holiadur yn gwbl hygyrch:"
 
-#: templates/static/accessibility.html:40
+#: templates/static/accessibility.html:31
 msgid "you cannot modify the line height or spacing of text"
 msgstr "ni allwch addasu uchder llinellau na'r bylchau rhwng testun"
 
-#: templates/static/accessibility.html:41
+#: templates/static/accessibility.html:32
 msgid "the online system for getting a new census code has not been fully tested so parts of it may not be accessible to all users"
 msgstr "nid yw'r system ar-lein ar gyfer cael cod cyfrifiad newydd wedi cael ei phrofi'n llawn felly mae'n bosibl na fydd rhannau ohoni yn hygyrch i bob defnyddiwr"
 
-#: templates/static/accessibility.html:42
+#: templates/static/accessibility.html:33
 msgid "the Web chat tool may not be fully accessible"
 msgstr "mae'n bosibl na fydd yr adnodd sgwrs dros y we yn gwbl hygyrch"
 
-#: templates/static/accessibility.html:43
+#: templates/static/accessibility.html:34
 msgid "some page titles may not accurately reflect the content on the page for audio users"
 msgstr "mae'n bosibl na fydd teitlau rhai tudalennau yn adlewyrchu cynnwys y dudalen yn gywir i ddefnyddwyr clywedol"
 
-#: templates/static/accessibility.html:46
+#: templates/static/accessibility.html:37
 msgid "What to do if you need guidance"
 msgstr "Beth i'w wneud os bydd angen arweiniad arnoch"
 
-#: templates/static/accessibility.html:48
+#: templates/static/accessibility.html:39
 msgid "Our <a href='{url}'>guidance leaflets about the census</a> are available:"
 msgstr "Mae ein <a href='{url}'>taflenni canllaw am y cyfrifiad</a> ar gael:"
 
-#: templates/static/accessibility.html:51
+#: templates/static/accessibility.html:42
 msgid "in Braille"
 msgstr "mewn Braille"
 
-#: templates/static/accessibility.html:52
+#: templates/static/accessibility.html:43
 msgid "in British Sign Language (BSL)"
 msgstr "yn Iaith Arwyddion Prydain"
 
-#: templates/static/accessibility.html:53
+#: templates/static/accessibility.html:44
 msgid "as an easy read version (which uses pictures to explain the census)"
 msgstr "mewn fersiwn hawdd ei darllen (sy'n defnyddio lluniau i esbonio'r cyfrifiad)"
 
-#: templates/static/accessibility.html:54
+#: templates/static/accessibility.html:45
 msgid "as a Welsh audio"
 msgstr "fel fersiwn glywedol Gymraeg"
 
-#: templates/static/accessibility.html:55
+#: templates/static/accessibility.html:46
 msgid "as large print in English or large print in Welsh"
 msgstr "mewn print mawr yn Gymraeg neu'n Saesneg"
 
-#: templates/static/accessibility.html:58
+#: templates/static/accessibility.html:49
 msgid "Reporting accessibility problems"
 msgstr "Rhoi gwybod am broblemau hygyrchedd"
 
-#: templates/static/accessibility.html:60
+#: templates/static/accessibility.html:51
 msgid "We’re always looking to improve the accessibility of this service. If you find any problems that are not listed on this page or think we’re not meeting accessibility requirements, you can <a href='{url}'>contact us</a>."
 msgstr "Rydym bob amser yn ceisio gwella hygyrchedd y gwasanaeth hwn. Os ydych chi’n dod o hyd i unrhyw broblemau nad ydynt wedi’u rhestru ar y dudalen hon neu rydych chi’n credu nad ydym yn cwrdd â gofynion hygyrchedd, gallwch <a href='{url}'>gysylltu â ni</a>."
 
-#: templates/static/accessibility.html:62
+#: templates/static/accessibility.html:53
 msgid "Enforcement procedure"
 msgstr "Gweithdrefn gorfodi"
 
-#: templates/static/accessibility.html:64
+#: templates/static/accessibility.html:55
 msgid "The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Website and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’). If you’re not happy with how we respond to your complaint, contact the:"
 msgstr "Y Comisiwn Cydraddoldeb a Hawliau Dynol sy'n gyfrifol am orfodi Rheoliadau Hygyrchedd Cyrff y Sector Cyhoeddus (Gwefannau a Chymwysiadau Symudol) (Rhif 2) 2018 (y 'rheoliadau hygyrchedd'). Os na fyddwch yn fodlon ar y ffordd rydym yn ymateb i'ch cwyn, cysylltwch â'r canlynol:"
 
-#: templates/static/accessibility.html:67
+#: templates/static/accessibility.html:58
 msgid "<a href='{url}'>Equality Advisory and Support Service (EASS)</a> if you live in England or Wales"
 msgstr "<a href='{url}'>Gwasanaeth Cynghori a Chymorth Cydraddoldeb (EASS)</a> os ydych chi'n byw yng Nghymru neu Loegr"
 
-#: templates/static/accessibility.html:68
+#: templates/static/accessibility.html:59
 msgid "<a href='{url}'>Equalities Commission for Northern Ireland (ECNI)</a> if you live in Northern Ireland"
 msgstr "<a href='{url}'>Comisiwn Cydraddoldeb dros Ogledd Iwerddon (ECNI)</a> os ydych chi'n byw yng Ngogledd Iwerddon"
 
-#: templates/static/accessibility.html:71
+#: templates/static/accessibility.html:62
 msgid "Technical information about this questionnaire’s accessibility"
 msgstr "Gwybodaeth dechnegol am hygyrchedd yr holiadur hwn"
 
-#: templates/static/accessibility.html:73
+#: templates/static/accessibility.html:64
 msgid "The Office for National Statistics is committed to making its website accessible, in accordance with the Public Sector Bodies (Website and Mobile Applications) (No. 2) Accessibility Regulations 2018."
 msgstr "Mae'r Swyddfa Ystadegau Gwladol yn ymrwymedig i wneud ei gwefan yn hygyrch, yn unol â Rheoliadau Hygyrchedd Cyrff y Sector Cyhoeddus (Gwefannau a Chymwysiadau Symudol) (Rhif 2) 2018."
 
-#: templates/static/accessibility.html:75
+#: templates/static/accessibility.html:66
 msgid "This service is partially compliant with the <a href='{url}'>Web Content Accessibility Guidelines version 2.1</a> AA standard, due to the non-compliances listed."
 msgstr "Mae'r wefan hon yn cydymffurfio'n rhannol â <a href='{url}'>Chanllawiau Hygyrchedd Cynnwys y We fersiwn 2.1</a> safon AA, oherwydd yr achosion o ddiffyg cydymffurfio a restrir."
 
-#: templates/static/accessibility.html:77
+#: templates/static/accessibility.html:68
 msgid "Non-accessible content"
 msgstr "Cynnwys nad yw'n hygyrch"
 
-#: templates/static/accessibility.html:79
+#: templates/static/accessibility.html:70
 msgid "The content listed is non-accessible for the following reasons. We are planning to fix the following issues for Census 2021."
 msgstr "Nid yw'r cynnwys a restrir yn hygyrch am y rhesymau canlynol. Rydym yn bwriadu delio â'r problemau canlynol ar gyfer Cyfrifiad 2021."
 
-#: templates/static/accessibility.html:81
+#: templates/static/accessibility.html:72
 msgid "Non-compliance with the accessibility regulations"
 msgstr "Diffyg cydymffurfio â'r rheoliadau hygyrchedd"
 
-#: templates/static/accessibility.html:83
+#: templates/static/accessibility.html:74
 msgid "Non-descriptive form elements. On the ‘Check your answers’ summary page there is an option to “change” items, but the link does not describe where it goes to. Fails on WCAG 2.1 A number 1.3.1."
 msgstr "Elfennau o'r ffurflen nad ydynt yn ddisgrifiadol. Ar dudalen grynhoi 'Edrych dros eich atebion', mae opsiwn i \"newid\" eitemau, ond nid yw'r ddolen yn disgrifio i ble mae'n mynd. Methu ar WCAG 2.1 A rhif 1.3.1."
 
-#: templates/static/accessibility.html:85
+#: templates/static/accessibility.html:76
 msgid "Error messages are too generic. If the text in a field is incorrect or in the wrong format, the answer validation page says the answer is incorrect without explaining what you need to do. Fails on WCAG 2.1 A number 3.3.1."
 msgstr "Mae'r negeseuon gwall yn rhy generig. Os yw'r testun mewn blwch yn anghywir neu yn y fformat anghywir, mae tudalen dilysu'r ateb yn dweud bod yr ateb yn anghywir heb esbonio'r hyn y mae angen i chi ei wneud. Methu ar WCAG 2.1 A rhif 3.3.1."
 
-#: templates/static/accessibility.html:87
+#: templates/static/accessibility.html:78
 msgid "Form label issue. On the ‘What is your name?’ page, middle name is optional but this is not clear to the user. Fails on WCAG 2.1 A number 3.3.2."
 msgstr "Problem gyda label ar y ffurflen. Ar y dudalen ‘Beth yw eich enw?’ mae'r enw canol yn ddewisol ond nid yw hyn yn glir i'r defnyddiwr. Methu ar WCAG 2.1 A rhif 3.3.2."
 
-#: templates/static/accessibility.html:89
+#: templates/static/accessibility.html:80
 msgid "Form label issue. When selecting the appropriate relationship, it is possible to ‘Save and continue’ without selecting an option. Fails on WCAG 2.1 A number 2.4.6."
 msgstr "Problem gyda label ar y ffurflen. Wrth ddewis y berthynas briodol, mae'n bosibl clicio ar 'Cadw a pharhau' heb ddewis opsiwn. Methu ar WCAG 2.1 A rhif 2.4.6."
 
-#: templates/static/accessibility.html:91
+#: templates/static/accessibility.html:82
 msgid "On the ‘Is this address correct?’ page, the title may not accurately reflect the content on the page for audio users. The ‘Submit survey’ page does not have a page title. Fails on WCAG 2.1 A number 2.4.2."
 msgstr "Ar dudalen 'Ydy'r cyfeiriad hwn yn gywir?', mae'n bosibl nad yw'r teitl yn adlewyrchu'r cynnwys ar y dudalen yn gywir ar gyfer defnyddwyr clywedol. Nid oes teitl ar dudalen 'Cyflwyno holiadur'. Methu ar WCAG 2.1 A rhif 2.4.2."
 
-#: templates/static/accessibility.html:93
+#: templates/static/accessibility.html:84
 msgid "Timeout issue. Users are not informed of a time limit and service times out without warning. During the validation process there is no return link on the session timeout page. Fails on WCAG 2.1 A number 2.2.1 and AAA number 2.2.6."
 msgstr "Problem gyda therfyn amser. Nid yw'r defnyddwyr yn cael gwybod bod terfyn amser ac mae'r gwasanaeth yn cyrraedd ei derfyn amser heb rybudd. Yn ystod y broses ddilysu, nid yw'r dudalen sy'n nodi bod y sesiwn wedi cyrraedd ei therfyn amser yn cynnwys dolen i fynd yn ôl. Methu ar WCAG 2.1 A rhif 2.2.1 ac AAA rhif 2.2.6."
 
-#: templates/static/accessibility.html:95
+#: templates/static/accessibility.html:86
 msgid "The ‘Hide this’ button text on accordions such as ‘What does “usually live” mean?’ is non-descriptive for JAWS users as the text above it is read back to users. Fails on WCAG 2.1 AA number 2.4.6."
 msgstr "Nid yw testun y botwm 'Cuddio hyn' ar acordiynau megis ‘Beth mae “byw fel arfer” yn ei olygu?’ yn ddisgrifiadol ar gyfer defnyddwyr JAWS gan fod y testun uwch ei ben yn cael ei ddarllen yn ôl i ddefnyddwyr. Methu ar WCAG 2.1 AA rhif 2.4.6."
 
-#: templates/static/accessibility.html:97
+#: templates/static/accessibility.html:88
 msgid "Screen readers may not let users know when an accordion is expanded or collapsed. Fails on WCAG 2.1 A number 2.4.4."
 msgstr "Mae'n bosibl na fydd darllenwyr sgrin yn rhoi gwybod i ddefnyddwyr pan fydd acordion wedi'i ehangu neu ei gau. Methu ar WCAG 2.1 A rhif 2.4.4."
 
-#: templates/static/accessibility.html:99
+#: templates/static/accessibility.html:90
 msgid "Non-descriptive headings. On the relationships page, the heading does not accurately describe the content for screen readers. Fails on WCAG 2.1 A number 2.4.6."
 msgstr "Penawdau nad ydynt yn ddisgrifiadol. Ar y dudalen ar gyfer nodi perthynas, nid yw'r pennawd yn disgrifio'r cynnwys yn gywir i ddefnyddwyr darllenwyr sgrin. Methu ar WCAG 2.1 A rhif 2.4.6."
 
-#: templates/static/accessibility.html:101
+#: templates/static/accessibility.html:92
 msgid "Some links are not descriptive enough for screen reader users. Fails on WCAG 2.1 AAA number 2.4.9."
 msgstr "Nid yw rhai dolenni yn ddigon disgrifiadol ar gyfer defnyddwyr darllenwyr sgrin. Methu ar WCAG AAA 2.1 rhif 2.4.9."
 
-#: templates/static/accessibility.html:103
+#: templates/static/accessibility.html:94
 msgid "Some headings do not follow a logical hierarchical structure. Fails on WCAG AAA 2.1 number 2.4.10."
 msgstr "Nid yw rhai penawdau yn dilyn strwythur hierarchaidd rhesymegol. Methu ar WCAG AAA 2.1 rhif 2.4.10."
 
-#: templates/static/accessibility.html:105
+#: templates/static/accessibility.html:96
 msgid "Some text is highlighted, such as addresses and names that a user has confirmed. Highlighting is not accessible for some users. This does not conform to Government Digital Service (GDS) guidelines."
 msgstr "Mae rhywfaint o'r testun wedi'i amlygu, megis cyfeiriadau ac enwau y mae defnyddiwr wedi'u cadarnhau. Nid yw rhai defnyddwyr yn cael hyn. Nid yw hyn yn cydymffurfio â chanllawiau Gwasanaeth Digidol y Llywodraeth (GDS)."
 
-#: templates/static/accessibility.html:107
+#: templates/static/accessibility.html:98
 msgid "Some radio inputs on the relationships page do not conform to GDS guidelines. When selected, three different elements on the page are updated."
 msgstr "Nid yw rhai mewnbynnau radio ar y dudalen ar gyfer nodi perthynas yn cydymffurfio â chanllawiau GDS. Wrth ddewis, caiff tair elfen wahanol ar y sgrin eu diweddaru."
 
-#: templates/static/accessibility.html:109
+#: templates/static/accessibility.html:100
 msgid "On ‘Who lives here?’ there is a ‘Previous’ link on the page that does not conform with GDS guidelines. The text used should read as ‘Back’."
 msgstr "Ar dudalen ‘Pwy sy'n byw yma?’ mae dolen ‘Blaenorol’ ar y dudalen nad yw'n cydymffurfio â chanllawiau GDS. Dylai'r testun sy'n cael ei ddefnyddio ddweud ‘Yn ôl’."
 
-#: templates/static/accessibility.html:111
+#: templates/static/accessibility.html:102
 msgid "Error messages do not result in a change to the page title to reflect that an error has been made. This does not conform to GDS guidelines."
 msgstr "Nid yw negeseuon gwall yn newid teitl y dudalen er mwyn dangos bod gwall wedi'i wneud. Nid yw hyn yn cydymffurfio â chanllawiau GDS."
 
-#: templates/static/accessibility.html:113
+#: templates/static/accessibility.html:104
 msgid "How we tested this questionnaire"
 msgstr "Sut y gwnaethom brofi'r holiadur hwn"
 
-#: templates/static/accessibility.html:115
+#: templates/static/accessibility.html:106
 msgid "Over the last few years we have tested the full questionnaire, including:"
 msgstr "Dros y blynyddoedd diwethaf, rydym wedi profi'r holiadur llawn, gan gynnwys:"
 
-#: templates/static/accessibility.html:118
+#: templates/static/accessibility.html:109
 msgid "<a href='{url}'>Digital Accessibility Centre (DAC)</a> carrying out a professional, technical audit"
 msgstr "cael y <a href='{url}'>Ganolfan Hygyrchedd Digidol (DAC)</a> i gynnal archwiliad technegol proffesiynol"
 
-#: templates/static/accessibility.html:119
+#: templates/static/accessibility.html:110
 msgid "user testing with the public on different devices, different locations, in their homes with various assistive technologies including free and paid versions"
 msgstr "cynnal profion defnyddwyr gyda'r cyhoedd ar ddyfeisiau gwahanol, mewn lleoliadau gwahanol, yn eu cartrefi gyda thechnolegau cynorthwyol amrywiol, gan gynnwys fersiynau am ddim a rhai y mae'n rhaid talu amdanynt"
 
-#: templates/static/accessibility.html:120
+#: templates/static/accessibility.html:111
 msgid "testing with charities, such as Scope and RNIB in their labs"
 msgstr "cynnal profion gydag elusennau, megis Scope a Sefydliad Cenedlaethol Brenhinol Pobl Ddall (RNIB) yn eu labordai"
 
-#: templates/static/accessibility.html:121
+#: templates/static/accessibility.html:112
 msgid "using job centres and libraries for pop-up testing"
 msgstr "defnyddio canolfannau gwaith a llyfrgelloedd i gynnal profion ar adegau penodol"
 
-#: templates/static/accessibility.html:122
+#: templates/static/accessibility.html:113
 msgid "covering a wide range of ages, additional needs and disabilities"
 msgstr "cwmpasu ystod eang o oedrannau, anghenion ychwanegol ac anableddau"
 
-#: templates/static/accessibility.html:123
+#: templates/static/accessibility.html:114
 msgid "making sure the offline journey and non-digital products were considered in the end-to-end journey"
 msgstr "sicrhau bod y daith all-lein a chynhyrchion nad ydynt yn ddigidol yn cael eu hystyried o'r dechrau i'r diwedd"
 
-#: templates/static/accessibility.html:124
+#: templates/static/accessibility.html:115
 msgid "changing designs based on feedback from user testing, such as letter structure and the summary of sections and progress through questionnaire"
 msgstr "newid dyluniadau yn seiliedig ar adborth o brofion defnyddwyr, megis strwythur llythyrau, crynodeb o adrannau a chynnydd drwy'r holiadur"
 
-#: templates/static/accessibility.html:127
+#: templates/static/accessibility.html:118
 msgid "Digital Accessibility Centre testing"
 msgstr "Profion y Ganolfan Hygyrchedd Digidol"
 
-#: templates/static/accessibility.html:129
+#: templates/static/accessibility.html:120
 msgid "Parts of this questionnaire were last tested on 3 September 2019 by the Digital Accessibility Centre (DAC)."
 msgstr "Cafodd rhannau o'r holiadur hwn eu profi ddiwethaf ar 3 Medi 2019 gan y Ganolfan Hygyrchedd Digidol (DAC)."
 
-#: templates/static/accessibility.html:132
+#: templates/static/accessibility.html:123
 msgid "<a href='{url}' download>DAC Report - September 2019</a>"
 msgstr "<a href='{url}' download>Adroddiad DAC - Medi 2019</a>"
 
-#: templates/static/accessibility.html:134
+#: templates/static/accessibility.html:125
 msgid "You can read the last full accessibility test report from 28 June 2019."
 msgstr "Gallwch ddarllen yr adroddiad ar y prawf hygyrchedd llawn diwethaf o 28 Mehefin 2019."
 
-#: templates/static/accessibility.html:136
+#: templates/static/accessibility.html:127
 msgid "<a href='{url}' download>DAC Report - June 2019</a>"
 msgstr "<a href='{url}' download>Adroddiad DAC - Mehefin 2019</a>"
 
-#: templates/static/accessibility.html:138
+#: templates/static/accessibility.html:129
 msgid "What we’re doing to improve accessibility"
 msgstr "Yr hyn rydym yn ei wneud i wella hygyrchedd"
 
-#: templates/static/accessibility.html:140
+#: templates/static/accessibility.html:131
 msgid "We are continuing to work with various charities and local deaf communities to understand their needs for the census."
 msgstr "Rydym yn parhau i weithio gydag elusennau amrywiol a chymunedau byddar lleol i ddeall eu hanghenion ar gyfer y cyfrifiad."
 
-#: templates/static/accessibility.html:142
+#: templates/static/accessibility.html:133
 msgid "We are looking at designs to see if it is possible to have British Sign Language on every page. This is challenging as we have been unable to find another service that does this, but we continue to investigate."
 msgstr "Rydym yn edrych ar ddyluniadau er mwyn gweld a yw hi'n bosibl cael Iaith Arwyddion Prydain ar bob tudalen. Mae hyn yn heriol oherwydd nid ydym wedi llwyddo i ddod o hyd i wasanaeth arall sy'n gwneud hyn, ond rydym yn parhau i ymchwilio."
 
-#: templates/static/accessibility.html:144
+#: templates/static/accessibility.html:135
 msgid "We will act on feedback from the 2019 Rehearsal in October."
 msgstr "Byddwn yn gweithredu ar adborth o Ymarfer 2019 ym mis Hydref."
 
-#: templates/static/accessibility.html:146
+#: templates/static/accessibility.html:137
 msgid "This statement was prepared on 17 September. It was last updated on 17 September."
 msgstr "Cafodd y datganiad hwn ei lunio ar 17 Medi. Cafodd ei ddiweddaru ddiwethaf ar 17 Medi."
 
-#: templates/static/privacy.html:4
-msgid "ONS Business Surveys"
-msgstr "Arolygon Busnes y SYG"
-
-#: templates/static/privacy.html:10
+#: templates/static/privacy.html:11
 msgid "The information you provide when you fill in your census rehearsal questionnaire is protected by law."
 msgstr "Mae'r wybodaeth y byddwch chi'n ei darparu pan fyddwch chi'n llenwi eich holiadur ymarfer y cyfrifiad wedi'i diogelu gan y gyfraith."
 
-#: templates/static/privacy.html:11
+#: templates/static/privacy.html:12
 msgid "Here we detail why we need your information. We also describe all the steps that we take to make sure your information and your privacy are safe."
 msgstr "Yma rydym yn egluro pam mae angen eich gwybodaeth arnom. Rydym hefyd yn disgrifio'r holl gamau rydym yn eu cymryd i wneud yn siŵr bod eich gwybodaeth a'ch preifatrwydd yn ddiogel."
 
-#: templates/static/privacy.html:14
+#: templates/static/privacy.html:15
 msgid "How and why we use your information"
 msgstr "Sut y byddwn yn defnyddio eich gwybodaeth a pham rydym yn gwneud hynny"
 
-#: templates/static/privacy.html:16
+#: templates/static/privacy.html:17
 msgid "We collect information from your questionnaire under our statutory objective to promote and safeguard the production of official statistics that serve the public good. This means that any personal data we collect will only ever be used to produce statistics or undertake statistical research. People will not be identified within those statistics or research."
 msgstr "Rydym yn casglu gwybodaeth o'ch holiadur o dan ein hamcan statudol i hybu a diogelu'r gwaith o gynhyrchu ystadegau swyddogol sydd o fudd i'r cyhoedd. Mae hyn yn golygu y bydd unrhyw ddata personol rydym yn eu casglu ond yn cael eu defnyddio i gynhyrchu ystadegau neu gyflawni gwaith ymchwil ystadegol. Ni ellir adnabod unrhyw berson yn yr ymchwil na'r ystadegau hyn."
 
-#: templates/static/privacy.html:18
+#: templates/static/privacy.html:19
 msgid "Every 10 years, the census gathers vital information that helps the government and local authorities plan services like health services, roads and libraries."
 msgstr "Bob 10 mlynedd, mae'r cyfrifiad yn casglu gwybodaeth hollbwysig sy'n helpu'r llywodraeth ac awdurdodau lleol i gynllunio gwasanaethau fel gwasanaethau iechyd, ffyrdd a llyfrgelloedd."
 
-#: templates/static/privacy.html:20
+#: templates/static/privacy.html:21
 msgid "By running a rehearsal for Census 2021, we can test our processes, systems and services and make sure everything goes smoothly for the real thing. The personal data you provide on your questionnaire will also be used to undertake research and produce statistics that serve the public good, both by the Office for National Statistics (ONS) and accredited researchers from other organisations."
 msgstr "Drwy gynnal ymarfer ar gyfer Cyfrifiad 2021, gallwn brofi ein prosesau, systemau a gwasanaethau a gwneud yn siŵr bod popeth yn rhedeg yn esmwyth ar gyfer y cyfrifiad go iawn. Caiff y data personol y byddwch chi'n eu darparu ar eich holiadur eu defnyddio hefyd i gyflawni gwaith ymchwil a chynhyrchu ystadegau sydd o fudd i'r cyhoedd, gan y Swyddfa Ystadegau Gwladol (SYG) ac ymchwilwyr achrededig o sefydliadau eraill."
 
-#: templates/static/privacy.html:22
+#: templates/static/privacy.html:23
 msgid "We may occasionally record information about a property or an individual, in the interests of safeguarding the wellbeing of both those being interviewed and interviewers, as well as to assist people in the completion of their questionnaires. We’ll hold the minimum amount of personal data needed to meet these purposes."
 msgstr "Weithiau gallwn gofnodi gwybodaeth am eiddo neu unigolyn, er mwyn diogelu llesiant y rhai sy'n cael cyfweliad a chyfwelwyr, yn ogystal â helpu pobl i gwblhau eu holiadur. Byddwn yn cadw cyn lleied o ddata personol ag sydd angen i gyflawni'r dibenion hyn."
 
-#: templates/static/privacy.html:24
+#: templates/static/privacy.html:25
 msgid "For online completion, we’ll collect information about how people fill in their questionnaires online to provide us with knowledge of how to improve our online services."
 msgstr "Ar gyfer holiaduron ar-lein, byddwn yn casglu gwybodaeth am y ffordd mae pobl yn llenwi eu holiaduron ar lein i roi gwybodaeth i ni am sut i wella ein gwasanaethau ar-lein."
 
-#: templates/static/privacy.html:26
+#: templates/static/privacy.html:27
 msgid "If you provide feedback by email we will ensure your email address is deleted promptly after the feedback has been received. We will never share your details with anyone else. The feedback you give us will be used for research purposes only."
 msgstr "Os byddwch chi'n rhoi adborth drwy e-bost byddwn ni'n sicrhau bod eich cyfeiriad e-bost yn cael ei ddileu'n brydlon ar ôl cael yr adborth. Ni fyddwn ni byth yn rhannu eich manylion ag unrhyw un arall. At ddibenion ymchwil yn unig y caiff yr adborth y byddwch chi'n ei roi i ni ei ddefnyddio."
 
-#: templates/static/privacy.html:29
+#: templates/static/privacy.html:30
 msgid "Who can access the information?"
 msgstr "Pwy sy'n gallu gweld y wybodaeth?"
 
-#: templates/static/privacy.html:31
+#: templates/static/privacy.html:32
 msgid "During the rehearsal we’ll employ third-party providers to assist us with parts of the operation. These third parties work under our instruction."
 msgstr "Yn ystod yr ymarfer byddwn yn cyflogi darparwyr trydydd parti i'n helpu gyda rhywfaint o'r gwaith. Mae'r trydydd partïon hyn yn gweithio o dan ein cyfarwyddyd ni."
 
-#: templates/static/privacy.html:32
+#: templates/static/privacy.html:33
 msgid "We treat the information we hold with respect, keeping it secure and confidential. Data may be made available to approved researchers where there is a clear public value and it’s safe and lawful to do so. More information on <a href='{policies_url}'>how we allow access to data for research</a> is available. We also publish a full list of all the <a href='{researchers_url}'>approved researchers</a> who we’ve granted access to."
 msgstr "Rydym yn trin y wybodaeth a gawn â pharch, gan ei chadw'n ddiogel ac yn gyfrinachol. Gall data fod ar gael i ymchwilwyr cymeradwy pan fydd o werth clir i'r cyhoedd a'i bod yn ddiogel a chyfreithlon gwneud hynny. Mae rhagor o wybodaeth am <a href='{policies_url}'>sut rydym yn caniatáu mynediad at ddata ar gyfer ymchwil</a> ar gael. Rydym hefyd yn cyhoeddi rhestr lawn o'r holl <a href='{researchers_url}'>ymchwilwyr cymeradwy</a> rydym wedi rhoi mynediad iddynt."
 
-#: templates/static/privacy.html:35
+#: templates/static/privacy.html:36
 msgid "How long are personal data kept?"
 msgstr "Am faint o amser y caiff data personol eu cadw?"
 
-#: templates/static/privacy.html:37
+#: templates/static/privacy.html:38
 msgid "Data protection law requires that personal data are kept for no longer than is needed to fulfil the purposes for which they were originally collected."
 msgstr "Mae cyfraith diogelu data yn ei gwneud yn ofynnol i beidio â chadw data personol am fwy nag sydd angen i gyflawni'r dibenion y cawsant eu casglu ar eu cyfer yn wreiddiol."
 
-#: templates/static/privacy.html:39
+#: templates/static/privacy.html:40
 msgid "The law allows that information held for statistical purposes only, such as information from your questionnaire, may be kept for longer periods. We’ll only continue to hold personal data where they are still used to produce statistics. Data used by approved researchers will be held within our <a href='{url}'>Secure Research Service</a>. Any personal data that we do not need, such as names and addresses, will be removed from the data at the earliest opportunity. The data will undergo regular reviews and will be deleted when they are no longer required."
 msgstr "Mae'r gyfraith yn caniatáu cadw gwybodaeth a ddelir at ddibenion ystadegol yn unig, fel gwybodaeth o'ch holiadur, am gyfnodau hwy. Byddwn ond yn parhau i gadw data personol pan fyddant yn cael eu defnyddio i gynhyrchu ystadegau o hyd. Caiff data a gaiff eu defnyddio gan ymchwilwyr cymeradwy eu cadw yn ein <a href='{url}'>Gwasanaeth Ymchwil Diogel</a>. Caiff unrhyw ddata personol nad oes eu hangen arnom, fel enwau a chyfeiriadau, eu tynnu o'r data cyn gynted â phosibl. Bydd y data yn cael eu hadolygu'n rheolaidd a byddant yn cael eu dileu pan na fydd eu hangen mwyach."
 
-#: templates/static/privacy.html:41
+#: templates/static/privacy.html:42
 msgid "Safeguarding data, such as information about a property or an individual, will be held for the duration of the rehearsal. Most of the information will be deleted at the end of the rehearsal. In some instances, data will be held for longer periods, where keeping them continues to serve safeguarding purposes."
 msgstr "Caiff data diogelu, fel gwybodaeth am eiddo neu unigolyn, eu cadw drwy gydol cyfnod yr ymarfer. Caiff y rhan fwyaf o'r wybodaeth ei dileu ar ddiwedd yr ymarfer. Mewn rhai achosion, caiff data eu cadw am gyfnodau hwy, pan fydd eu cadw yn parhau i wasanaethu dibenion diogelu."
 
-#: templates/static/privacy.html:43
+#: templates/static/privacy.html:44
 msgid "Metrics containing information about how people fill in their questionnaires will be held in an identifiable form only until the necessary statistical matching has taken place. After this point the data will be de-identified and used for the purposes of improving our services."
 msgstr "Bydd metrigau yn cynnwys gwybodaeth am y ffordd mae pobl yn llenwi eu holiaduron yn cael eu cadw ar ffurf adnabyddadwy, a hynny dim ond nes bod y gwaith cyfateb ystadegau angenrheidiol wedi cael ei wneud. Ar ôl hynny byddwn yn tynnu unrhyw wybodaeth y gellir ei defnyddio i adnabod unigolyn o'r data a byddant yn cael eu defnyddio at ddibenion gwella ein gwasanaethau."
 
-#: templates/static/privacy.html:46
+#: templates/static/privacy.html:47
 msgid "How the law protects your information"
 msgstr "Sut mae'r gyfraith yn diogelu eich gwybodaeth"
 
-#: templates/static/privacy.html:48
+#: templates/static/privacy.html:49
 msgid "The <a href='{data_protection_url}'>General Data Protection Regulation</a> and the <a href='{data_protection_act_url}'>Data Protection Act 2018</a> determine how, when and why any organisation can process your personal data. Personal data is any information that can identify a living individual. These laws exist to make sure your data are managed safely and used responsibly. They also give you certain rights about your data and create a responsibility on the ONS, as a user of personal data, to provide you with certain information."
 msgstr "Mae'r <a href='{data_protection_url}'>Rheoliad Cyffredinol ar Ddiogelu Data</a> a <a href='{data_protection_act_url}'>Deddf Diogelu Data 2018</a> yn pennu sut, pryd a pham y gall unrhyw sefydliad brosesu eich data personol. Data personol yw unrhyw wybodaeth y gellir ei defnyddio i adnabod unigolyn byw. Mae'r cyfreithiau hyn yn bodoli i wneud yn siŵr y caiff eich data eu rheoli'n ddiogel a'u defnyddio'n gyfrifol. Maent hefyd yn rhoi hawliau penodol i chi ynglŷn â'ch data ac yn rhoi cyfrifoldeb ar SYG, fel defnyddiwr data personol, i roi gwybodaeth benodol i chi."
 
-#: templates/static/privacy.html:50
+#: templates/static/privacy.html:51
 msgid "The ONS is a statutory body, meaning it was created by legislation, specifically the <a href='{url}'>Statistics and Registration Service Act 2007</a>. Our objective is to promote and safeguard the production and publication of official statistics that serve the public good. All our collection and use of data comes from powers that can be found in that Act or other UK legislation."
 msgstr "Mae SYG yn gorff statudol, sy'n golygu y cafodd ei greu gan ddeddfwriaeth, sef <a href='{url}'>Deddf Ystadegau a Gwasanaeth Cofrestru 2007</a> yn benodol. Ein hamcan yw hybu a diogelu'r gwaith o gynhyrchu a chyhoeddi ystadegau swyddogol sydd o fudd i'r cyhoedd. Mae ein holl waith casglu a defnyddio data yn deillio o bwerau sydd i'w gweld yn y Ddeddf honno neu ddeddfwriaeth arall y DU."
 
-#: templates/static/privacy.html:52
+#: templates/static/privacy.html:53
 msgid "The census rehearsal questionnaire has been assessed as compatible with the <a href='{url}'>Human Rights Act 1998</a>, specifically Article 8 (right to respect for a private and family life) and Article 9 (freedom of thought, conscience and religion) of the convention rights."
 msgstr "Aseswyd bod holiadur ymarfer y cyfrifiad yn gydnaws â <a href='{url}'>Deddf Hawliau Dynol 1998</a>, yn benodol Erthygl 8 (hawl i barch at fywyd preifat a bywyd teuluol) ac Erthygl 9 (rhyddid meddwl, cydwybod a chrefydd) o hawliau'r confensiwn."
 
-#: templates/static/privacy.html:55
+#: templates/static/privacy.html:56
 msgid "Legal basis for processing your data"
 msgstr "Sail gyfreithiol prosesu eich data"
 
-#: templates/static/privacy.html:57
+#: templates/static/privacy.html:58
 msgid "Data protection legislation requires that all processing of personal data is undertaken under one or more conditions."
 msgstr "Mae deddfwriaeth diogelu data yn ei gwneud yn ofynnol i'r holl waith o brosesu data personol gael ei gyflawni o dan un amod neu fwy."
 
-#: templates/static/privacy.html:59
+#: templates/static/privacy.html:60
 msgid "For the census rehearsal, we’ll process information from your questionnaire, information about a property or an individual and information about how people fill in their questionnaires under the following condition:"
 msgstr "Ar gyfer ymarfer y cyfrifiad, byddwn yn prosesu gwybodaeth o'ch holiadur, gwybodaeth am eiddo neu unigolyn a gwybodaeth am y ffordd mae pobl yn llenwi eu holiaduron o dan yr amod canlynol:"
 
-#: templates/static/privacy.html:62
+#: templates/static/privacy.html:63
 msgid "processing is necessary for the performance of a task carried out in the public interest or in the exercise of official authority vested in the controller."
 msgstr "mae prosesu yn angenrheidiol er mwyn cyflawni tasg a wneir er budd y cyhoedd neu wrth arfer awdurdod swyddogol sydd gan y rheolydd."
 
-#: templates/static/privacy.html:65
+#: templates/static/privacy.html:66
 msgid "Under data protection legislation, an additional condition is required for the processing of special category personal data. These data include information about your racial or ethnic origin, political opinions, religious or philosophical beliefs, trade union membership, sex life or sexual orientation. They also include genetic and biometric data."
 msgstr "O dan ddeddfwriaeth diogelu data, mae amod ychwanegol yn ofynnol ar gyfer prosesu data personol categori arbennig. Mae'r data hyn yn cynnwys gwybodaeth am eich tarddiad hiliol neu ethnig, barn wleidyddol, credoau crefyddol neu athronyddol, aelodaeth o undeb llafur, bywyd rhywiol neu gyfeiriadedd rhywiol. Maent hefyd yn cynnwys data genetig a data biometrig."
 
-#: templates/static/privacy.html:67
+#: templates/static/privacy.html:68
 msgid "For the rehearsal, we’ll process special category personal data on race, ethnicity, religion, philosophical beliefs and sexual orientation. nformation from your questionnaire is processed under the following two conditions:"
 msgstr "Ar gyfer yr ymarfer, byddwn yn prosesu data personol categori arbennig ar hil, ethnigrwydd, crefydd, credoau athronyddol a chyfeiriadedd rhywiol. Caiff gwybodaeth o'ch holiadur ei phrosesu o dan y ddau amod canlynol:"
 
-#: templates/static/privacy.html:70
+#: templates/static/privacy.html:71
 msgid "processing is necessary for archiving in the public interest, scientific or historical research purposes or statistical purposes based on UK law."
 msgstr "mae prosesu yn angenrheidiol ar gyfer archifo er budd y cyhoedd, at ddibenion ymchwil wyddonol neu hanesyddol neu at ddibenion ystadegol yn seiliedig ar gyfraith y DU."
 
-#: templates/static/privacy.html:71 templates/static/privacy.html:77
+#: templates/static/privacy.html:72 templates/static/privacy.html:78
 msgid "processing is necessary for reasons of substantial public interest."
 msgstr "mae prosesu yn angenrheidiol ar sail budd sylweddol i'r cyhoedd."
 
-#: templates/static/privacy.html:74
+#: templates/static/privacy.html:75
 msgid "We’ll process special category data on information about a property or an individual under the following condition:"
 msgstr "Byddwn yn prosesu data categori arbennig ar wybodaeth am eiddo neu unigolyn o dan yr amod canlynol:"
 
-#: templates/static/privacy.html:80
+#: templates/static/privacy.html:81
 msgid "We’ll ensure the principle of data minimisation and have measures in place to delete or de-identify personal data where appropriate."
 msgstr "Byddwn yn sicrhau egwyddor lleihau data a bydd gennym fesurau ar waith i ddileu data personol neu dynnu unrhyw wybodaeth y gellir ei defnyddio i adnabod unigolyn o ddata personol lle y bo'n briodol."
 
-#: templates/static/privacy.html:82
+#: templates/static/privacy.html:83
 msgid "The census rehearsal gives us invaluable information about the systems and processes required for Census 2021. It’ll help us complete one of our main functions in delivering Census 2021, which will subsequently provide numerous benefits for the wider society."
 msgstr "Mae ymarfer y cyfrifiad yn rhoi gwybodaeth werthfawr tu hwnt i ni am y systemau a'r prosesau sy'n ofynnol ar gyfer Cyfrifiad 2021. Bydd yn ein helpu i gwblhau un o'n prif swyddogaethau wrth gynnal Cyfrifiad 2021, a fydd yn arwain at fanteision niferus i gymdeithas yn ehangach."
 
-#: templates/static/privacy.html:84
+#: templates/static/privacy.html:85
 msgid "There’s substantial public interest in the collection of safeguarding data to ensure the safety of both interviewers and respondents. We’re required to ensure the safety of our staff and the public."
 msgstr "Mae casglu data diogelu i sicrhau diogelwch cyfwelwyr ac ymatebwyr o fudd sylweddol i'r cyhoedd. Mae'n ofynnol i ni sicrhau diogelwch ein staff a'r cyhoedd."
 
-#: templates/static/privacy.html:87
+#: templates/static/privacy.html:88
 msgid "Your rights"
 msgstr "Eich hawliau"
 
-#: templates/static/privacy.html:89
+#: templates/static/privacy.html:90
 msgid "As a data subject (someone whose personal data we hold), you have rights available to you under data protection law. If you wish to exercise any of these rights, please contact our data protection officer. However, please be aware that we may not be required to comply if the data are being held for statistical purposes only. Compliance requirements are set out in the Data Protection Act 2018."
 msgstr "Fel testun data (rhywun rydym yn cadw data personol amdano), mae gennych hawliau o dan gyfraith diogelu data. Os byddwch am arfer unrhyw un o'r hawliau hyn, cysylltwch â'n swyddog diogelu data. Fodd bynnag, dylech fod yn ymwybodol efallai na fydd yn ofynnol i ni gydymffurfio, os yw'r data'n cael eu cadw at ddibenion ystadegol yn unig. Nodir gofynion cydymffurfio yn Neddf Diogelu Data 2018."
 
-#: templates/static/privacy.html:91
+#: templates/static/privacy.html:92
 msgid "You have the right to request from any controller that holds your personal data access to the information they hold about you. You can ask them to amend any wrong or inaccurate information they hold about you. You have the right to object to your personal data being processed."
 msgstr "Mae gennych hawl i ofyn i unrhyw reolydd sy'n cadw eich data personol am gael gweld y wybodaeth sydd ganddo amdanoch. Gallwch ofyn i'r rheolydd newid unrhyw wybodaeth anghywir sydd ganddo amdanoch. Mae gennych hawl i wrthwynebu'r gwaith o brosesu eich data personol."
 
-#: templates/static/privacy.html:93
+#: templates/static/privacy.html:94
 msgid "You have the right, in some circumstances, to ask for any controller to:"
 msgstr "Mae gennych hawl, o dan rai amgylchiadau, i ofyn i unrhyw reolydd wneud y canlynol:"
 
-#: templates/static/privacy.html:96
+#: templates/static/privacy.html:97
 msgid "erase any personal data they may hold about you"
 msgstr "dileu unrhyw ddata personol sydd ganddo amdanoch"
 
-#: templates/static/privacy.html:97
+#: templates/static/privacy.html:98
 msgid "stop processing your personal data"
 msgstr "rhoi'r gorau i brosesu eich data personol"
 
-#: templates/static/privacy.html:98
+#: templates/static/privacy.html:99
 msgid "pass any information they hold about you to another controller"
 msgstr "trosglwyddo unrhyw wybodaeth sydd ganddo amdanoch i reolydd arall"
 
-#: templates/static/privacy.html:101
+#: templates/static/privacy.html:102
 msgid "You can get further information on the rights available to you and the circumstances under which you can exercise them from the <a href='{url}'>Information Commissioner’s Office</a>."
 msgstr "Gallwch gael rhagor o wybodaeth am eich hawliau a'r amgylchiadau lle y gallwch eu harfer gan <a href='{url}'>Swyddfa'r Comisiynydd Gwybodaeth</a>."
 
-#: templates/static/privacy.html:104
+#: templates/static/privacy.html:105
 msgid "The data controller"
 msgstr "Y rheolydd data"
 
-#: templates/static/privacy.html:106
+#: templates/static/privacy.html:107
 msgid "The controller is the person or organisation that decides which personal data will be processed and for what purpose. For the census rehearsal, the ONS is the controller and makes those decisions."
 msgstr "Y rheolydd yw'r person neu'r sefydliad sy'n penderfynu pa ddata personol fydd yn cael eu prosesu ac at ba ddiben. Ar gyfer ymarfer y cyfrifiad, SYG yw'r rheolydd ac sy'n gwneud y penderfyniadau hynny."
 
-#: templates/static/privacy.html:108
+#: templates/static/privacy.html:109
 msgid "You can contact us by:"
 msgstr "Gallwch gysylltu â ni fel a ganlyn:"
 
-#: templates/static/privacy.html:110
+#: templates/static/privacy.html:111
 #, python-format
 msgid "Telephone: %(telephone_number)s"
 msgstr "Ffôn: %(telephone_number)s"
 
-#: templates/static/privacy.html:112
+#: templates/static/privacy.html:113
 #, python-format
 msgid "Email: %(email_address)s"
 msgstr "E-bost: %(email_address)s"
 
-#: templates/static/privacy.html:114 templates/static/privacy.html:134
-#: templates/static/privacy.html:155
+#: templates/static/privacy.html:115 templates/static/privacy.html:135
+#: templates/static/privacy.html:156
 msgid "Post:"
 msgstr "Cyfeiriad:"
 
-#: templates/static/privacy.html:124
+#: templates/static/privacy.html:125
 msgid "How to contact the data protection officer"
 msgstr "Sut i gysylltu â'r swyddog diogelu data"
 
-#: templates/static/privacy.html:126
+#: templates/static/privacy.html:127
 msgid "Our data protection officer is the person charged with providing us with advice and guidance on the ways we can best protect the information we collect and use. They are involved in all the major decisions we make in relation to personal data. If you have any queries or concerns regarding our use of your data, or wish to exercise any of your rights."
 msgstr "Ein swyddog diogelu data yw'r person sy'n gyfrifol am roi cyngor ac arweiniad i ni ar y ffyrdd gorau y gallwn ddiogelu'r wybodaeth rydym yn ei chasglu a'i defnyddio. Mae'n rhan o'r holl benderfyniadau mawr a wnawn mewn perthynas â data personol. Os oes gennych chi unrhyw ymholiadau neu bryderon ynghylch ein defnydd o'ch data, neu os hoffech arfer unrhyw un o'ch hawliau."
 
-#: templates/static/privacy.html:128
+#: templates/static/privacy.html:129
 msgid "You can contact the data protection officer by:"
 msgstr "Gallwch gysylltu â'r swyddog diogelu data fel a ganlyn:"
 
-#: templates/static/privacy.html:130 templates/static/privacy.html:151
+#: templates/static/privacy.html:131 templates/static/privacy.html:152
 msgid "Telephone: {telephone_number}"
 msgstr "Ffôn: {telephone_number}"
 
-#: templates/static/privacy.html:132 templates/static/privacy.html:153
+#: templates/static/privacy.html:133 templates/static/privacy.html:154
 msgid "Email: {email_address}"
 msgstr "E-bost: {email_address}"
 
-#: templates/static/privacy.html:145
+#: templates/static/privacy.html:146
 msgid "The Information Commissioner’s Office"
 msgstr "Swyddfa'r Comisiynydd Gwybodaeth"
 
-#: templates/static/privacy.html:147
+#: templates/static/privacy.html:148
 msgid "The Information Commissioner’s Office (ICO) is the independent organisation tasked with regulating data protection in the UK. The ICO can give you <a href='{url}'>extra information about data protection</a> and your rights and will deal with any complaints you may have about our use of your information."
 msgstr "Swyddfa'r Comisiynydd Gwybodaeth yw'r sefydliad annibynnol sy'n gyfrifol am reoleiddio gwaith diogelu data yn y DU. Gall Swyddfa'r Comisiynydd Gwybodaeth roi <a href='{url}'>gwybodaeth ychwanegol i chi am ddiogelu data</a> a'ch hawliau a bydd yn delio ag unrhyw gwynion a all fod gennych am ein defnydd o'ch data."
 
-#: templates/static/privacy.html:149
+#: templates/static/privacy.html:150
 msgid "You can contact the ICO by:"
 msgstr "Gallwch gysylltu â Swyddfa'r Comisiynydd Gwybodaeth fel a ganlyn:"
 


### PR DESCRIPTION
### What is the context of this PR?
Updates the static translations for `cy`. Translation for `eo` and `ga` were no different.

### How to review 
Ensure the translations match the ones in Crowdin.

The cy version had an issue where a placeholder was added when it shouldn't have been.
To fix this, line 707 was updated from
 ```
msgstr[0] "Mae %(num)s broblem gyda'ch ateb"
```
To:
```
msgstr[0] "Mae problem gyda'ch ateb"
``````
### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
