### PR TITLE
Add feedback sent template button text to translations template

### DIFF
--- a/app/translations/messages.pot
+++ b/app/translations/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-11-06 14:44+0000\n"
+"POT-Creation-Date: 2020-11-09 09:45+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -653,6 +653,10 @@ msgstr ""
 msgid ""
 "Your comments will help us make improvements to our surveys. We are not "
 "able to reply to comments, but we appreciate your feedback"
+msgstr ""
+
+#: templates/feedback-sent.html:28
+msgid "Done"
 msgstr ""
 
 #: templates/feedback.html:15

--- a/templates/feedback-sent.html
+++ b/templates/feedback-sent.html
@@ -25,7 +25,7 @@
     onsButton({
         "attributes": {"data-qa": "btn-done"},
         "type": "button",
-        "text": "Done",
+        "text": _("Done"),
         "classes": "u-mb-m",
         "url": url_for('post_submission.get_thank_you')
     })


### PR DESCRIPTION
### What is the context of this PR?
This marks "Done" button text on `feedback-sent` page for translation as described on [this Trello card](https://trello.com/c/Sezy5CDM). New `messages.pot` file needs uploading to Crowdin and new `.po` file needs adding to runner.

### How to review
Check new messages.pot file and that feedback-sent html template text is marked for translation.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
