### PR TITLE
Add missing auto-suggest properties to address lookup

### DIFF
--- a/app/translations/messages.pot
+++ b/app/translations/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-11-09 09:45+0000\n"
+"POT-Creation-Date: 2020-11-10 17:17+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -67,7 +67,7 @@ msgstr ""
 msgid "Enter a date"
 msgstr ""
 
-#: app/forms/error_messages.py:23 templates/partials/answers/address.html:54
+#: app/forms/error_messages.py:23 templates/partials/answers/address.html:56
 msgid "Enter an address"
 msgstr ""
 
@@ -719,7 +719,7 @@ msgstr ""
 msgid "Close this window to continue with your current survey"
 msgstr ""
 
-#: templates/partials/answers/address.html:53 templates/question.html:10
+#: templates/partials/answers/address.html:55 templates/question.html:10
 #, python-format
 msgid "There is a problem with your answer"
 msgid_plural "There are %(num)s problems with your answer"
@@ -1156,34 +1156,42 @@ msgid ""
 msgstr ""
 
 #: templates/partials/answers/address.html:47
-msgid "Enter more of the address to improve results"
+msgid "There are {n} for {x}"
 msgstr ""
 
 #: templates/partials/answers/address.html:48
-msgid "Select an address"
+msgid "{n} addresses"
 msgstr ""
 
 #: templates/partials/answers/address.html:49
-msgid "No results found. Try entering a different part of the address"
+msgid "Enter more of the address to improve results"
 msgstr ""
 
 #: templates/partials/answers/address.html:50
-msgid "{n} results found. Enter more of the address to improve results"
+msgid "Select an address"
 msgstr ""
 
 #: templates/partials/answers/address.html:51
+msgid "No results found. Try entering a different part of the address"
+msgstr ""
+
+#: templates/partials/answers/address.html:52
+msgid "{n} results found. Enter more of the address to improve results"
+msgstr ""
+
+#: templates/partials/answers/address.html:53
 msgid "Enter more of the address to get results"
 msgstr ""
 
-#: templates/partials/answers/address.html:55
+#: templates/partials/answers/address.html:57
 msgid "Select or manually enter an address"
 msgstr ""
 
-#: templates/partials/answers/address.html:56
+#: templates/partials/answers/address.html:58
 msgid "Sorry, there was a problem loading addresses"
 msgstr ""
 
-#: templates/partials/answers/address.html:57
+#: templates/partials/answers/address.html:59
 msgid "Enter address manually"
 msgstr ""
 

--- a/templates/partials/answers/address.html
+++ b/templates/partials/answers/address.html
@@ -44,6 +44,8 @@
     "ariaOneResult": _("There is one suggestion available."),
     "ariaNResults": _("There are {n} suggestions available."),
     "ariaLimitedResults": _("Results have been limited to 10 suggestions. Type more characters to improve your search"),
+    "ariaGroupedResults": _("There are {n} for {x}"),
+    "groupCount": _("{n} addresses"),
     "moreResults": _("Enter more of the address to improve results"),
     "resultsTitle": _("Select an address"),
     "noResults": _("No results found. Try entering a different part of the address"),


### PR DESCRIPTION
### What is the context of this PR?
Add missing auto-suggest properties to address lookup used by screen readers. Checked with Matt and confirmed that these are only needed for address lookups and not textfield suggestion lookups.

### How to review 
Try the address lookup and ensure results are grouped when search term is too broad i.e. `CF63`
To test `"There are {n} for {x}"` you will have to use the VoiceOver feature and hover over a grouped result, which should read like `There are 8 addresses for Court Road, Barry, CF63 1AB` etc.

Before:
<img width="677" alt="Screenshot 2020-11-10 at 17 22 03" src="https://user-images.githubusercontent.com/35296336/98708635-4b85b180-2379-11eb-8035-d5032978e0ad.png">

After:
<img width="676" alt="Screenshot 2020-11-10 at 17 21 46" src="https://user-images.githubusercontent.com/35296336/98708657-504a6580-2379-11eb-8209-7c8fadc769e3.png">

### Checklist

* [x] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
