### PR TITLE
Update googletagmanager querystring

### DIFF
--- a/app/setup.py
+++ b/app/setup.py
@@ -51,7 +51,10 @@ CSP_POLICY = {
         "https://fonts.googleapis.com",
         "'unsafe-inline'",
     ],
-    "connect-src": ["'self'"],
+    "connect-src": [
+        "'self'",
+        "https://www.google-analytics.com",
+    ],
     "frame-src": ["https://www.googletagmanager.com"],
     "img-src": [
         "'self'",

--- a/app/setup.py
+++ b/app/setup.py
@@ -51,10 +51,7 @@ CSP_POLICY = {
         "https://fonts.googleapis.com",
         "'unsafe-inline'",
     ],
-    "connect-src": [
-        "'self'",
-        "https://www.google-analytics.com",
-    ],
+    "connect-src": ["'self'"],
     "frame-src": ["https://www.googletagmanager.com"],
     "img-src": [
         "'self'",

--- a/templates/layouts/_base.html
+++ b/templates/layouts/_base.html
@@ -85,7 +85,7 @@
       (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
       new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
       j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-      'https://www.googletagmanager.com/gtm.js?id='+i+dl+ '&gtm_auth={{ google_tag_manager_auth }}&gtm_preview={{ google_tag_manager_preview }}&gtm_cookies_win=x';f.parentNode.insertBefore(j,f);
+      'https://www.googletagmanager.com/gtm.js?id='+i+dl+ '&gtm_auth={{ google_tag_manager_auth }}&gtm_cookies_win=x';f.parentNode.insertBefore(j,f);
       })(window,document,'script','dataLayer','{{ google_tag_manager_id }}');
     </script>
     <!-- End Google Tag Manager -->


### PR DESCRIPTION
A breaking googletagmanager api change means the `gtm_preview` parameter needs to be removed from the request in the snippet. The presence of this param causes the request to fail with a 404.

Check that a GTM integrated environment no longer results in a 404 for the gtm.js resource when an EQ page loads.

While investigating (and fixing) this initial issue it was found that a subsequent content-security-policy is breached by the current GTM script. The connect-src does not allow the necessary GTM domains for the scripts to function. This is not being resolved by this PR as we first need to better understand the implications of relaxing the CSP for this domain (as the relaxation should not be required for GTM to function).