### PR TITLE
Fix strings in templates not being marked for translation when using .format

### DIFF
--- a/app/translations/messages.pot
+++ b/app/translations/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-11-24 13:56+0000\n"
+"POT-Creation-Date: 2020-11-24 14:45+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1123,6 +1123,12 @@ msgstr ""
 msgid ""
 "You can <em>share your household access code</em> with the people you "
 "live with so they can complete their own sections."
+msgstr ""
+
+#: templates/partials/individual-response-guidance.html:25
+msgid ""
+"If this is not possible, there are <a href={url}>other ways each person "
+"can complete their own census.</a>"
 msgstr ""
 
 #: templates/partials/last_viewed_question_guidance.html:7

--- a/app/translations/messages.pot
+++ b/app/translations/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-11-24 14:45+0000\n"
+"POT-Creation-Date: 2020-11-24 14:56+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -997,10 +997,18 @@ msgid ""
 "for help."
 msgstr ""
 
+#: templates/individual_response/confirmation-post.html:15
+msgid "A letter has been sent to Individual Resident at {display_address}"
+msgstr ""
+
 #: templates/individual_response/confirmation-post.html:17
 msgid ""
 "The letter with an individual access code should arrive soon for them to "
 "complete their own census"
+msgstr ""
+
+#: templates/individual_response/confirmation-text-message.html:15
+msgid "We have sent a text to {mobile_number}"
 msgstr ""
 
 #: templates/individual_response/confirmation-text-message.html:17
@@ -1031,6 +1039,12 @@ msgstr ""
 
 #: templates/individual_response/interstitial.html:13
 msgid "Request separate census"
+msgstr ""
+
+#: templates/individual_response/question.html:9
+msgid ""
+"To request a census in a different format or for further help, please <a "
+"href='{contact_us_url}'>contact us</a>"
 msgstr ""
 
 #: templates/layouts/_base.html:18

--- a/templates/individual_response/confirmation-post.html
+++ b/templates/individual_response/confirmation-post.html
@@ -12,7 +12,7 @@
         "iconSize": "l"
         }) %}
     <h1 id="question-title"class="question__title u-mb-xs u-fs-l js-piping">
-        {{ _("A letter has been sent to Individual Resident at {display_address}".format(display_address=display_address)) }}
+        {{ _("A letter has been sent to Individual Resident at {display_address}").format(display_address=display_address) }}
     </h1>
     <p>{{ _("The letter with an individual access code should arrive soon for them to complete their own census") }}</p>
     {% endcall %}

--- a/templates/individual_response/confirmation-text-message.html
+++ b/templates/individual_response/confirmation-text-message.html
@@ -12,7 +12,7 @@
         "iconSize": "l"
         }) %}
     <h1 id="question-title"class="question__title u-mb-xs u-fs-l js-piping">
-        {{ _("We have sent a text to {mobile_number}".format(mobile_number=mobile_number)) }}
+        {{ _("We have sent a text to {mobile_number}").format(mobile_number=mobile_number) }}
     </h1>
     <p>{{ _("The text message with an individual access code should arrive soon for them to complete their own census") }}</p>
     {% endcall %}

--- a/templates/individual_response/question.html
+++ b/templates/individual_response/question.html
@@ -6,6 +6,6 @@
 
 {% block after_submit_button_content %}
     {% if show_contact_us_guidance %}
-      <p class='u-mt-xl'>{{ _("To request a census in a different format or for further help, please <a href='{contact_us_url}'>contact us</a>".format(contact_us_url=contact_us_url)) }}</p>
+      <p class='u-mt-xl'>{{ _("To request a census in a different format or for further help, please <a href='{contact_us_url}'>contact us</a>").format(contact_us_url=contact_us_url) }}</p>
     {% endif %}
 {% endblock %}

--- a/templates/partials/individual-response-guidance.html
+++ b/templates/partials/individual-response-guidance.html
@@ -22,6 +22,6 @@
 }) %}
   <div class="u-mt-s">
       <p>{{ _("You can <em>share your household access code</em> with the people you live with so they can complete their own sections.") }}</p>
-      <p data-qa=individual-response-url >{{ _("If this is not possible, there are <a href={url}>other ways each person can complete their own census.</a>".format(url=content.individual_response_url))}}</p>
+      <p data-qa=individual-response-url >{{ _("If this is not possible, there are <a href={url}>other ways each person can complete their own census.</a>").format(url=content.individual_response_url)}}</p>
   </div>
 {% endcall %}


### PR DESCRIPTION
### What is the context of this PR?

Fixes an issue where some strings using .format in templates were not being marked for translation due to miss-placed brackets.

### How to review 

Check that the updated strings are being displayed correctly and any placeholders\links are still working.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
