### PR TITLE
Unpin pylint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ format: format-python
 	yarn format
 
 format-python:
-	pipenv run isort --recursive .
+	pipenv run isort .
 	pipenv run black .
 
 test:

--- a/Pipfile
+++ b/Pipfile
@@ -8,7 +8,7 @@ verify_ssl = true
 mock = "*"
 pytest-cov = "*"
 jsonschema = "*"
-pylint = "==2.4.4"
+pylint = "*"
 pylint-mccabe = "*"
 pylint-quotes = "*"
 "beautifulsoup4" = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "83e106c04c2fb4d87d5840cd8a79c92c318976d36df5d21ac554d65c2dc8b101"
+            "sha256": "c6a5186982ce71dba777eb0b5e76f1128137b3db9c33d8adfe668e76870e611c"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -998,11 +998,11 @@
         },
         "astroid": {
             "hashes": [
-                "sha256:71ea07f44df9568a75d0f354c49143a4575d90645e9fead6dfb52c26a85ed13a",
-                "sha256:840947ebfa8b58f318d42301cf8c0a20fd794a33b61cc4638e28e9e61ba32f42"
+                "sha256:2f4078c2a41bf377eea06d71c9d2ba4eb8f6b1af2135bec27bbbb7d8f12bb703",
+                "sha256:bc58d83eb610252fd8de6363e39d4f1d0619c894b0ed24603b881c02e64c7386"
             ],
             "markers": "python_version >= '3.5'",
-            "version": "==2.3.3"
+            "version": "==2.4.2"
         },
         "attrs": {
             "hashes": [
@@ -1342,11 +1342,11 @@
         },
         "isort": {
             "hashes": [
-                "sha256:54da7e92468955c4fceacd0c86bd0ec997b0e1ee80d97f67c35a78b719dccab1",
-                "sha256:6e811fcb295968434526407adb8796944f1988c5b65e8139058f2014cbe100fd"
+                "sha256:dcab1d98b469a12a1a624ead220584391648790275560e1a43e54c5dceae65e7",
+                "sha256:dcaeec1b5f0eca77faea2a35ab790b4f3680ff75590bfcb7145986905aab2f58"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==4.3.21"
+            "markers": "python_version >= '3.6' and python_version < '4'",
+            "version": "==5.6.4"
         },
         "itsdangerous": {
             "hashes": [
@@ -1631,11 +1631,11 @@
         },
         "pylint": {
             "hashes": [
-                "sha256:3db5468ad013380e987410a8d6956226963aed94ecb5f9d3a28acca6d9ac36cd",
-                "sha256:886e6afc935ea2590b462664b161ca9a5e40168ea99e5300935f6591ad467df4"
+                "sha256:bb4a908c9dadbc3aac18860550e870f58e1a02c9f2c204fdf5693d73be061210",
+                "sha256:bfe68f020f8a0fece830a22dd4d5dddb4ecc6137db04face4c3420a46a52239f"
             ],
             "index": "pypi",
-            "version": "==2.4.4"
+            "version": "==2.6.0"
         },
         "pylint-mccabe": {
             "hashes": [
@@ -1956,9 +1956,9 @@
         },
         "wrapt": {
             "hashes": [
-                "sha256:565a021fd19419476b9362b05eeaa094178de64f8361e44468f9e9d7843901e1"
+                "sha256:b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7"
             ],
-            "version": "==1.11.2"
+            "version": "==1.12.1"
         },
         "xmltodict": {
             "hashes": [

--- a/scripts/run_lint_python.sh
+++ b/scripts/run_lint_python.sh
@@ -28,7 +28,7 @@ pylint --reports=n --output-format=colorized --rcfile=.pylintrc -j 0 **/*.py *.p
 # http://stackoverflow.com/questions/6626351/how-to-extract-bits-from-return-code-number-in-bash
 display_result $? 1 "Pylint linting check"
 
-isort --check --recursive .
+isort --check .
 display_result $? 1 "isort linting check"
 
 ./scripts/run_mypy.sh


### PR DESCRIPTION
### What is the context of this PR?
Unpins pylint.

The recursive option is the default for isort in the latest version.

### How to review 
Test that linting works. Note that there is an outstanding issue that pylint is not checking all files, I have created a card for this as there is a lot of linting errors that need to be worked through.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
