### PR TITLE
Add SubmitType equal to timer to 'save and continue' button

### DIFF
--- a/templates/layouts/_questionnaire.html
+++ b/templates/layouts/_questionnaire.html
@@ -23,6 +23,7 @@
   {% block submit_button %}
       {{
           onsButton({
+              "submitType": "timer",
               "text": continue_button_text | default(_("Save and continue")),
               "classes": "u-mt-xl",
               "attributes": {


### PR DESCRIPTION
### What is the context of this PR?
This adds submit type ('SubmitType', [check DS component)](https://ons-design-system.netlify.app/components/button/) to questionnaire template button and sets it to 'timer' to prevent from double clicking on 'save and continue' and adding additional person to the household. [Trello card with bug description](https://trello.com/c/yNEM1BTY).

### How to review 
Inspect 'Save and continue' button using chrome dev tools. Check if button html component has a new "js-timer" class attached to it. Compare with default button. Try double clicking when adding extra person to the household (non-primary).

### Checklist

* [x] New static content marked up for translation
* [x] Newly defined schema content included in eq-translations repo
