### PR TITLE
Checkbox/Radio answer labels with escaped characters not being displayed on the summary pages

### DIFF
--- a/app/views/contexts/summary/question.py
+++ b/app/views/contexts/summary/question.py
@@ -1,3 +1,4 @@
+from jinja2 import escape, Markup
 from app.views.contexts.summary.answer import Answer
 
 
@@ -95,7 +96,7 @@ class Question:
     def _build_checkbox_answers(self, answer, answer_schema, answer_store):
         multiple_answers = []
         for option in answer_schema["options"]:
-            if option["value"] in answer:
+            if escape(option["value"]) in answer:
                 detail_answer_value = self._get_detail_answer_value(
                     option, answer_store
                 )
@@ -116,7 +117,7 @@ class Question:
 
     def _build_radio_answer(self, answer, answer_schema, answer_store):
         for option in answer_schema["options"]:
-            if answer == option["value"]:
+            if answer == escape(option["value"]):
                 detail_answer_value = self._get_detail_answer_value(
                     option, answer_store
                 )

--- a/app/views/contexts/summary/question.py
+++ b/app/views/contexts/summary/question.py
@@ -1,4 +1,5 @@
 from jinja2 import escape
+
 from app.views.contexts.summary.answer import Answer
 
 

--- a/app/views/contexts/summary/question.py
+++ b/app/views/contexts/summary/question.py
@@ -1,4 +1,4 @@
-from jinja2 import escape, Markup
+from jinja2 import escape
 from app.views.contexts.summary.answer import Answer
 
 

--- a/test_schemas/en/test_checkbox.json
+++ b/test_schemas/en/test_checkbox.json
@@ -47,8 +47,8 @@
                                                 "q_code": "0"
                                             },
                                             {
-                                                "label": "Cheese",
-                                                "value": "Cheese",
+                                                "label": "Ham & Cheese",
+                                                "value": "Ham & Cheese",
                                                 "q_code": "1"
                                             },
                                             {

--- a/test_schemas/en/test_radio_mandatory.json
+++ b/test_schemas/en/test_radio_mandatory.json
@@ -48,6 +48,10 @@
                                             {
                                                 "label": "Tea",
                                                 "value": "Tea"
+                                            },
+                                            {
+                                                "label": "Tea & Coffee",
+                                                "value": "Tea & Coffee"
                                             }
                                         ]
                                     }

--- a/tests/app/views/contexts/summary/test_question.py
+++ b/tests/app/views/contexts/summary/test_question.py
@@ -401,12 +401,12 @@ class TestQuestion(AppContextTestCase):  # pylint: disable=too-many-public-metho
     def test_checkbox_answer_with_numeric_detail_answer_returns_number(self):
         # Given
         self.answer_store.add_or_update(
-            Answer(answer_id="answer_1", value=[1, "Other"])
+            Answer(answer_id="answer_1", value=["1", "Other"])
         )
         self.answer_store.add_or_update(Answer(answer_id="child_answer", value=2))
 
         options = [
-            {"label": 1, "value": 1},
+            {"label": "1", "value": "1"},
             {
                 "label": "Other",
                 "value": "Other",

--- a/tests/functional/spec/checkbox.spec.js
+++ b/tests/functional/spec/checkbox.spec.js
@@ -95,7 +95,7 @@ describe('Checkbox with "other" option', () => {
     expect($(SummaryPage.nonMandatoryCheckboxAnswer()).getText()).to.contain("The other value");
   });
 
-  t("Given that there is an escaped character in an answer label, when the user selects the answer, then the label should be displayed on the summary screen", () => {
+  it("Given that there is an escaped character in an answer label, when the user selects the answer, then the label should be displayed on the summary screen", () => {
     // When
     $(MandatoryCheckboxPage.hamCheese()).click();
     $(MandatoryCheckboxPage.submit()).click();

--- a/tests/functional/spec/checkbox.spec.js
+++ b/tests/functional/spec/checkbox.spec.js
@@ -95,6 +95,18 @@ describe('Checkbox with "other" option', () => {
     expect($(SummaryPage.nonMandatoryCheckboxAnswer()).getText()).to.contain("The other value");
   });
 
+  t("Given that there is an escaped character in an answer label, when the user selects the answer, then the label should be displayed on the summary screen", () => {
+    // When
+    $(MandatoryCheckboxPage.hamCheese()).click();
+    $(MandatoryCheckboxPage.submit()).click();
+    $(NonMandatoryCheckboxPage.other()).click();
+    $(NonMandatoryCheckboxPage.otherDetail()).setValue("The other value");
+    $(NonMandatoryCheckboxPage.submit()).click();
+    $(singleCheckboxPage.submit()).click();
+    // Then
+    expect($(SummaryPage.mandatoryCheckboxAnswer()).getText()).to.contain("Ham & Cheese");
+  });
+
   it("Given I have previously added text in other textfield and saved, when I uncheck other options and select a different checkbox as answer, then the text entered in other field must be wiped.", () => {
     // When
     $(MandatoryCheckboxPage.other()).click();
@@ -102,7 +114,7 @@ describe('Checkbox with "other" option', () => {
     $(MandatoryCheckboxPage.submit()).click();
     $(NonMandatoryCheckboxPage.previous()).click();
     $(MandatoryCheckboxPage.other()).click();
-    $(MandatoryCheckboxPage.cheese()).click();
+    $(MandatoryCheckboxPage.hamCheese()).click();
     $(MandatoryCheckboxPage.submit()).click();
     $(NonMandatoryCheckboxPage.previous()).click();
     // Then
@@ -126,7 +138,7 @@ describe('Checkbox with "other" option', () => {
   it("Given a mandatory checkbox answer, when the user selects more than one option, then the answer should be displayed as a list on the summary screen", () => {
     // When
     $(MandatoryCheckboxPage.ham()).click();
-    $(MandatoryCheckboxPage.cheese()).click();
+    $(MandatoryCheckboxPage.hamCheese()).click();
     $(MandatoryCheckboxPage.submit()).click();
     $(NonMandatoryCheckboxPage.submit()).click();
     $(singleCheckboxPage.submit()).click();

--- a/tests/functional/spec/components/radio/radio.js
+++ b/tests/functional/spec/components/radio/radio.js
@@ -22,18 +22,24 @@ describe("Component: Radio", () => {
       browser.openQuestionnaire("test_radio_mandatory.json");
     });
 
-    it("When I have selected a radio option, Then the selected option should be displayed in the summary", () => {
-      $(RadioMandatoryPage.coffee()).click();
-      $(RadioMandatoryPage.submit()).click();
-      expect(browser.getUrl()).to.contain(RadioMandatorySummary.pageName);
-      expect($(RadioMandatorySummary.radioMandatoryAnswer()).getText()).to.contain("Coffee");
-    });
-
     it("When I have selected a radio option that contains an escaped character, Then the selected option should be displayed in the summary", () => {
       $(RadioMandatoryPage.teaCoffee()).click();
       $(RadioMandatoryPage.submit()).click();
       expect(browser.getUrl()).to.contain(RadioMandatorySummary.pageName);
       expect($(RadioMandatorySummary.radioMandatoryAnswer()).getText()).to.contain("Tea & Coffee");
+    });
+   });
+
+  describe("Given I start a Mandatory Radio survey", () => {
+    before(() => {
+      browser.openQuestionnaire("test_radio_mandatory.json");
+    });
+
+    it("When I have selected a radio option, Then the selected option should be displayed in the summary", () => {
+      $(RadioMandatoryPage.coffee()).click();
+      $(RadioMandatoryPage.submit()).click();
+      expect(browser.getUrl()).to.contain(RadioMandatorySummary.pageName);
+      expect($(RadioMandatorySummary.radioMandatoryAnswer()).getText()).to.contain("Coffee");
     });
   });
 

--- a/tests/functional/spec/components/radio/radio.js
+++ b/tests/functional/spec/components/radio/radio.js
@@ -28,7 +28,7 @@ describe("Component: Radio", () => {
       expect(browser.getUrl()).to.contain(RadioMandatorySummary.pageName);
       expect($(RadioMandatorySummary.radioMandatoryAnswer()).getText()).to.contain("Tea & Coffee");
     });
-   });
+  });
 
   describe("Given I start a Mandatory Radio survey", () => {
     before(() => {

--- a/tests/functional/spec/components/radio/radio.js
+++ b/tests/functional/spec/components/radio/radio.js
@@ -28,6 +28,13 @@ describe("Component: Radio", () => {
       expect(browser.getUrl()).to.contain(RadioMandatorySummary.pageName);
       expect($(RadioMandatorySummary.radioMandatoryAnswer()).getText()).to.contain("Coffee");
     });
+
+    it("When I have selected a radio option that contains an escaped character, Then the selected option should be displayed in the summary", () => {
+      $(RadioMandatoryPage.teaCoffee()).click();
+      $(RadioMandatoryPage.submit()).click();
+      expect(browser.getUrl()).to.contain(RadioMandatorySummary.pageName);
+      expect($(RadioMandatorySummary.radioMandatoryAnswer()).getText()).to.contain("Tea & Coffee");
+    });
   });
 
   describe("Given I start a Mandatory Radio survey  ", () => {


### PR DESCRIPTION
### What is the context of this PR?

Fixes a bug where any answer labels for Radio and Checkbox questions that contain values that need to be escaped like `&` were not being displayed on the Summary page.

For example `Hotel, guest house, B&B, youth hostel` was displaying on the Summary page as `No answer provided`.

When checking Radio/Checkbox answers the code was previously comparing escaped Markup answer values with strings.

### How to review 

Use the updated test schemas `test_radio_mandatory` and  `test_checkbox` to check that answers with `&` are displayed on the Summary page

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
