### PR TITLE
Fix 500 error on POST to /questionnaire/relationships

### DIFF
--- a/app/routes/questionnaire.py
+++ b/app/routes/questionnaire.py
@@ -220,7 +220,7 @@ def block(schema, questionnaire_store, block_id, list_name=None, list_item_id=No
 
 @questionnaire_blueprint.route(
     "relationships/",
-    methods=["GET"],
+    methods=["GET", "POST"],
 )
 @questionnaire_blueprint.route(
     "relationships/<list_name>/<list_item_id>/to/<to_list_item_id>/",

--- a/tests/integration/questionnaire/test_questionnaire_relationships.py
+++ b/tests/integration/questionnaire/test_questionnaire_relationships.py
@@ -118,3 +118,11 @@ class TestQuestionnaireRelationships(QuestionnaireTestCase):
         self.post({"anyone-else": "No"})
 
         self.assertEqual(list_item_ids_original, list_item_ids_new)
+
+    def test_post_to_relationships_root(self):
+        self.launchSurvey("test_relationships")
+        self.add_person("Marie", "Doe")
+        self.add_person("John", "Doe")
+        self.post({"anyone-else": "No"})
+        self.post(url="/questionnaire/relationships")
+        self.assertStatusOK()


### PR DESCRIPTION
### What is the context of this PR?

Sending a POST request to `/questionnaire/relationships` was failing because it was falling into the non-relationship block handling code. Although we wouldn't expect this behaviour, it has been observed during testing, and should be handled properly. To fix this `POST` has been enabled on the `/questionnaire/relationships` endpoint, which consequently does the same as the `GET` and redirects to the first relationship.

### How to review 
I used the `test_relationships` schema, added some people and their relationships, then edited the HTML of a page in the browser Developer Tools to set `action="/questionnaire/relationships"` on the `form` element. 

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
