### PR TITLE
Add restore questionnaire state ci task

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -38,6 +38,24 @@ Questionnaire state can be backed up using the `backup_questionnaire_state.yaml`
 
 ```sh
 PROJECT_ID=<project_id> \
+BUCKET_NAME=<bucket_name> \
 fly -t <target-concourse> execute \
   --config ci/backup_questionnaire_state.yaml
 ```
+
+- `BUCKET_NAME` should not contain `gs://`
+
+## Restoring questionnaire state
+
+Questionnaire state can be restored using the `restore_questionnaire_state.yaml` task. This can be done via Concourse using the following command:
+
+```sh
+PROJECT_ID=<project_id> \
+BUCKET_NAME=<bucket_name> \
+BACKUP_NAME=<backup_name> \
+fly -t <target-concourse> execute \
+  --config ci/restore_questionnaire_state.yaml
+```
+
+- `BUCKET_NAME` should not contain `gs://`
+- `BACKUP_NAME` is the timestamped folder name containing the backup files and folders e.g. `2021-01-05T09:37:15_88808`

--- a/ci/restore_questionnaire_state.yaml
+++ b/ci/restore_questionnaire_state.yaml
@@ -1,0 +1,35 @@
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: google/cloud-sdk
+    tag: alpine
+params:
+  SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+  PROJECT_ID:
+  BUCKET_NAME:
+  BACKUP_NAME:
+outputs:
+  - name: restore-questionnaire-state-output
+run:
+  path: bash
+  args:
+    - -exc
+    - |
+      export GOOGLE_APPLICATION_CREDENTIALS=~/gcloud-service-key.json
+      cat >$GOOGLE_APPLICATION_CREDENTIALS <<EOL
+      $SERVICE_ACCOUNT_JSON
+      EOL
+
+      gcloud auth activate-service-account --key-file $GOOGLE_APPLICATION_CREDENTIALS
+      gcloud config set project "${PROJECT_ID}"
+
+      IMPORT_OPERATION=$(gcloud datastore import gs://"${BUCKET_NAME}/${BACKUP_NAME}/${BACKUP_NAME}.overall_export_metadata" --kinds="questionnaire-state" --format="value(name.scope())")
+      IMPORT_STATE=$(gcloud datastore operations describe "${IMPORT_OPERATION}" --format="value(metadata.common.state.scope())")
+      TOTAL_ENTITIES_IMPORTED=$(gcloud datastore operations describe "${IMPORT_OPERATION}" --format="value(metadata.progressEntities.workCompleted.scope())")
+
+      if [[ "${IMPORT_STATE}" == "SUCCESSFUL" ]]; then
+        echo "Questionnaire State Restore Successful - ${TOTAL_ENTITIES_IMPORTED:-0} entities imported" > "restore-questionnaire-state-output/notification-message"
+      else
+        exit 1
+      fi


### PR DESCRIPTION
### What is the context of this PR?
Adds a CI task for restoring questionnaire state. It mirrors the backup task with the addition of `BACKUP_NAME` for specifying which backup to restore. 

### How to review 
Use the README instructions to restore a backup to a GCP environment.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
