### PR TITLE
Allow multiple lookups selection

### DIFF
--- a/scripts/run_validator.sh
+++ b/scripts/run_validator.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-tag=lookups-allow-multiple-selection
+tag=latest
 docker pull onsdigital/eq-questionnaire-validator:$tag
 docker run -d -p 5001:5000 "onsdigital/eq-questionnaire-validator:$tag"

--- a/scripts/run_validator.sh
+++ b/scripts/run_validator.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-tag=latest
+tag=lookups-allow-multiple-selection
 docker pull onsdigital/eq-questionnaire-validator:$tag
 docker run -d -p 5001:5000 "onsdigital/eq-questionnaire-validator:$tag"

--- a/templates/partials/answers/textfield.html
+++ b/templates/partials/answers/textfield.html
@@ -43,7 +43,7 @@
     "ariaNResults": "There are {n} suggestions available.",
     "ariaLimitedResults": "Results have been limited to 10 suggestions. Type more characters to improve your search.",
     "autosuggestData": answer.suggestions.url,
-    "allowMultiple": answer.suggestions.allow_multiple | lower if answer.suggestions.allow_multiple is defined,
+    "allowMultiple": "true" if answer.suggestions.allow_multiple else "false"
   }) %}
   {% set config = config | setAttribute("autocomplete", "off") %}
 {% endif %}

--- a/templates/partials/answers/textfield.html
+++ b/templates/partials/answers/textfield.html
@@ -30,7 +30,7 @@
   }) %}
 {% endif %}
 
-{% if answer.suggestions_url %}
+{% if answer.suggestions.url %}
   {% set config = config | setAttribute("autosuggest", {
     "instructions": _("Use up and down keys to navigate suggestions once you\'ve typed more than two characters. Use the enter key to select a suggestion. Touch device users, explore by touch or with swipe gestures."),
     "moreResults": _("Continue entering to improve suggestions"),
@@ -42,8 +42,8 @@
     "ariaOneResult": "There is one suggestion available.",
     "ariaNResults": "There are {n} suggestions available.",
     "ariaLimitedResults": "Results have been limited to 10 suggestions. Type more characters to improve your search.",
-    "autosuggestData": answer.suggestions_url,
-    "allowMultiple": answer.allow_multiple | lower if answer.allow_multiple is defined,
+    "autosuggestData": answer.suggestions.url,
+    "allowMultiple": answer.suggestions.allow_multiple | lower if answer.suggestions.allow_multiple is defined,
   }) %}
   {% set config = config | setAttribute("autocomplete", "off") %}
 {% endif %}

--- a/templates/partials/answers/textfield.html
+++ b/templates/partials/answers/textfield.html
@@ -30,7 +30,7 @@
   }) %}
 {% endif %}
 
-{% if answer.suggestions.url %}
+{% if answer.suggestions %}
   {% set config = config | setAttribute("autosuggest", {
     "instructions": _("Use up and down keys to navigate suggestions once you\'ve typed more than two characters. Use the enter key to select a suggestion. Touch device users, explore by touch or with swipe gestures."),
     "moreResults": _("Continue entering to improve suggestions"),

--- a/templates/partials/answers/textfield.html
+++ b/templates/partials/answers/textfield.html
@@ -42,7 +42,8 @@
     "ariaOneResult": "There is one suggestion available.",
     "ariaNResults": "There are {n} suggestions available.",
     "ariaLimitedResults": "Results have been limited to 10 suggestions. Type more characters to improve your search.",
-    "autosuggestData": answer.suggestions_url
+    "autosuggestData": answer.suggestions_url,
+    "allowMultiple": answer.allow_multiple | lower if answer.allow_multiple is defined,
   }) %}
   {% set config = config | setAttribute("autocomplete", "off") %}
 {% endif %}

--- a/test_schemas/en/test_textfield_suggestions.json
+++ b/test_schemas/en/test_textfield_suggestions.json
@@ -47,6 +47,26 @@
                             "routing_rules": []
                         },
                         {
+                            "type": "Question",
+                            "id": "country-block-multiple-selections",
+                            "question": {
+                                "answers": [
+                                    {
+                                        "id": "country-multiple-selections-answer",
+                                        "label": "What is your country of birth?",
+                                        "mandatory": false,
+                                        "suggestions_url": "https://cdn.eq.census-gcp.onsdigital.uk/data/v5.0.0/gb/en/countries-of-birth.json",
+                                        "allow_multiple": true,
+                                        "type": "TextField"
+                                    }
+                                ],
+                                "id": "country-of-birth-multiple-selections-question",
+                                "title": "Title",
+                                "type": "General"
+                            },
+                            "routing_rules": []
+                        },
+                        {
                             "type": "Summary",
                             "id": "summary"
                         }

--- a/test_schemas/en/test_textfield_suggestions.json
+++ b/test_schemas/en/test_textfield_suggestions.json
@@ -38,7 +38,7 @@
                                         "mandatory": false,
                                         "suggestions": {
                                             "url": "https://cdn.eq.census-gcp.onsdigital.uk/eq-lookup-suggestions-data/v5.3.0/gb/en/countries-of-birth.json",
-                                            "allow_multiple": true
+                                            "allow_multiple": false
                                         },
                                         "type": "TextField"
                                     }

--- a/test_schemas/en/test_textfield_suggestions.json
+++ b/test_schemas/en/test_textfield_suggestions.json
@@ -50,22 +50,22 @@
                         },
                         {
                             "type": "Question",
-                            "id": "country-block-multiple-selections",
+                            "id": "multiple-country-block",
                             "question": {
                                 "answers": [
                                     {
-                                        "id": "country-multiple-selections-answer",
-                                        "label": "Country",
+                                        "id": "multiple-country-answer",
+                                        "label": "Passports",
                                         "mandatory": false,
                                         "suggestions": {
-                                            "url": "https://cdn.eq.census-gcp.onsdigital.uk/eq-lookup-suggestions-data/v5.3.0/gb/en/countries-of-birth.json",
+                                            "url": "https://cdn.eq.census-gcp.onsdigital.uk/eq-lookup-suggestions-data/v5.3.0/gb/en/passport-countries.json",
                                             "allow_multiple": true
                                         },
                                         "type": "TextField"
                                     }
                                 ],
-                                "id": "country-of-birth-multiple-selections-question",
-                                "title": "What is your country of birth?",
+                                "id": "multiple-country-question",
+                                "title": "What passports do you hold?",
                                 "type": "General"
                             }
                         },

--- a/test_schemas/en/test_textfield_suggestions.json
+++ b/test_schemas/en/test_textfield_suggestions.json
@@ -34,7 +34,7 @@
                                 "answers": [
                                     {
                                         "id": "country-answer",
-                                        "label": "What is your country of birth?",
+                                        "label": "Country",
                                         "mandatory": false,
                                         "suggestions": {
                                             "url": "https://cdn.eq.census-gcp.onsdigital.uk/eq-lookup-suggestions-data/v5.3.0/gb/en/countries-of-birth.json",
@@ -44,7 +44,7 @@
                                     }
                                 ],
                                 "id": "country-of-birth-question",
-                                "title": "Title",
+                                "title": "What is your country of birth?",
                                 "type": "General"
                             }
                         },
@@ -55,7 +55,7 @@
                                 "answers": [
                                     {
                                         "id": "country-multiple-selections-answer",
-                                        "label": "What is your country of birth?",
+                                        "label": "Country",
                                         "mandatory": false,
                                         "suggestions": {
                                             "url": "https://cdn.eq.census-gcp.onsdigital.uk/eq-lookup-suggestions-data/v5.3.0/gb/en/countries-of-birth.json",
@@ -65,7 +65,7 @@
                                     }
                                 ],
                                 "id": "country-of-birth-multiple-selections-question",
-                                "title": "Title",
+                                "title": "What is your country of birth?",
                                 "type": "General"
                             }
                         },

--- a/test_schemas/en/test_textfield_suggestions.json
+++ b/test_schemas/en/test_textfield_suggestions.json
@@ -58,7 +58,7 @@
                                         "label": "Passports",
                                         "mandatory": false,
                                         "suggestions": {
-                                            "url": "https://cdn.eq.census-gcp.onsdigital.uk/eq-lookup-suggestions-data/v5.3.0/gb/en/countries-of-birth.json",
+                                            "url": "https://cdn.eq.census-gcp.onsdigital.uk/eq-lookup-suggestions-data/v5.3.0/gb/en/passport-countries.json",
                                             "allow_multiple": true
                                         },
                                         "type": "TextField"

--- a/test_schemas/en/test_textfield_suggestions.json
+++ b/test_schemas/en/test_textfield_suggestions.json
@@ -36,15 +36,17 @@
                                         "id": "country-answer",
                                         "label": "What is your country of birth?",
                                         "mandatory": false,
-                                        "suggestions_url": "https://cdn.eq.census-gcp.onsdigital.uk/data/v5.0.0/gb/en/countries-of-birth.json",
+                                        "suggestions": {
+                                            "url": "https://cdn.eq.census-gcp.onsdigital.uk/eq-lookup-suggestions-data/v5.3.0/gb/en/countries-of-birth.json",
+                                            "allow_multiple": true
+                                        },
                                         "type": "TextField"
                                     }
                                 ],
                                 "id": "country-of-birth-question",
                                 "title": "Title",
                                 "type": "General"
-                            },
-                            "routing_rules": []
+                            }
                         },
                         {
                             "type": "Question",
@@ -55,16 +57,17 @@
                                         "id": "country-multiple-selections-answer",
                                         "label": "What is your country of birth?",
                                         "mandatory": false,
-                                        "suggestions_url": "https://cdn.eq.census-gcp.onsdigital.uk/data/v5.0.0/gb/en/countries-of-birth.json",
-                                        "allow_multiple": true,
+                                        "suggestions": {
+                                            "url": "https://cdn.eq.census-gcp.onsdigital.uk/eq-lookup-suggestions-data/v5.3.0/gb/en/countries-of-birth.json",
+                                            "allow_multiple": true
+                                        },
                                         "type": "TextField"
                                     }
                                 ],
                                 "id": "country-of-birth-multiple-selections-question",
                                 "title": "Title",
                                 "type": "General"
-                            },
-                            "routing_rules": []
+                            }
                         },
                         {
                             "type": "Summary",

--- a/test_schemas/en/test_textfield_suggestions.json
+++ b/test_schemas/en/test_textfield_suggestions.json
@@ -58,7 +58,7 @@
                                         "label": "Passports",
                                         "mandatory": false,
                                         "suggestions": {
-                                            "url": "https://cdn.eq.census-gcp.onsdigital.uk/eq-lookup-suggestions-data/v5.3.0/gb/en/passport-countries.json",
+                                            "url": "https://cdn.eq.census-gcp.onsdigital.uk/eq-lookup-suggestions-data/v5.3.0/gb/en/countries-of-birth.json",
                                             "allow_multiple": true
                                         },
                                         "type": "TextField"

--- a/tests/functional/spec/textfield_suggestions.spec.js
+++ b/tests/functional/spec/textfield_suggestions.spec.js
@@ -11,7 +11,7 @@ describe("Suggestions", () => {
 });
 
 describe("Suggestions", () => {
-  it("Given I open a textfield with a suggestions url, when I have entered text and picked suggestion from a list, then after typing text it will show new suggestions", () => {
+  it("Given I open a textfield with a suggestions url, when I have entered text and picked suggestion from a list, then after typing more text it will show new suggestions", () => {
     browser.openQuestionnaire("test_textfield_suggestions.json");
     $(SuggestionsPage.country()).setValue("United States of America");
     $(SuggestionsPage.submit()).click();

--- a/tests/functional/spec/textfield_suggestions.spec.js
+++ b/tests/functional/spec/textfield_suggestions.spec.js
@@ -16,15 +16,15 @@ describe("Suggestions", () => {
     $(SuggestionsPage.country()).setValue("United States of America");
     $(SuggestionsPage.submit()).click();
     $(MultipleSuggestionsPage.countryMultipleSelections()).click();
-    browser.keys("Ita")
+    browser.keys("Ita");
     $("#country-multiple-selections-answer-listbox li").waitForDisplayed();
     expect($$(".js-autosuggest-listbox li").length).to.equal(2);
-    $("#country-multiple-selections-answer-listbox__option--0").click()
+    $("#country-multiple-selections-answer-listbox__option--0").click();
     $(MultipleSuggestionsPage.countryMultipleSelections()).click();
-    // Browser needs to pause in order to fetch api results, otherwise it works instantly
-    browser.pause(500)
-    browser.keys(' Canada')
+    // Browser needs to pause before typing starts, otherwise this sequence is executed almost instantly
+    browser.pause(500);
+    browser.keys(" United States");
     $("#country-multiple-selections-answer-listbox li").waitForDisplayed();
-    expect($$(".js-autosuggest-listbox li").length).to.equal(1);
+    expect($$(".js-autosuggest-listbox li").length).to.equal(3);
   });
 });

--- a/tests/functional/spec/textfield_suggestions.spec.js
+++ b/tests/functional/spec/textfield_suggestions.spec.js
@@ -16,8 +16,9 @@ describe("Suggestions", () => {
     $(SuggestionsPage.country()).setValue("United States of America");
     $(SuggestionsPage.submit()).click();
     $(MultipleSuggestionsPage.multipleCountry()).click();
+    browser.pause(500);
     browser.keys("Ita");
-    $("#multiple-country-answer-listbox__option--0").waitForExist();
+    $("#multiple-country-answer-listbox li").waitForExist();
     $("#multiple-country-answer-listbox__option--0").click();
     $(MultipleSuggestionsPage.multipleCountry()).click();
     // Browser needs to pause before typing starts, otherwise this sequence is executed almost instantly

--- a/tests/functional/spec/textfield_suggestions.spec.js
+++ b/tests/functional/spec/textfield_suggestions.spec.js
@@ -1,5 +1,5 @@
 import SuggestionsPage from "../generated_pages/textfield_suggestions/country-block.page.js";
-import MultipleSuggestionsPage from "../generated_pages/textfield_suggestions/country-block-multiple-selections.page.js";
+import MultipleSuggestionsPage from "../generated_pages/textfield_suggestions/multiple-country-block.page.js";
 
 describe("Suggestions", () => {
   it("Given I open a textfield with a suggestions url, when I have entered text, then it will show suggestions", () => {
@@ -15,16 +15,16 @@ describe("Suggestions", () => {
     browser.openQuestionnaire("test_textfield_suggestions.json");
     $(SuggestionsPage.country()).setValue("United States of America");
     $(SuggestionsPage.submit()).click();
-    $(MultipleSuggestionsPage.countryMultipleSelections()).click();
+    $(MultipleSuggestionsPage.multipleCountry()).click();
     browser.keys("Ita");
-    $("#country-multiple-selections-answer-listbox li").waitForDisplayed();
+    $("#multiple-country-answer-listbox li").waitForDisplayed();
     expect($$(".js-autosuggest-listbox li").length).to.equal(2);
-    $("#country-multiple-selections-answer-listbox__option--0").click();
-    $(MultipleSuggestionsPage.countryMultipleSelections()).click();
+    $("#multiple-country-answer-listbox__option--0").click();
+    $(MultipleSuggestionsPage.multipleCountry()).click();
     // Browser needs to pause before typing starts, otherwise this sequence is executed almost instantly
     browser.pause(500);
-    browser.keys(" United States");
-    $("#country-multiple-selections-answer-listbox li").waitForDisplayed();
+    browser.keys(" United");
+    $("#multiple-country-answer-listbox li").waitForDisplayed();
     expect($$(".js-autosuggest-listbox li").length).to.equal(3);
   });
 });

--- a/tests/functional/spec/textfield_suggestions.spec.js
+++ b/tests/functional/spec/textfield_suggestions.spec.js
@@ -21,7 +21,7 @@ describe("Suggestions", () => {
     $("#multiple-country-answer-listbox li").waitForExist();
     $("#multiple-country-answer-listbox__option--0").click();
     $(MultipleSuggestionsPage.multipleCountry()).click();
-    // Browser needs to pause before typing starts, otherwise this sequence is executed almost instantly
+    // Browser needs to pause before typing starts to allow for the autosuggest Javascript to initialise
     browser.pause(500);
     browser.keys(" United");
     $("#multiple-country-answer-listbox li").waitForExist();

--- a/tests/functional/spec/textfield_suggestions.spec.js
+++ b/tests/functional/spec/textfield_suggestions.spec.js
@@ -16,6 +16,7 @@ describe("Suggestions", () => {
     $(SuggestionsPage.country()).setValue("United States of America");
     $(SuggestionsPage.submit()).click();
     $(MultipleSuggestionsPage.multipleCountry()).click();
+    // Browser needs to pause before typing starts to allow for the autosuggest Javascript to initialise
     browser.pause(500);
     browser.keys("Ita");
     $("#multiple-country-answer-listbox li").waitForExist();

--- a/tests/functional/spec/textfield_suggestions.spec.js
+++ b/tests/functional/spec/textfield_suggestions.spec.js
@@ -18,6 +18,7 @@ describe("Suggestions", () => {
     $(MultipleSuggestionsPage.multipleCountry()).click();
     browser.keys("Ita");
     $("#multiple-country-answer-listbox li").waitForExist();
+    browser.pause(1000);
     $("#multiple-country-answer-listbox__option--0").click();
     $(MultipleSuggestionsPage.multipleCountry()).click();
     // Browser needs to pause before typing starts, otherwise this sequence is executed almost instantly

--- a/tests/functional/spec/textfield_suggestions.spec.js
+++ b/tests/functional/spec/textfield_suggestions.spec.js
@@ -16,6 +16,7 @@ describe("Suggestions", () => {
     $(SuggestionsPage.country()).setValue("United States of America");
     $(SuggestionsPage.submit()).click();
     $(MultipleSuggestionsPage.multipleCountry()).click();
+    browser.pause(1000);
     browser.keys("Ita");
     $("#multiple-country-answer-listbox li").waitForExist();
     browser.pause(1000);

--- a/tests/functional/spec/textfield_suggestions.spec.js
+++ b/tests/functional/spec/textfield_suggestions.spec.js
@@ -16,9 +16,8 @@ describe("Suggestions", () => {
     $(SuggestionsPage.country()).setValue("United States of America");
     $(SuggestionsPage.submit()).click();
     $(MultipleSuggestionsPage.multipleCountry()).click();
-    browser.pause(500);
     browser.keys("Ita");
-    $("#multiple-country-answer-listbox li").waitForExist();
+    $("#multiple-country-answer-listbox__option--0").waitForExist();
     $("#multiple-country-answer-listbox__option--0").click();
     $(MultipleSuggestionsPage.multipleCountry()).click();
     // Browser needs to pause before typing starts, otherwise this sequence is executed almost instantly

--- a/tests/functional/spec/textfield_suggestions.spec.js
+++ b/tests/functional/spec/textfield_suggestions.spec.js
@@ -1,4 +1,5 @@
 import SuggestionsPage from "../generated_pages/textfield_suggestions/country-block.page.js";
+import MultipleSuggestionsPage from "../generated_pages/textfield_suggestions/country-block-multiple-selections.page.js";
 
 describe("Suggestions", () => {
   it("Given I open a textfield with a suggestions url, when I have entered text, then it will show suggestions", () => {
@@ -6,5 +7,24 @@ describe("Suggestions", () => {
     $(SuggestionsPage.country()).setValue("Uni");
     $("#country-answer-listbox li").waitForDisplayed();
     expect($$(".js-autosuggest-listbox li").length).to.not.equal(0);
+  });
+});
+
+describe("Suggestions", () => {
+  it("Given I open a textfield with a suggestions url, when I have entered text followed by comma, then it will show multiple suggestions", () => {
+    browser.openQuestionnaire("test_textfield_suggestions.json");
+    $(SuggestionsPage.country()).setValue("United States of America");
+    $(SuggestionsPage.submit()).click();
+    $(MultipleSuggestionsPage.countryMultipleSelections()).click();
+    browser.keys("Ita")
+    $("#country-multiple-selections-answer-listbox li").waitForDisplayed();
+    expect($$(".js-autosuggest-listbox li").length).to.equal(2);
+    $("#country-multiple-selections-answer-listbox__option--0").click()
+    $(MultipleSuggestionsPage.countryMultipleSelections()).click();
+    // Browser needs to pause in order to fetch api results, otherwise it works instantly
+    browser.pause(500)
+    browser.keys(' Canada')
+    $("#country-multiple-selections-answer-listbox li").waitForDisplayed();
+    expect($$(".js-autosuggest-listbox li").length).to.equal(1);
   });
 });

--- a/tests/functional/spec/textfield_suggestions.spec.js
+++ b/tests/functional/spec/textfield_suggestions.spec.js
@@ -18,7 +18,6 @@ describe("Suggestions", () => {
     $(MultipleSuggestionsPage.multipleCountry()).click();
     browser.keys("Ita");
     $("#multiple-country-answer-listbox li").waitForDisplayed();
-    expect($$(".js-autosuggest-listbox li").length).to.not.equal(0);
     $("#multiple-country-answer-listbox__option--0").click();
     $(MultipleSuggestionsPage.multipleCountry()).click();
     // Browser needs to pause before typing starts, otherwise this sequence is executed almost instantly
@@ -26,5 +25,8 @@ describe("Suggestions", () => {
     browser.keys(" United");
     $("#multiple-country-answer-listbox li").waitForDisplayed();
     expect($$(".js-autosuggest-listbox li").length).to.not.equal(0);
+    $("#multiple-country-answer-listbox__option--0").click();
+    $(MultipleSuggestionsPage.submit()).click();
+    expect(browser.getUrl()).to.contain("summary");
   });
 });

--- a/tests/functional/spec/textfield_suggestions.spec.js
+++ b/tests/functional/spec/textfield_suggestions.spec.js
@@ -11,7 +11,7 @@ describe("Suggestions", () => {
 });
 
 describe("Suggestions", () => {
-  it("Given I open a textfield with a suggestions url, when I have entered text followed by comma, then it will allow multiple suggestions", () => {
+  it("Given I open a textfield with a suggestions url, when I have entered text and picked suggestion from a list, then after typing text it will show new suggestions", () => {
     browser.openQuestionnaire("test_textfield_suggestions.json");
     $(SuggestionsPage.country()).setValue("United States of America");
     $(SuggestionsPage.submit()).click();

--- a/tests/functional/spec/textfield_suggestions.spec.js
+++ b/tests/functional/spec/textfield_suggestions.spec.js
@@ -18,13 +18,13 @@ describe("Suggestions", () => {
     $(MultipleSuggestionsPage.multipleCountry()).click();
     browser.keys("Ita");
     $("#multiple-country-answer-listbox li").waitForDisplayed();
-    expect($$(".js-autosuggest-listbox li").length).to.equal(2);
+    expect($$(".js-autosuggest-listbox li").length).to.not.equal(0);
     $("#multiple-country-answer-listbox__option--0").click();
     $(MultipleSuggestionsPage.multipleCountry()).click();
     // Browser needs to pause before typing starts, otherwise this sequence is executed almost instantly
     browser.pause(500);
     browser.keys(" United");
     $("#multiple-country-answer-listbox li").waitForDisplayed();
-    expect($$(".js-autosuggest-listbox li").length).to.equal(3);
+    expect($$(".js-autosuggest-listbox li").length).to.not.equal(0);
   });
 });

--- a/tests/functional/spec/textfield_suggestions.spec.js
+++ b/tests/functional/spec/textfield_suggestions.spec.js
@@ -17,13 +17,13 @@ describe("Suggestions", () => {
     $(SuggestionsPage.submit()).click();
     $(MultipleSuggestionsPage.multipleCountry()).click();
     browser.keys("Ita");
-    $("#multiple-country-answer-listbox li").waitForDisplayed();
+    $("#multiple-country-answer-listbox li").waitForExist();
     $("#multiple-country-answer-listbox__option--0").click();
     $(MultipleSuggestionsPage.multipleCountry()).click();
     // Browser needs to pause before typing starts, otherwise this sequence is executed almost instantly
     browser.pause(500);
     browser.keys(" United");
-    $("#multiple-country-answer-listbox li").waitForDisplayed();
+    $("#multiple-country-answer-listbox li").waitForExist();
     expect($$(".js-autosuggest-listbox li").length).to.not.equal(0);
     $("#multiple-country-answer-listbox__option--0").click();
     $(MultipleSuggestionsPage.submit()).click();

--- a/tests/functional/spec/textfield_suggestions.spec.js
+++ b/tests/functional/spec/textfield_suggestions.spec.js
@@ -11,7 +11,7 @@ describe("Suggestions", () => {
 });
 
 describe("Suggestions", () => {
-  it("Given I open a textfield with a suggestions url, when I have entered text followed by comma, then it will show multiple suggestions", () => {
+  it("Given I open a textfield with a suggestions url, when I have entered text followed by comma, then it will allow multiple suggestions", () => {
     browser.openQuestionnaire("test_textfield_suggestions.json");
     $(SuggestionsPage.country()).setValue("United States of America");
     $(SuggestionsPage.submit()).click();

--- a/tests/functional/spec/textfield_suggestions.spec.js
+++ b/tests/functional/spec/textfield_suggestions.spec.js
@@ -16,10 +16,9 @@ describe("Suggestions", () => {
     $(SuggestionsPage.country()).setValue("United States of America");
     $(SuggestionsPage.submit()).click();
     $(MultipleSuggestionsPage.multipleCountry()).click();
-    browser.pause(1000);
+    browser.pause(500);
     browser.keys("Ita");
     $("#multiple-country-answer-listbox li").waitForExist();
-    browser.pause(1000);
     $("#multiple-country-answer-listbox__option--0").click();
     $(MultipleSuggestionsPage.multipleCountry()).click();
     // Browser needs to pause before typing starts, otherwise this sequence is executed almost instantly

--- a/tests/functional/spec/textfield_suggestions.spec.js
+++ b/tests/functional/spec/textfield_suggestions.spec.js
@@ -11,7 +11,7 @@ describe("Suggestions", () => {
 });
 
 describe("Suggestions", () => {
-  it("Given I open a textfield with a suggestions url, when I have entered text and picked suggestion from a list, then after typing more text it will show new suggestions", () => {
+  it("Given I open a textfield with a suggestions url that allows multiple suggestions, when I have entered text and picked suggestion from a list, then after typing more text it will show new suggestions", () => {
     browser.openQuestionnaire("test_textfield_suggestions.json");
     $(SuggestionsPage.country()).setValue("United States of America");
     $(SuggestionsPage.submit()).click();


### PR DESCRIPTION
### What is the context of this PR?
This adds support to multiple lookups selection in [autosuggest component](https://ons-design-system.netlify.app/components/autosuggest/). This feature is described in [Trello card](https://trello.com/c/RqJlAYzx). It requires this [validator PR](https://github.com/ONSdigital/eq-questionnaire-validator/pull/86) to merge first.

### How to review 
New functional test was added and textfield suggestions schema was expanded. Run new functional test, run through `test_textfield_suggestions.json` manually.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
