### PR TITLE
Add Google Analytics to connect-src CSP policy

### DIFF
--- a/app/setup.py
+++ b/app/setup.py
@@ -59,7 +59,7 @@ CSP_POLICY = {
         "https://fonts.googleapis.com",
         "'unsafe-inline'",
     ],
-    "connect-src": ["'self'"],
+    "connect-src": ["'self'", "https://www.google-analytics.com"],
     "frame-src": ["https://www.googletagmanager.com"],
     "img-src": [
         "'self'",

--- a/tests/integration/test_app_create.py
+++ b/tests/integration/test_app_create.py
@@ -156,7 +156,7 @@ class TestCreateApp(unittest.TestCase):  # pylint: disable=too-many-public-metho
                 "frame-src https://www.googletagmanager.com", csp_policy_parts
             )
             self.assertIn(
-                f"connect-src 'self' {cdn_url} {address_lookup_api_url}",
+                f"connect-src 'self' https://www.google-analytics.com {cdn_url} {address_lookup_api_url}",
                 csp_policy_parts,
             )
 


### PR DESCRIPTION
### What is the context of this PR?
Adds the Google Analytics url to connect-src CSP policy.

### How to review 
Verify the connect-src contains the Google Analytics url.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
