### PR TITLE
Add a pod securityContext that drops NET_RAW capability

### DIFF
--- a/k8s/helm/templates/deployment.yaml
+++ b/k8s/helm/templates/deployment.yaml
@@ -8,10 +8,6 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
-  securityContext:
-    capabilities:
-      drop:
-        - NET_RAW
   replicas: {{ .Values.autoscaler.minReplicas }}
   strategy:
     type: RollingUpdate
@@ -54,6 +50,10 @@ spec:
             - name: secrets
               mountPath: "/secrets"
               readOnly: true
+          securityContext:
+            capabilities:
+              drop:
+                - NET_RAW
           env:
             - name: EQ_STORAGE_BACKEND
               value: "datastore"

--- a/k8s/helm/templates/deployment.yaml
+++ b/k8s/helm/templates/deployment.yaml
@@ -50,6 +50,10 @@ spec:
             - name: secrets
               mountPath: "/secrets"
               readOnly: true
+          securityContext:
+            capabilities:
+              drop:
+                - NET_RAW
           env:
             - name: EQ_STORAGE_BACKEND
               value: "datastore"

--- a/k8s/helm/templates/deployment.yaml
+++ b/k8s/helm/templates/deployment.yaml
@@ -8,6 +8,10 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
+  securityContext:
+    capabilities:
+      drop:
+        - NET_RAW
   replicas: {{ .Values.autoscaler.minReplicas }}
   strategy:
     type: RollingUpdate
@@ -50,10 +54,6 @@ spec:
             - name: secrets
               mountPath: "/secrets"
               readOnly: true
-          securityContext:
-            capabilities:
-              drop:
-                - NET_RAW
           env:
             - name: EQ_STORAGE_BACKEND
               value: "datastore"


### PR DESCRIPTION
### What is the context of this PR?
Adds a container security context definition to the Helm chart for the Runner deployment.

### How to review 
Deploy this branch to GCP. Test that the securityContext is created in the pod details page.

