### PR TITLE
Fix error messages on dates

### DIFF
--- a/app/forms/validators.py
+++ b/app/forms/validators.py
@@ -222,25 +222,15 @@ class DateCheck:
         self.message = message or error_messages["INVALID_DATE"]
 
     def __call__(self, form, field):
-
-        if not form.data or not re.match(r"\d{4}$", str(form.year.data)):
-            raise validators.StopValidation(self.message)
-        if re.match(r"^\d{4}-", str(form.data)) and not re.match(
-            r"\d{1,2}", str(form.month.data)
-        ):
-            raise validators.StopValidation(self.message)
-        if re.match(r"^\d{4}-\d{1,2}-", str(form.data)) and not re.match(
-            r"\d{1,2}", str(form.day.data)
-        ):
+        if not form.data or not hasattr(form, "year"):
             raise validators.StopValidation(self.message)
 
         try:
-            substrings = form.data.split("-")
-            if len(substrings) == 3:
+            if hasattr(form, "day"):
                 datetime.strptime(form.data, "%Y-%m-%d")
-            if len(substrings) == 2:
+            elif hasattr(form, "month"):
                 datetime.strptime(form.data, "%Y-%m")
-            if len(substrings) == 1:
+            else:
                 datetime.strptime(form.data, "%Y")
         except ValueError:
             raise validators.StopValidation(self.message)

--- a/app/forms/validators.py
+++ b/app/forms/validators.py
@@ -225,6 +225,14 @@ class DateCheck:
 
         if not form.data or not re.match(r"\d{4}$", str(form.year.data)):
             raise validators.StopValidation(self.message)
+        if re.match(r"^\d{4}-", str(form.data)) and not re.match(
+            r"\d{1,2}", str(form.month.data)
+        ):
+            raise validators.StopValidation(self.message)
+        if re.match(r"^\d{4}-\d{1,2}-", str(form.data)) and not re.match(
+            r"\d{1,2}", str(form.day.data)
+        ):
+            raise validators.StopValidation(self.message)
 
         try:
             substrings = form.data.split("-")

--- a/app/forms/validators.py
+++ b/app/forms/validators.py
@@ -222,7 +222,7 @@ class DateCheck:
         self.message = message or error_messages["INVALID_DATE"]
 
     def __call__(self, form, field):
-        if not form.data or not hasattr(form, "year"):
+        if not form.data:
             raise validators.StopValidation(self.message)
 
         try:

--- a/tests/app/forms/validation/test_date_check_validator.py
+++ b/tests/app/forms/validation/test_date_check_validator.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import Mock
+from unittest.mock import MagicMock, Mock
 
 from wtforms.validators import StopValidation
 
@@ -24,9 +24,11 @@ class TestDateCheckValidator(unittest.TestCase):
     def test_date_type_validator_missing_day(self):
         validator = DateCheck()
 
-        mock_form = Mock()
+        mock_form = MagicMock()
         mock_form.data = "2016-12-"
         mock_form.year.data = "2016"
+        mock_form.month.data = "12"
+        mock_form.day.data = ""
 
         mock_field = Mock()
 
@@ -38,9 +40,11 @@ class TestDateCheckValidator(unittest.TestCase):
     def test_date_type_validator_missing_month(self):
         validator = DateCheck()
 
-        mock_form = Mock()
+        mock_form = MagicMock()
         mock_form.data = "2016--03"
         mock_form.year.data = "2016"
+        mock_form.month.data = ""
+        mock_form.day.data = "03"
 
         mock_field = Mock()
 
@@ -52,7 +56,7 @@ class TestDateCheckValidator(unittest.TestCase):
     def test_date_type_validator_missing_year(self):
         validator = DateCheck()
 
-        mock_form = Mock()
+        mock_form = MagicMock()
         mock_form.data = "-12-03"
 
         mock_field = Mock()
@@ -65,9 +69,11 @@ class TestDateCheckValidator(unittest.TestCase):
     def test_date_type_validator_invalid_day(self):
         validator = DateCheck()
 
-        mock_form = Mock()
+        mock_form = MagicMock()
         mock_form.data = "2016-12-40"
         mock_form.year.data = "2016"
+        mock_form.year.month = "12"
+        mock_form.year.day = "40"
 
         mock_field = Mock()
 
@@ -79,9 +85,11 @@ class TestDateCheckValidator(unittest.TestCase):
     def test_date_type_validator_invalid_month(self):
         validator = DateCheck()
 
-        mock_form = Mock()
+        mock_form = MagicMock()
         mock_form.data = "2016-13-20"
         mock_form.year.data = "2016"
+        mock_form.year.month = "13"
+        mock_form.year.day = "20"
 
         mock_field = Mock()
 
@@ -93,7 +101,7 @@ class TestDateCheckValidator(unittest.TestCase):
     def test_date_type_validator_invalid_year(self):
         validator = DateCheck()
 
-        mock_form = Mock()
+        mock_form = MagicMock()
         mock_form.data = "20000-12-20"
         mock_form.year.data = "20000"
 
@@ -107,9 +115,40 @@ class TestDateCheckValidator(unittest.TestCase):
     def test_date_type_validator_invalid_year_digits(self):
         validator = DateCheck()
 
-        mock_form = Mock()
+        mock_form = MagicMock()
         mock_form.data = "2-12-20"
         mock_form.year.data = "2"
+
+        mock_field = Mock()
+
+        with self.assertRaises(StopValidation) as ite:
+            validator(mock_form, mock_field)
+
+        self.assertEqual(error_messages["INVALID_DATE"], str(ite.exception))
+
+    def test_date_type_validator_invalid_month_digits(self):
+        validator = DateCheck()
+
+        mock_form = MagicMock()
+        mock_form.data = "2020--2-20"
+        mock_form.year.data = "2020"
+        mock_form.month.data = "-2"
+
+        mock_field = Mock()
+
+        with self.assertRaises(StopValidation) as ite:
+            validator(mock_form, mock_field)
+
+        self.assertEqual(error_messages["INVALID_DATE"], str(ite.exception))
+
+    def test_date_type_validator_invalid_day_digits(self):
+        validator = DateCheck()
+
+        mock_form = MagicMock()
+        mock_form.data = "2020-12--2"
+        mock_form.year.data = "2020"
+        mock_form.month.data = "12"
+        mock_form.day.data = "-2"
 
         mock_field = Mock()
 
@@ -123,9 +162,11 @@ class TestDateCheckValidator(unittest.TestCase):
         validator = DateCheck()
 
         # 2015 was not a leap year
-        mock_form = Mock()
+        mock_form = MagicMock()
         mock_form.data = "2015-02-29"
         mock_form.year.data = "2015"
+        mock_form.month.data = "02"
+        mock_form.day.data = "29"
 
         mock_field = Mock()
 
@@ -139,9 +180,11 @@ class TestDateCheckValidator(unittest.TestCase):
         validator = DateCheck()
 
         # 2016 WAS a leap year
-        mock_form = Mock()
+        mock_form = MagicMock()
         mock_form.data = "2016-02-29"
         mock_form.year.data = "2016"
+        mock_form.month.data = "02"
+        mock_form.day.data = "29"
 
         mock_field = Mock()
         validator(mock_form, mock_field)
@@ -150,23 +193,29 @@ class TestDateCheckValidator(unittest.TestCase):
     def test_date_type_validator_valid_dates():
         validator = DateCheck()
 
-        mock_form = Mock()
+        mock_form = MagicMock()
         mock_form.data = "2016-01-29"
         mock_form.year.data = "2016"
+        mock_form.month.data = "01"
+        mock_form.day.data = "29"
 
         mock_field = Mock()
         validator(mock_form, mock_field)
 
-        mock_form = Mock()
+        mock_form = MagicMock()
         mock_form.data = "2016-12-01"
         mock_form.year.data = "2016"
+        mock_form.month.data = "12"
+        mock_form.day.data = "01"
 
         mock_field = Mock()
         validator(mock_form, mock_field)
 
-        mock_form = Mock()
+        mock_form = MagicMock()
         mock_form.data = "2016-03-03"
         mock_form.year.data = "2016"
+        mock_form.month.data = "03"
+        mock_form.day.data = "03"
 
         mock_field = Mock()
         validator(mock_form, mock_field)

--- a/tests/app/forms/validation/test_date_check_validator.py
+++ b/tests/app/forms/validation/test_date_check_validator.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import MagicMock, Mock
+from unittest.mock import Mock
 
 from wtforms.validators import StopValidation
 
@@ -24,11 +24,9 @@ class TestDateCheckValidator(unittest.TestCase):
     def test_date_type_validator_missing_day(self):
         validator = DateCheck()
 
-        mock_form = MagicMock()
+        mock_form = Mock()
         mock_form.data = "2016-12-"
         mock_form.year.data = "2016"
-        mock_form.month.data = "12"
-        mock_form.day.data = ""
 
         mock_field = Mock()
 
@@ -40,11 +38,9 @@ class TestDateCheckValidator(unittest.TestCase):
     def test_date_type_validator_missing_month(self):
         validator = DateCheck()
 
-        mock_form = MagicMock()
+        mock_form = Mock()
         mock_form.data = "2016--03"
         mock_form.year.data = "2016"
-        mock_form.month.data = ""
-        mock_form.day.data = "03"
 
         mock_field = Mock()
 
@@ -56,7 +52,7 @@ class TestDateCheckValidator(unittest.TestCase):
     def test_date_type_validator_missing_year(self):
         validator = DateCheck()
 
-        mock_form = MagicMock()
+        mock_form = Mock()
         mock_form.data = "-12-03"
 
         mock_field = Mock()
@@ -69,11 +65,9 @@ class TestDateCheckValidator(unittest.TestCase):
     def test_date_type_validator_invalid_day(self):
         validator = DateCheck()
 
-        mock_form = MagicMock()
+        mock_form = Mock()
         mock_form.data = "2016-12-40"
         mock_form.year.data = "2016"
-        mock_form.year.month = "12"
-        mock_form.year.day = "40"
 
         mock_field = Mock()
 
@@ -85,11 +79,9 @@ class TestDateCheckValidator(unittest.TestCase):
     def test_date_type_validator_invalid_month(self):
         validator = DateCheck()
 
-        mock_form = MagicMock()
+        mock_form = Mock()
         mock_form.data = "2016-13-20"
         mock_form.year.data = "2016"
-        mock_form.year.month = "13"
-        mock_form.year.day = "20"
 
         mock_field = Mock()
 
@@ -101,7 +93,7 @@ class TestDateCheckValidator(unittest.TestCase):
     def test_date_type_validator_invalid_year(self):
         validator = DateCheck()
 
-        mock_form = MagicMock()
+        mock_form = Mock()
         mock_form.data = "20000-12-20"
         mock_form.year.data = "20000"
 
@@ -115,7 +107,7 @@ class TestDateCheckValidator(unittest.TestCase):
     def test_date_type_validator_invalid_year_digits(self):
         validator = DateCheck()
 
-        mock_form = MagicMock()
+        mock_form = Mock()
         mock_form.data = "2-12-20"
         mock_form.year.data = "2"
 
@@ -129,10 +121,8 @@ class TestDateCheckValidator(unittest.TestCase):
     def test_date_type_validator_invalid_month_digits(self):
         validator = DateCheck()
 
-        mock_form = MagicMock()
+        mock_form = Mock()
         mock_form.data = "2020--2-20"
-        mock_form.year.data = "2020"
-        mock_form.month.data = "-2"
 
         mock_field = Mock()
 
@@ -144,11 +134,9 @@ class TestDateCheckValidator(unittest.TestCase):
     def test_date_type_validator_invalid_day_digits(self):
         validator = DateCheck()
 
-        mock_form = MagicMock()
+        mock_form = Mock()
         mock_form.data = "2020-12--2"
         mock_form.year.data = "2020"
-        mock_form.month.data = "12"
-        mock_form.day.data = "-2"
 
         mock_field = Mock()
 
@@ -162,11 +150,9 @@ class TestDateCheckValidator(unittest.TestCase):
         validator = DateCheck()
 
         # 2015 was not a leap year
-        mock_form = MagicMock()
+        mock_form = Mock()
         mock_form.data = "2015-02-29"
         mock_form.year.data = "2015"
-        mock_form.month.data = "02"
-        mock_form.day.data = "29"
 
         mock_field = Mock()
 
@@ -180,11 +166,9 @@ class TestDateCheckValidator(unittest.TestCase):
         validator = DateCheck()
 
         # 2016 WAS a leap year
-        mock_form = MagicMock()
+        mock_form = Mock()
         mock_form.data = "2016-02-29"
         mock_form.year.data = "2016"
-        mock_form.month.data = "02"
-        mock_form.day.data = "29"
 
         mock_field = Mock()
         validator(mock_form, mock_field)
@@ -193,29 +177,23 @@ class TestDateCheckValidator(unittest.TestCase):
     def test_date_type_validator_valid_dates():
         validator = DateCheck()
 
-        mock_form = MagicMock()
+        mock_form = Mock()
         mock_form.data = "2016-01-29"
         mock_form.year.data = "2016"
-        mock_form.month.data = "01"
-        mock_form.day.data = "29"
 
         mock_field = Mock()
         validator(mock_form, mock_field)
 
-        mock_form = MagicMock()
+        mock_form = Mock()
         mock_form.data = "2016-12-01"
         mock_form.year.data = "2016"
-        mock_form.month.data = "12"
-        mock_form.day.data = "01"
 
         mock_field = Mock()
         validator(mock_form, mock_field)
 
-        mock_form = MagicMock()
+        mock_form = Mock()
         mock_form.data = "2016-03-03"
         mock_form.year.data = "2016"
-        mock_form.month.data = "03"
-        mock_form.day.data = "03"
 
         mock_field = Mock()
         validator(mock_form, mock_field)


### PR DESCRIPTION
### What is the context of this PR?
This fixes error messages when dates entered are negative, it now displays correct invalid date text for day and month incorrect numbers. This problem is described on [following Trello card](https://trello.com/c/ebDRRBVT).

### How to review 
Try `test_dates`, two new unit tests were added for negative number of days and months.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
