### PR TITLE
Update Cloud SDK location

### DIFF
--- a/ci/backup_questionnaire_state.yaml
+++ b/ci/backup_questionnaire_state.yaml
@@ -2,7 +2,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: google/cloud-sdk
+    repository: gcr.io/google.com/cloudsdktool/cloud-sdk
     tag: alpine
 params:
   SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))

--- a/ci/deploy_credentials.yaml
+++ b/ci/deploy_credentials.yaml
@@ -2,7 +2,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: google/cloud-sdk
+    repository: gcr.io/google.com/cloudsdktool/cloud-sdk
 inputs:
   - name: eq-questionnaire-runner
 params:

--- a/ci/purge_expired_sessions.yaml
+++ b/ci/purge_expired_sessions.yaml
@@ -2,7 +2,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: google/cloud-sdk
+    repository: gcr.io/google.com/cloudsdktool/cloud-sdk
 params:
   SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
   PROJECT_ID:

--- a/ci/restore_questionnaire_state.yaml
+++ b/ci/restore_questionnaire_state.yaml
@@ -2,7 +2,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: google/cloud-sdk
+    repository: gcr.io/google.com/cloudsdktool/cloud-sdk
     tag: alpine
 params:
   SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))


### PR DESCRIPTION
### What is the context of this PR?

Due to  [deprecation](https://hub.docker.com/r/google/cloud-sdk/), update image source from google/cloud-sdk:slim gcr.io/google.com/cloudsdktool/cloud-sdk:slim 

### How to review
Run the yaml locally or by the pipeline to make sure they still work
