### PR TITLE
Override skip to content to allow translation

### DIFF
--- a/app/translations/messages.pot
+++ b/app/translations/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2021-02-01 10:53+0000\n"
+"POT-Creation-Date: 2021-02-04 15:29+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,14 +17,14 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.9.0\n"
 
-#: app/forms/validators.py:338 app/jinja_filters.py:94
+#: app/forms/validators.py:336 app/jinja_filters.py:94
 #, python-format
 msgid "%(num)s year"
 msgid_plural "%(num)s years"
 msgstr[0] ""
 msgstr[1] ""
 
-#: app/forms/validators.py:342 app/jinja_filters.py:102
+#: app/forms/validators.py:340 app/jinja_filters.py:102
 #, python-format
 msgid "%(num)s month"
 msgid_plural "%(num)s months"
@@ -192,7 +192,7 @@ msgstr ""
 msgid "Remove an answer"
 msgstr ""
 
-#: app/forms/validators.py:349
+#: app/forms/validators.py:347
 #, python-format
 msgid "%(num)s day"
 msgid_plural "%(num)s days"
@@ -1055,40 +1055,44 @@ msgid ""
 "href='{contact_us_url}'>contact us</a>"
 msgstr ""
 
-#: templates/layouts/_base.html:18
+#: templates/layouts/_base.html:19
 msgid "Previous"
 msgstr ""
 
-#: templates/layouts/_base.html:61
+#: templates/layouts/_base.html:62
 msgid "Tell us whether you accept cookies"
 msgstr ""
 
-#: templates/layouts/_base.html:62
+#: templates/layouts/_base.html:63
 msgid ""
 "We use <a href='{cookie_settings_url}'>cookies to collect information</a>"
 " about how you use census.gov.uk. We use this information to make the "
 "website work as well as possible and improve our services."
 msgstr ""
 
-#: templates/layouts/_base.html:63
+#: templates/layouts/_base.html:64
 msgid ""
 "You’ve accepted all cookies. You can <a "
 "href='{cookie_settings_url}'>change your cookie preferences</a> at any "
 "time."
 msgstr ""
 
-#: templates/layouts/_base.html:64
+#: templates/layouts/_base.html:65
 msgid "Accept all cookies"
 msgstr ""
 
-#: templates/layouts/_base.html:65
+#: templates/layouts/_base.html:66
 msgid "Set cookie preferences"
 msgstr ""
 
-#: templates/layouts/_base.html:66
+#: templates/layouts/_base.html:67
 #: templates/partials/introduction/preview.html:30
 #: templates/partials/summary/collapsible-summary.html:14
 msgid "Hide"
+msgstr ""
+
+#: templates/layouts/_base.html:114
+msgid "Skip to main content"
 msgstr ""
 
 #: templates/layouts/_questionnaire.html:38

--- a/templates/layouts/_base.html
+++ b/templates/layouts/_base.html
@@ -1,5 +1,6 @@
 {% extends "layout/_template.njk" %}
 {% from "components/cookies-banner/_macro.njk" import onsCookiesBanner %}
+{% from "components/skip-to-content/_macro.njk" import onsSkipToContent %}
 
 {% set form = {
   "attributes": {
@@ -103,6 +104,16 @@
     </noscript>
     <!-- End Google Tag Manager (noscript) -->
   {% endif %}
+{% endblock %}
+
+
+{% block skipLink %}
+  {{
+    onsSkipToContent({
+      "url": "#main-content",
+      "text": _("Skip to main content")
+    })
+  }}
 {% endblock %}
 
 


### PR DESCRIPTION
### What is the context of this PR?
Overrides the onsSkiptToContent macro to allow translation of the link text.

### How to review 
Check the macro still renders correctly and the translation templates are updatd correctly

### Checklist

* [x] New static content marked up for translation
