### PR TITLE
Update footer copyright parameters

### DIFF
--- a/app/helpers/template_helpers.py
+++ b/app/helpers/template_helpers.py
@@ -86,10 +86,9 @@ def get_footer_context(
             )
             if theme == "census-nisra"
             else lazy_gettext("Crown copyright and database rights 2020 OS 100019153."),
-            "text": lazy_gettext("Use of address data is subject to the"),
-            "link": lazy_gettext("terms and conditions"),
-            "url": static_content_urls["terms_and_conditions"],
-            "target": "_blank",
+            "text": lazy_gettext(
+                "Use of address data is subject to the terms and conditions."
+            ),
         },
         "rows": [
             {"itemsList": items_list},

--- a/app/translations/messages.pot
+++ b/app/translations/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2021-02-03 16:13+0000\n"
+"POT-Creation-Date: 2021-02-05 08:09+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -203,72 +203,68 @@ msgstr[1] ""
 msgid "Not a valid choice"
 msgstr ""
 
-#: app/helpers/template_helpers.py:21
+#: app/helpers/template_helpers.py:22
 msgid "Office for National Statistics logo"
 msgstr ""
 
-#: app/helpers/template_helpers.py:30 app/helpers/template_helpers.py:39
-#: app/helpers/template_helpers.py:174 templates/signed-out.html:3
+#: app/helpers/template_helpers.py:31 app/helpers/template_helpers.py:40
+#: app/helpers/template_helpers.py:168 templates/signed-out.html:3
 msgid "Census 2021"
 msgstr ""
 
-#: app/helpers/template_helpers.py:35
+#: app/helpers/template_helpers.py:36
 msgid "Northern Ireland Statistics and Research Agency logo"
 msgstr ""
 
-#: app/helpers/template_helpers.py:50 app/helpers/template_helpers.py:63
+#: app/helpers/template_helpers.py:53
 msgid "Help"
 msgstr ""
 
-#: app/helpers/template_helpers.py:55 app/helpers/template_helpers.py:68
+#: app/helpers/template_helpers.py:58
 msgid "Contact us"
 msgstr ""
 
-#: app/helpers/template_helpers.py:73
+#: app/helpers/template_helpers.py:67
 msgid "Languages"
 msgstr ""
 
-#: app/helpers/template_helpers.py:78
+#: app/helpers/template_helpers.py:72
 msgid "BSL and audio videos"
 msgstr ""
 
-#: app/helpers/template_helpers.py:86
+#: app/helpers/template_helpers.py:82
 msgid "The following links open in a new tab"
 msgstr ""
 
-#: app/helpers/template_helpers.py:88
+#: app/helpers/template_helpers.py:84
 msgid "Crown copyright and database rights 2021 NIMA MOU577.501."
 msgstr ""
 
-#: app/helpers/template_helpers.py:92
+#: app/helpers/template_helpers.py:88
 msgid "Crown copyright and database rights 2020 OS 100019153."
 msgstr ""
 
-#: app/helpers/template_helpers.py:93
-msgid "Use of address data is subject to the"
+#: app/helpers/template_helpers.py:89
+msgid "Use of address data is subject to the terms and conditions."
 msgstr ""
 
-#: app/helpers/template_helpers.py:94
-msgid "terms and conditions"
-msgstr ""
-
-#: app/helpers/template_helpers.py:105
+#: app/helpers/template_helpers.py:100
 msgid "Cookies"
 msgstr ""
 
-#: app/helpers/template_helpers.py:110
+#: app/helpers/template_helpers.py:105
 msgid "Accessibility statement"
 msgstr ""
 
-#: app/helpers/template_helpers.py:115
+#: app/helpers/template_helpers.py:110
 msgid "Privacy and data protection"
 msgstr ""
 
-#: app/helpers/template_helpers.py:120
+#: app/helpers/template_helpers.py:115
 msgid "Terms and conditions"
 msgstr ""
 
-#: app/helpers/template_helpers.py:130
+#: app/helpers/template_helpers.py:125
 msgid ""
 "Make sure you <a href='{sign_out_url}'>leave this page</a> or close your "
 "browser if using a shared device"

--- a/tests/app/helpers/test_template_helpers.py
+++ b/tests/app/helpers/test_template_helpers.py
@@ -14,10 +14,7 @@ def test_get_footer_context_nisra_theme(app):
             "newTabWarning": "The following links open in a new tab",
             "copyrightDeclaration": {
                 "copyright": "Crown copyright and database rights 2021 NIMA MOU577.501.",
-                "text": "Use of address data is subject to the",
-                "link": "terms and conditions",
-                "url": "https://census.gov.uk/ni/terms-and-conditions/",
-                "target": "_blank",
+                "text": "Use of address data is subject to the terms and conditions",
             },
             "rows": [
                 {

--- a/tests/app/helpers/test_template_helpers.py
+++ b/tests/app/helpers/test_template_helpers.py
@@ -14,7 +14,7 @@ def test_get_footer_context_nisra_theme(app):
             "newTabWarning": "The following links open in a new tab",
             "copyrightDeclaration": {
                 "copyright": "Crown copyright and database rights 2021 NIMA MOU577.501.",
-                "text": "Use of address data is subject to the terms and conditions",
+                "text": "Use of address data is subject to the terms and conditions.",
             },
             "rows": [
                 {


### PR DESCRIPTION
### What is the context of this PR?
This removes `link`, `url` and `target` in the copyright declaration in the footer. Words 'terms and conditions' are now part of the same `text` string. Change is described on [this Trello](https://trello.com/c/jkRlGJ4x).

### How to review 
Check in census schemas if footer has the full `Use of address data is subject to the terms and conditions` text now.

### Checklist

* [x] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
