### PR TITLE
Remove unsafe-* values from script-src in CSP policy

### DIFF
--- a/app/setup.py
+++ b/app/setup.py
@@ -50,6 +50,8 @@ CSP_POLICY = {
     "script-src": [
         "'self'",
         "https://www.googletagmanager.com",
+        "https://www.google-analytics.com",
+        "https://ssl.google-analytics.com",
     ],
     "style-src": [
         "'self'",

--- a/app/setup.py
+++ b/app/setup.py
@@ -50,8 +50,6 @@ CSP_POLICY = {
     "script-src": [
         "'self'",
         "https://www.googletagmanager.com",
-        "'unsafe-inline'",
-        "'unsafe-eval'",
     ],
     "style-src": [
         "'self'",

--- a/templates/layouts/_base.html
+++ b/templates/layouts/_base.html
@@ -85,7 +85,8 @@
       (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
       new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
       j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-      'https://www.googletagmanager.com/gtm.js?id='+i+dl+ '&gtm_auth={{ google_tag_manager_auth }}&gtm_cookies_win=x';f.parentNode.insertBefore(j,f);
+      'https://www.googletagmanager.com/gtm.js?id='+i+dl+ '&gtm_auth={{ google_tag_manager_auth }}&gtm_cookies_win=x';var n=d.querySelector('[nonce]');
+      n&&j.setAttribute('nonce',n.nonce||n.getAttribute('nonce'));f.parentNode.insertBefore(j,f);
       })(window,document,'script','dataLayer','{{ google_tag_manager_id }}');
     </script>
     <!-- End Google Tag Manager -->

--- a/tests/integration/test_app_create.py
+++ b/tests/integration/test_app_create.py
@@ -137,7 +137,7 @@ class TestCreateApp(unittest.TestCase):  # pylint: disable=too-many-public-metho
             csp_policy_parts = headers["Content-Security-Policy"].split("; ")
             self.assertIn(f"default-src 'self' {cdn_url}", csp_policy_parts)
             self.assertIn(
-                f"script-src 'self' https://www.googletagmanager.com 'unsafe-inline' 'unsafe-eval' {cdn_url} 'nonce-{request.csp_nonce}'",
+                f"script-src 'self' https://www.googletagmanager.com https://www.google-analytics.com https://ssl.google-analytics.com {cdn_url} 'nonce-{request.csp_nonce}'",
                 csp_policy_parts,
             )
             self.assertIn(


### PR DESCRIPTION
### What is the context of this PR?
`unsafe-eval` was added to enable custom Javascript variables in Google Analytics. As these are no longer used (we now use the data layer) this has been removed.

`unsafe-inline` was added to allow scripts in Google Analytics to work. Using the nonce compatible Tag Manager script removes the need for this.

Universal Analytics values were missing from `srcipt-src`, these have been added.

These CSP policy changes were made referencing the guide at https://developers.google.com/tag-manager/web/csp

### How to review
- The changes have been tested against the staging environment by the performance analyst to ensure they do not break analytics.
- To test that the snippet renders appropriately, ensure values are set for `EQ_GOOGLE_TAG_MANAGER_ID` and `EQ_GOOGLE_TAG_MANAGER_AUTH` (any values).
- Ensure that the CSP policy changes have not broken any Javascript or styles.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
