### PR TITLE
Update CSP policy

### DIFF
--- a/app/setup.py
+++ b/app/setup.py
@@ -50,8 +50,9 @@ CSP_POLICY = {
     "script-src": [
         "'self'",
         "https://www.googletagmanager.com",
+        "https://www.google-analytics.com",
+        "https://ssl.google-analytics.com",
         "'unsafe-inline'",
-        "'unsafe-eval'",
     ],
     "style-src": [
         "'self'",

--- a/app/setup.py
+++ b/app/setup.py
@@ -69,6 +69,8 @@ CSP_POLICY = {
         "https://ssl.gstatic.com",
         "https://www.gstatic.com",
     ],
+    "object-src": ["'none'"],
+    "base-uri": ["'none'"],
 }
 
 compress = Compress()
@@ -239,7 +241,7 @@ def setup_jinja_env(application):
 def _add_cdn_url_to_csp_policy(cdn_url) -> Dict:
     csp_policy = deepcopy(CSP_POLICY)
     for directive in csp_policy:
-        if directive != "frame-src":
+        if directive not in ["frame-src", "object-src", "base-uri"]:
             csp_policy[directive].append(cdn_url)
     return csp_policy
 

--- a/templates/layouts/_base.html
+++ b/templates/layouts/_base.html
@@ -85,7 +85,8 @@
       (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
       new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
       j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-      'https://www.googletagmanager.com/gtm.js?id='+i+dl+ '&gtm_auth={{ google_tag_manager_auth }}&gtm_cookies_win=x';f.parentNode.insertBefore(j,f);
+      'https://www.googletagmanager.com/gtm.js?id='+i+dl+ '&gtm_auth={{ google_tag_manager_auth }}&gtm_cookies_win=x';var n=d.querySelector('[nonce]');
+      n&&j.setAttribute('nonce',n.nonce||n.getAttribute('nonce'));f.parentNode.insertBefore(j,f);
       })(window,document,'script','dataLayer','{{ google_tag_manager_id }}');
     </script>
     <!-- End Google Tag Manager -->

--- a/tests/integration/test_app_create.py
+++ b/tests/integration/test_app_create.py
@@ -137,7 +137,7 @@ class TestCreateApp(unittest.TestCase):  # pylint: disable=too-many-public-metho
             csp_policy_parts = headers["Content-Security-Policy"].split("; ")
             self.assertIn(f"default-src 'self' {cdn_url}", csp_policy_parts)
             self.assertIn(
-                f"script-src 'self' https://www.googletagmanager.com 'unsafe-inline' 'unsafe-eval' {cdn_url} 'nonce-{request.csp_nonce}'",
+                f"script-src 'self' https://www.googletagmanager.com https://www.google-analytics.com https://ssl.google-analytics.com 'unsafe-inline' {cdn_url} 'nonce-{request.csp_nonce}'",
                 csp_policy_parts,
             )
             self.assertIn(

--- a/tests/integration/test_app_create.py
+++ b/tests/integration/test_app_create.py
@@ -159,6 +159,14 @@ class TestCreateApp(unittest.TestCase):  # pylint: disable=too-many-public-metho
                 f"connect-src 'self' https://www.google-analytics.com {cdn_url} {address_lookup_api_url}",
                 csp_policy_parts,
             )
+            self.assertIn(
+                f"object-src 'none'",
+                csp_policy_parts,
+            )
+            self.assertIn(
+                f"base-uri 'none'",
+                csp_policy_parts,
+            )
 
     # Indirectly covered by higher level integration
     # tests, keeping to highlight that create_app is where


### PR DESCRIPTION
### What is the context of this PR?

Updates the CSP policy to ensure it as strict as possible. 

- The `unsafe-eval` value has been removed from `script-src`. Originally this was required for Google Analytics to work, but this is no longer the case (see https://developers.google.com/tag-manager/web/csp). The tag manager snippet has been update to use the nonce compatible version.

- Values required for Google Universal Analytics have been added to the `script-src` directive (see https://developers.google.com/tag-manager/web/csp#universal_analytics_google_analytics)

- The `object-src` directive has been added with a value of `'none'`. This stops any objects being embedded (via `<object>`, `<embed>` or `<applet>` tags).

- The `base-uri` directive has been added with a value of `'none'`. This stops URIs being used in a `base` HTML element. 

A useful explanation of these changes can be viewed at https://csp.withgoogle.com/docs/strict-csp.html.

### How to review 

- Review the CSP policy - does it allow everything it should? does it block anything it shouldn't? The strictness of the policy changes can be reviewed with https://csp-evaluator.withgoogle.com. This can be done by copy pasting the CSP response header from the browser dev tools.
- Test that the CSP policy changes haven't broken anything e.g. scripts/styles/fonts etc.
- The changes have been tested against the Google Analytics staging environment by the performance analyst to ensure they do not break analytics.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
