### PR TITLE
Update the mobileLogo for NISRA

### DIFF
--- a/app/helpers/template_helpers.py
+++ b/app/helpers/template_helpers.py
@@ -32,7 +32,7 @@ def get_page_header_context(language: str, theme: str) -> Dict[str, Any]:
         },
         "census-nisra": {
             "logo": "nisra-logo-en",
-            "mobileLogo": "nisra-logo-en",
+            "mobileLogo": "nisra-logo-en-mobile",
             "logoAlt": lazy_gettext(
                 "Northern Ireland Statistics and Research Agency logo"
             ),


### PR DESCRIPTION
### What is the context of this PR?

Updates the mobileLogo param to `nisra-logo-en-mobile` for the `census-nisra` application (was previously `nisra-logo-en`). This means that the size of the NISRA logo will display correctly on mobile devices.

### How to review 

Use a Census Nisra schema and check the NISRA logo in the header on a mobile device.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
