### PR TITLE
Use tag in pull request action docker push

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -165,4 +165,4 @@ jobs:
         run: |
           echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
           echo "Pushing to DockerHub with tag $TAG"
-          docker push onsdigital/eq-questionnaire-runner
+          docker push onsdigital/eq-questionnaire-runner:$TAG


### PR DESCRIPTION
### What is the context of this PR?
Github actions now uses a version of Docker (>=20.10.0) that defaults to latest rather than all tags on push. This change explicitly sets the tag on the pull request action push.

https://docs.docker.com/engine/release-notes/#runtime-1

### How to review 
Check that the docker push Github action passes

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
