### PR TITLE
CE case_type fulfilment requests not to include individualCaseId

### DIFF
--- a/app/views/handlers/individual_response.py
+++ b/app/views/handlers/individual_response.py
@@ -927,7 +927,7 @@ class IndividualResponseFulfilmentRequest(FulfilmentRequest):
     def _get_individual_case_id_mapping(self) -> Mapping:
         return (
             {}
-            if self._metadata.get("case_type") == "SPG"
+            if self._metadata.get("case_type") in ["SPG", "CE"]
             else {"individualCaseId": str(uuid4())}
         )
 

--- a/tests/app/views/handlers/test_individual_response_fulfilment_request.py
+++ b/tests/app/views/handlers/test_individual_response_fulfilment_request.py
@@ -72,6 +72,15 @@ def test_individual_case_id_not_present_when_case_type_spg():
     assert "individualCaseId" not in json_message["payload"]["fulfilmentRequest"]
 
 
+@freeze_time(datetime.utcnow().isoformat())
+def test_individual_case_id_not_present_when_case_type_ce():
+    metadata = {"region_code": "GB-ENG", "case_id": str(uuid4()), "case_type": "CE"}
+    fulfilment_request = IndividualResponseFulfilmentRequest(metadata)
+
+    json_message = json.loads(fulfilment_request.message)
+    assert "individualCaseId" not in json_message["payload"]["fulfilmentRequest"]
+
+
 @pytest.mark.parametrize(
     "region_code, expected_fulfilment_code",
     [


### PR DESCRIPTION
### What is the context of this PR?

Extends our existing logic so that we don't include an `individualCaseId` when the `case_type` is `CE`. Previously we included an `individualCaseId` when the `case_type` was not `SPG`.

### How to review 

Check that there is no `individualCaseId` when the `case_type` is `CE`

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
