### PR TITLE
Add double click protection to submit buttons

### DIFF
--- a/templates/confirmation.html
+++ b/templates/confirmation.html
@@ -10,6 +10,7 @@
     {{
       onsButton({
         "text": _("Yes, I confirm these are correct"),
+        "submitType": 'timer',
         "classes": "btn--loader js-btn-submit",
         "attributes": {
           "data-qa": "btn-submit"

--- a/templates/feedback.html
+++ b/templates/feedback.html
@@ -39,6 +39,7 @@
   {{
     onsButton({
       "text": _("Send feedback"),
+      "submitType": 'timer',
       "classes": "u-mt-xl",
       "attributes": {
         "data-qa": "btn-submit"

--- a/templates/individual_response/confirmation-post.html
+++ b/templates/individual_response/confirmation-post.html
@@ -19,6 +19,7 @@
     {{
         onsButton({
             "text": _("Continue"),
+            "submitType": 'timer',
             "classes": 'u-mb-m u-mt-l',
             "attributes": {'data-qa': 'btn-submit'}
         })

--- a/templates/individual_response/confirmation-text-message.html
+++ b/templates/individual_response/confirmation-text-message.html
@@ -29,6 +29,7 @@
     {{
         onsButton({
             "text": _("Continue"),
+            "submitType": 'timer',
             "classes": 'u-mb-m u-mt-l',
             "attributes": {'data-qa': 'btn-submit'}
         })

--- a/templates/individual_response/interstitial.html
+++ b/templates/individual_response/interstitial.html
@@ -11,6 +11,7 @@
     {{
         onsButton({
             "text": _("Request separate census"),
+            "submitType": 'timer',
             "classes": 'btn u-mb-m u-mt-s btn--link',
             "url": next_location_url,
             "attributes": {'data-qa': 'btn-submit'}

--- a/templates/interstitial.html
+++ b/templates/interstitial.html
@@ -30,6 +30,7 @@
     {{
         onsButton({
             "text": continue_button_text | default(_("Save and continue")),
+            "submitType": 'timer',
             "classes": "u-mt-l",
             "attributes": {
                 "data-qa": "btn-submit"

--- a/templates/partials/email-form.html
+++ b/templates/partials/email-form.html
@@ -37,6 +37,7 @@
 {{
   onsButton({
     "text": _("Send confirmation"),
+    "submitType": 'timer',
     "classes": "u-mt-s u-mb-xl",
     "attributes": {
       "data-qa": "btn-submit"

--- a/templates/partials/introduction/start-survey.html
+++ b/templates/partials/introduction/start-survey.html
@@ -3,6 +3,7 @@
 {{
   onsButton({
     "text": _("Start survey"),
+    "submitType": 'timer',
     "classes": "u-mt-l qa-btn-get-started",
     "name": "action[start_questionnaire]"
   })

--- a/templates/sectionsummary.html
+++ b/templates/sectionsummary.html
@@ -46,6 +46,7 @@
     {{
         onsButton({
             "text": continue_button_text | default(_("Continue")),
+            "submitType": 'timer',
             "classes": "u-mt-xl",
             "attributes": {
                 "data-qa": "btn-submit"


### PR DESCRIPTION
### What is the context of this PR?

Adds the `submitType: timer` field to a number of our submit buttons to protect against double clicks.

### How to review 

Check the templates updated match those on the Trello card.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
