### PR TITLE
Handle confirmation param errors for mobile numbers and email when changed or removed

### DIFF
--- a/app/routes/errors.py
+++ b/app/routes/errors.py
@@ -6,6 +6,7 @@ from flask_login import current_user
 from flask_wtf.csrf import CSRFError
 from sdc.crypto.exceptions import InvalidTokenException
 from structlog import get_logger
+from werkzeug.exceptions import BadRequestKeyError
 
 from app.authentication.no_questionnaire_state_exception import (
     NoQuestionnaireStateException,
@@ -56,6 +57,7 @@ def _render_error_page(status_code, template=None, **kwargs):
 
 
 @errors_blueprint.app_errorhandler(400)
+@errors_blueprint.app_errorhandler(BadRequestKeyError)
 def bad_request(exception=None):
     log_exception(exception, 400)
     return _render_error_page(400, template="500")

--- a/app/routes/errors.py
+++ b/app/routes/errors.py
@@ -55,6 +55,12 @@ def _render_error_page(status_code, template=None, **kwargs):
     )
 
 
+@errors_blueprint.app_errorhandler(400)
+def bad_request(exception=None):
+    log_exception(exception, 400)
+    return _render_error_page(400, template="500")
+
+
 @errors_blueprint.app_errorhandler(401)
 @errors_blueprint.app_errorhandler(CSRFError)
 @errors_blueprint.app_errorhandler(NoTokenException)

--- a/app/routes/individual_response.py
+++ b/app/routes/individual_response.py
@@ -250,10 +250,8 @@ def individual_response_text_message_confirmation(schema, questionnaire_store):
     if request.method == "POST":
         return redirect(url_for("questionnaire.get_questionnaire"))
 
-    if not (request_mobile_number := request.args.get("mobile_number")):
-        raise BadRequest
     try:
-        mobile_number = url_safe_serializer().loads(request_mobile_number)
+        mobile_number = url_safe_serializer().loads(request.args["mobile_number"])
     except BadSignature:
         raise BadRequest
 

--- a/app/routes/questionnaire.py
+++ b/app/routes/questionnaire.py
@@ -347,11 +347,8 @@ def get_confirmation_email_sent(session_store, schema):
     if not session_store.session_data.confirmation_email_count:
         raise NotFound
 
-    if not (request_email := request.args.get("email")):
-        raise BadRequest
-
     try:
-        email = url_safe_serializer().loads(request_email)
+        email = url_safe_serializer().loads(request.args["email"])
     except BadSignature:
         raise BadRequest
 

--- a/app/routes/questionnaire.py
+++ b/app/routes/questionnaire.py
@@ -3,8 +3,9 @@ from flask import Blueprint, g, jsonify, redirect, request
 from flask import session as cookie_session
 from flask import url_for
 from flask_login import current_user, login_required
+from itsdangerous import BadSignature
 from structlog import get_logger
-from werkzeug.exceptions import NotFound
+from werkzeug.exceptions import BadRequest, NotFound
 
 from app.authentication.no_questionnaire_state_exception import (
     NoQuestionnaireStateException,
@@ -346,7 +347,13 @@ def get_confirmation_email_sent(session_store, schema):
     if not session_store.session_data.confirmation_email_count:
         raise NotFound
 
-    email = url_safe_serializer().loads(request.args.get("email"))
+    if not (request_email := request.args.get("email")):
+        raise BadRequest
+
+    try:
+        email = url_safe_serializer().loads(request_email)
+    except BadSignature:
+        raise BadRequest
 
     show_send_another_email_guidance = not ConfirmationEmail.is_limit_reached(
         session_store.session_data

--- a/app/views/handlers/individual_response.py
+++ b/app/views/handlers/individual_response.py
@@ -826,11 +826,10 @@ class IndividualResponseTextConfirmHandler(IndividualResponseHandler):
         form_data,
         list_item_id,
     ):
-        if not (request_mobile_number := request_args.get("mobile_number")):
-            raise BadRequest
-
         try:
-            self.mobile_number = url_safe_serializer().loads(request_mobile_number)
+            self.mobile_number = url_safe_serializer().loads(
+                request_args["mobile_number"]
+            )
         except BadSignature:
             raise BadRequest
 

--- a/app/views/handlers/individual_response.py
+++ b/app/views/handlers/individual_response.py
@@ -6,7 +6,8 @@ from uuid import uuid4
 from flask import current_app, redirect
 from flask.helpers import url_for
 from flask_babel import lazy_gettext
-from werkzeug.exceptions import NotFound
+from itsdangerous import BadSignature
+from werkzeug.exceptions import BadRequest, NotFound
 
 from app.data_models import CompletionStatus, FulfilmentRequest
 from app.forms.questionnaire_form import generate_form
@@ -825,9 +826,13 @@ class IndividualResponseTextConfirmHandler(IndividualResponseHandler):
         form_data,
         list_item_id,
     ):
-        self.mobile_number = url_safe_serializer().loads(
-            request_args.get("mobile_number")
-        )
+        if not (request_mobile_number := request_args.get("mobile_number")):
+            raise BadRequest
+
+        try:
+            self.mobile_number = url_safe_serializer().loads(request_mobile_number)
+        except BadSignature:
+            raise BadRequest
 
         super().__init__(
             schema,

--- a/tests/integration/individual_response/test_individual_response.py
+++ b/tests/integration/individual_response/test_individual_response.py
@@ -178,7 +178,7 @@ class TestIndividualResponseErrorStatus(IndividualResponseTestCase):
         self.get(
             f"individual-response/{person_id}/text/confirm-number?journey=hub&mobile_number=bad-signature"
         )
-        # Then a Bad Request error is returned
+        # Then a BadRequest error is returned
         self.assertBadRequest()
         self.assertEqualPageTitle("An error has occurred - Census 2021")
 
@@ -195,7 +195,7 @@ class TestIndividualResponseErrorStatus(IndividualResponseTestCase):
         person_id = self.last_url.split("/")[2]
         self.get(f"individual-response/{person_id}/text/confirm-number?journey=hub")
 
-        # Then a Bad Request error is returned
+        # Then a BadRequest error is returned
         self.assertBadRequest()
         self.assertEqualPageTitle("An error has occurred - Census 2021")
 
@@ -214,7 +214,7 @@ class TestIndividualResponseErrorStatus(IndividualResponseTestCase):
             f"individual-response/text/confirmation?journey=hub&mobile_number=bad-signature"
         )
 
-        # Then a Bad Request error is returned
+        # Then a BadRequest error is returned
         self.assertBadRequest()
         self.assertEqualPageTitle("An error has occurred - Census 2021")
 
@@ -231,7 +231,7 @@ class TestIndividualResponseErrorStatus(IndividualResponseTestCase):
         # When I try to view the confirmation page with no mobile number param
         self.get(f"individual-response/text/confirmation?journey=hub")
 
-        # Then a Bad Request error is returned
+        # Then a BadRequest error is returned
         self.assertBadRequest()
         self.assertEqualPageTitle("An error has occurred - Census 2021")
 

--- a/tests/integration/individual_response/test_individual_response.py
+++ b/tests/integration/individual_response/test_individual_response.py
@@ -164,6 +164,77 @@ class TestIndividualResponseOnHubDisabled(IndividualResponseTestCase):
 
 
 class TestIndividualResponseErrorStatus(IndividualResponseTestCase):
+    def test_ir_raises_400_confirm_number_bad_signature(self):
+        # Given I request an individual response by mobile phone
+        self._add_household_no_primary()
+        self.post()
+        self.get(self.individual_response_link)
+        self.get(self.individual_response_start_link)
+        self.post({"individual-response-how-answer": "Text message"})
+        self.post({"individual-response-enter-number-answer": "07970000000"})
+
+        # When I try to view the confirm number page with an incorrect mobile number hash
+        person_id = self.last_url.split("/")[2]
+        self.get(
+            f"individual-response/{person_id}/text/confirm-number?journey=hub&mobile_number=bad-signature"
+        )
+        # Then a Bad Request error is returned
+        self.assertBadRequest()
+        self.assertEqualPageTitle("An error has occurred - Census 2021")
+
+    def test_ir_raises_400_confirm_number_missing_mobile_param(self):
+        # Given I request an individual response by mobile phone
+        self._add_household_no_primary()
+        self.post()
+        self.get(self.individual_response_link)
+        self.get(self.individual_response_start_link)
+        self.post({"individual-response-how-answer": "Text message"})
+        self.post({"individual-response-enter-number-answer": "07970000000"})
+
+        # When I try to view the confirm number page with no mobile number param
+        person_id = self.last_url.split("/")[2]
+        self.get(f"individual-response/{person_id}/text/confirm-number?journey=hub")
+
+        # Then a Bad Request error is returned
+        self.assertBadRequest()
+        self.assertEqualPageTitle("An error has occurred - Census 2021")
+
+    def test_ir_raises_400_confirmation_bad_signature(self):
+        # Given I request an individual response by mobile phone
+        self._add_household_no_primary()
+        self.post()
+        self.get(self.individual_response_link)
+        self.get(self.individual_response_start_link)
+        self.post({"individual-response-how-answer": "Text message"})
+        self.post({"individual-response-enter-number-answer": "07970000000"})
+        self.post({"individual-response-text-confirm-answer": "Yes, send the text"})
+
+        # When I try to view the confirmation page with an incorrect mobile number hash
+        self.get(
+            f"individual-response/text/confirmation?journey=hub&mobile_number=bad-signature"
+        )
+
+        # Then a Bad Request error is returned
+        self.assertBadRequest()
+        self.assertEqualPageTitle("An error has occurred - Census 2021")
+
+    def test_ir_raises_400_confirmation_missing_mobile_param(self):
+        # Given I request an individual response by mobile phone
+        self._add_household_no_primary()
+        self.post()
+        self.get(self.individual_response_link)
+        self.get(self.individual_response_start_link)
+        self.post({"individual-response-how-answer": "Text message"})
+        self.post({"individual-response-enter-number-answer": "07970000000"})
+        self.post({"individual-response-text-confirm-answer": "Yes, send the text"})
+
+        # When I try to view the confirmation page with no mobile number param
+        self.get(f"individual-response/text/confirmation?journey=hub")
+
+        # Then a Bad Request error is returned
+        self.assertBadRequest()
+        self.assertEqualPageTitle("An error has occurred - Census 2021")
+
     def test_ir_raises_401_without_session(self):
         # Given the hub is enabled
         # And I add a household member

--- a/tests/integration/integration_test_case.py
+++ b/tests/integration/integration_test_case.py
@@ -311,6 +311,9 @@ class IntegrationTestCase(unittest.TestCase):  # pylint: disable=too-many-public
     def assertStatusOK(self):
         self.assertStatusCode(200)
 
+    def assertBadRequest(self):
+        self.assertStatusCode(400)
+
     def assertStatusUnauthorised(self):
         self.assertStatusCode(401)
 

--- a/tests/integration/routes/test_confirmation_email.py
+++ b/tests/integration/routes/test_confirmation_email.py
@@ -15,6 +15,29 @@ class TestEmailConfirmation(IntegrationTestCase):
         self.post({"answer_id": "Yes"})
         self.post()
 
+    def test_bad_signature_confirmation_email_sent(self):
+        # Given I launch and complete the test_confirmation_email questionnaire
+        self._launch_and_complete_questionnaire()
+        self.post({"email": "email@example.com"})
+
+        # When I try to view the sent page with an incorrect email hash
+        self.get("/submitted/confirmation-email/sent?email=bad-signature")
+
+        # Then a Bad Request error is returned
+        self.assertBadRequest()
+        self.assertEqualPageTitle("An error has occurred - Census 2021")
+
+    def test_missing_email_param_confirmation_email_sent(self):
+        # Given I launch and complete the test_confirmation_email questionnaire
+        self._launch_and_complete_questionnaire()
+        self.post({"email": "email@example.com"})
+
+        # When I try to view the sent page with no email param
+        self.get("/submitted/confirmation-email/sent")
+
+        # Then a Bad Request error is returned
+        self.assertBadRequest()
+
     def test_thank_you_page_get_not_allowed(self):
         # Given I launch the test_confirmation_email questionnaire
         self.launchSurvey("test_confirmation_email")
@@ -358,6 +381,6 @@ class TestEmailConfirmation(IntegrationTestCase):
         self.post({"email": "new-email@new-example.com"})
         self.get(f"/submitted/confirmation-email/sent?{query_params}")
 
-        # Then a 500 error is returned
-        self.assertStatusCode(500)
+        # Then a Bad Request error is returned
+        self.assertBadRequest()
         self.assertEqualPageTitle("An error has occurred - Census 2021")

--- a/tests/integration/routes/test_confirmation_email.py
+++ b/tests/integration/routes/test_confirmation_email.py
@@ -23,7 +23,7 @@ class TestEmailConfirmation(IntegrationTestCase):
         # When I try to view the sent page with an incorrect email hash
         self.get("/submitted/confirmation-email/sent?email=bad-signature")
 
-        # Then a Bad Request error is returned
+        # Then a BadRequest error is returned
         self.assertBadRequest()
         self.assertEqualPageTitle("An error has occurred - Census 2021")
 
@@ -35,7 +35,7 @@ class TestEmailConfirmation(IntegrationTestCase):
         # When I try to view the sent page with no email param
         self.get("/submitted/confirmation-email/sent")
 
-        # Then a Bad Request error is returned
+        # Then a BadRequest error is returned
         self.assertBadRequest()
 
     def test_thank_you_page_get_not_allowed(self):
@@ -381,6 +381,6 @@ class TestEmailConfirmation(IntegrationTestCase):
         self.post({"email": "new-email@new-example.com"})
         self.get(f"/submitted/confirmation-email/sent?{query_params}")
 
-        # Then a Bad Request error is returned
+        # Then a BadRequest error is returned
         self.assertBadRequest()
         self.assertEqualPageTitle("An error has occurred - Census 2021")


### PR DESCRIPTION
### What is the context of this PR?
This PR changes a 500 errors into a 400 (BadRequest) when a respondent has removed the param (email/mobile number) or has changed the hash value

### How to review 
Using test_confirmation_email, complete the form and send an email, now on the confirmation page try changing the email hash in the url and enter, make sure it returns a 400 rather than a 500. Now remove the email param and value completely and make sure it returns a 400 as well

Using test_individual_response add 2 people. From the hub request an individual response by text message. Now on the confirm-number page try changing the mobile phone hash in the url and enter, make sure it returns a 400 rather than a 500. Now remove the mobile phone param and value completely and make sure it returns a 400 as well. Repeat for the confirmation page (the page after confirm-number)

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
