### PR TITLE
Add transactionId to Individual Response and Confirmation logging

### DIFF
--- a/app/cloud_tasks/cloud_task_publishers.py
+++ b/app/cloud_tasks/cloud_task_publishers.py
@@ -46,24 +46,27 @@ class CloudTaskPublisher:
         )
         return task
 
-    def create_task(self, body: bytes, queue_name: str, function_name: str, transactionId: str) -> Task:
+    def create_task(
+        self, body: bytes, queue_name: str, function_name: str, transactionId: str
+    ) -> Task:
 
         parent = self._client.queue_path(self._project_id, "europe-west2", queue_name)
         try:
             task = self._create_task_with_retry(body, function_name, parent)
-            logger.info("task created successfully", transactionId=transactionId)  # pragma: no cover
+            logger.info(
+                "task created successfully", transactionId=transactionId
+            )  # pragma: no cover
             return task
         except Exception as exc:
-            logger.exception(
-                "task creation failed",
-                transactionId=transactionId
-            )
+            logger.exception("task creation failed", transactionId=transactionId)
             raise CloudTaskCreationFailed from exc
 
 
 class LogCloudTaskPublisher:
     @staticmethod
-    def create_task(body: bytes, queue_name: str, function_name: str, transactionId: str) -> None:
+    def create_task(
+        body: bytes, queue_name: str, function_name: str, transactionId: str
+    ) -> None:
         logger.info(
             "creating cloud task",
             body=body,

--- a/app/cloud_tasks/cloud_task_publishers.py
+++ b/app/cloud_tasks/cloud_task_publishers.py
@@ -53,9 +53,7 @@ class CloudTaskPublisher:
         parent = self._client.queue_path(self._project_id, "europe-west2", queue_name)
         try:
             task = self._create_task_with_retry(body, function_name, parent)
-            logger.info(
-                "task created successfully", transactionId=transactionId
-            )  # pragma: no cover
+            logger.info("task created successfully", transactionId=transactionId)
             return task
         except Exception as exc:
             logger.exception("task creation failed", transactionId=transactionId)

--- a/app/cloud_tasks/cloud_task_publishers.py
+++ b/app/cloud_tasks/cloud_task_publishers.py
@@ -47,28 +47,41 @@ class CloudTaskPublisher:
         return task
 
     def create_task(
-        self, body: bytes, queue_name: str, function_name: str, transactionId: str
+        self,
+        body: bytes,
+        queue_name: str,
+        function_name: str,
+        fulfilment_request_transaction_id: str,
     ) -> Task:
 
         parent = self._client.queue_path(self._project_id, "europe-west2", queue_name)
         try:
             task = self._create_task_with_retry(body, function_name, parent)
-            logger.info("task created successfully", transactionId=transactionId)
+            logger.info(
+                "task created successfully",
+                fulfilment_request_transaction_id=fulfilment_request_transaction_id,
+            )
             return task
         except Exception as exc:
-            logger.exception("task creation failed", transactionId=transactionId)
+            logger.exception(
+                "task creation failed",
+                fulfilment_request_transaction_id=fulfilment_request_transaction_id,
+            )
             raise CloudTaskCreationFailed from exc
 
 
 class LogCloudTaskPublisher:
     @staticmethod
     def create_task(
-        body: bytes, queue_name: str, function_name: str, transactionId: str
+        body: bytes,
+        queue_name: str,
+        function_name: str,
+        fulfilment_request_transaction_id: str,
     ) -> None:
         logger.info(
             "creating cloud task",
             body=body,
             queue_name=queue_name,
             function_name=function_name,
-            transactionId=transactionId,
+            fulfilment_request_transaction_id=fulfilment_request_transaction_id,
         )

--- a/app/cloud_tasks/cloud_task_publishers.py
+++ b/app/cloud_tasks/cloud_task_publishers.py
@@ -46,27 +46,28 @@ class CloudTaskPublisher:
         )
         return task
 
-    def create_task(self, body: bytes, queue_name: str, function_name: str) -> Task:
-        logger.info("creating cloud task")
+    def create_task(self, body: bytes, queue_name: str, function_name: str, transactionId: str) -> Task:
 
         parent = self._client.queue_path(self._project_id, "europe-west2", queue_name)
         try:
             task = self._create_task_with_retry(body, function_name, parent)
-            logger.info("task created successfully")  # pragma: no cover
+            logger.info("task created successfully", transactionId=transactionId)  # pragma: no cover
             return task
         except Exception as exc:
             logger.exception(
                 "task creation failed",
+                transactionId=transactionId
             )
             raise CloudTaskCreationFailed from exc
 
 
 class LogCloudTaskPublisher:
     @staticmethod
-    def create_task(body: bytes, queue_name: str, function_name: str) -> None:
+    def create_task(body: bytes, queue_name: str, function_name: str, transactionId: str) -> None:
         logger.info(
             "creating cloud task",
             body=body,
             queue_name=queue_name,
             function_name=function_name,
+            transactionId=transactionId,
         )

--- a/app/data_models/fulfilment_request.py
+++ b/app/data_models/fulfilment_request.py
@@ -14,7 +14,7 @@ class FulfilmentRequest(ABC):
         pass  # pragma: no cover
 
     @cached_property
-    def transactionId(self) -> str:
+    def transaction_id(self) -> str:
         return str(uuid4())
 
     @property
@@ -25,7 +25,7 @@ class FulfilmentRequest(ABC):
                 "source": "QUESTIONNAIRE_RUNNER",
                 "channel": "EQ",
                 "dateTime": datetime.now(tz=tzutc()).isoformat(),
-                "transactionId": self.transactionId,
+                "transactionId": self.transaction_id,
             },
             "payload": self._payload(),
         }

--- a/app/data_models/fulfilment_request.py
+++ b/app/data_models/fulfilment_request.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 from datetime import datetime
+from functools import cached_property
 from typing import Mapping
 from uuid import uuid4
 
@@ -12,6 +13,10 @@ class FulfilmentRequest(ABC):
     def _payload(self) -> Mapping:
         pass  # pragma: no cover
 
+    @cached_property
+    def transactionId(self) -> str:
+        return str(uuid4())
+
     @property
     def message(self) -> bytes:
         message = {
@@ -20,7 +25,7 @@ class FulfilmentRequest(ABC):
                 "source": "QUESTIONNAIRE_RUNNER",
                 "channel": "EQ",
                 "dateTime": datetime.now(tz=tzutc()).isoformat(),
-                "transactionId": str(uuid4()),
+                "transactionId": self.transactionId,
             },
             "payload": self._payload(),
         }

--- a/app/publisher/publisher.py
+++ b/app/publisher/publisher.py
@@ -12,7 +12,7 @@ logger = get_logger(__name__)
 
 class Publisher(ABC):
     @abstractmethod
-    def publish(self, topic_id, message):
+    def publish(self, topic_id, message, transactionId):
         pass  # pragma: no cover
 
 
@@ -27,7 +27,7 @@ class PubSubPublisher(Publisher):
         response: Future = self._client.publish(topic_path, message)
         return response
 
-    def publish(self, topic_id, message: bytes):
+    def publish(self, topic_id, message: bytes, transactionId: str):
         response = self._publish(topic_id, message)
         try:
             # Resolve the future
@@ -36,6 +36,7 @@ class PubSubPublisher(Publisher):
                 "message published successfully",
                 topic_id=topic_id,
                 message_id=message_id,
+                transactionId=transactionId,
             )
         except Exception as ex:  # pylint:disable=broad-except
             logger.exception(
@@ -46,5 +47,10 @@ class PubSubPublisher(Publisher):
 
 
 class LogPublisher(Publisher):
-    def publish(self, topic_id, message: bytes):
-        logger.info("publishing message", topic_id=topic_id, message=message)
+    def publish(self, topic_id, message: bytes, transactionId: str):
+        logger.info(
+            "publishing message",
+            topic_id=topic_id,
+            message=message,
+            transactionId=transactionId,
+        )

--- a/app/publisher/publisher.py
+++ b/app/publisher/publisher.py
@@ -12,7 +12,7 @@ logger = get_logger(__name__)
 
 class Publisher(ABC):
     @abstractmethod
-    def publish(self, topic_id, message, transactionId):
+    def publish(self, topic_id, message, fulfilment_request_transaction_id):
         pass  # pragma: no cover
 
 
@@ -27,7 +27,7 @@ class PubSubPublisher(Publisher):
         response: Future = self._client.publish(topic_path, message)
         return response
 
-    def publish(self, topic_id, message: bytes, transactionId: str):
+    def publish(self, topic_id, message: bytes, fulfilment_request_transaction_id: str):
         response = self._publish(topic_id, message)
         try:
             # Resolve the future
@@ -36,7 +36,7 @@ class PubSubPublisher(Publisher):
                 "message published successfully",
                 topic_id=topic_id,
                 message_id=message_id,
-                transactionId=transactionId,
+                fulfilment_request_transaction_id=fulfilment_request_transaction_id,
             )
         except Exception as ex:  # pylint:disable=broad-except
             logger.exception(
@@ -47,10 +47,10 @@ class PubSubPublisher(Publisher):
 
 
 class LogPublisher(Publisher):
-    def publish(self, topic_id, message: bytes, transactionId: str):
+    def publish(self, topic_id, message: bytes, fulfilment_request_transaction_id: str):
         logger.info(
             "publishing message",
             topic_id=topic_id,
             message=message,
-            transactionId=transactionId,
+            fulfilment_request_transaction_id=fulfilment_request_transaction_id,
         )

--- a/app/views/handlers/confirmation_email.py
+++ b/app/views/handlers/confirmation_email.py
@@ -76,7 +76,7 @@ class ConfirmationEmail:
                 body=fulfilment_request.message,
                 queue_name=EQ_SUBMISSION_CONFIRMATION_QUEUE,
                 function_name=EQ_SUBMISSION_CONFIRMATION_CLOUD_FUNCTION_NAME,
-                transactionId=fulfilment_request.transactionId
+                transactionId=fulfilment_request.transactionId,
             )
         except CloudTaskCreationFailed as exc:
             raise ConfirmationEmailFulfilmentRequestPublicationFailed from exc

--- a/app/views/handlers/confirmation_email.py
+++ b/app/views/handlers/confirmation_email.py
@@ -76,7 +76,7 @@ class ConfirmationEmail:
                 body=fulfilment_request.message,
                 queue_name=EQ_SUBMISSION_CONFIRMATION_QUEUE,
                 function_name=EQ_SUBMISSION_CONFIRMATION_CLOUD_FUNCTION_NAME,
-                transactionId=fulfilment_request.transactionId,
+                fulfilment_request_transaction_id=fulfilment_request.transaction_id,
             )
         except CloudTaskCreationFailed as exc:
             raise ConfirmationEmailFulfilmentRequestPublicationFailed from exc

--- a/app/views/handlers/confirmation_email.py
+++ b/app/views/handlers/confirmation_email.py
@@ -76,6 +76,7 @@ class ConfirmationEmail:
                 body=fulfilment_request.message,
                 queue_name=EQ_SUBMISSION_CONFIRMATION_QUEUE,
                 function_name=EQ_SUBMISSION_CONFIRMATION_CLOUD_FUNCTION_NAME,
+                transactionId=fulfilment_request.transactionId
             )
         except CloudTaskCreationFailed as exc:
             raise ConfirmationEmailFulfilmentRequestPublicationFailed from exc

--- a/app/views/handlers/individual_response.py
+++ b/app/views/handlers/individual_response.py
@@ -206,7 +206,7 @@ class IndividualResponseHandler:
             return current_app.eq["publisher"].publish(
                 topic_id,
                 message=fulfilment_request.message,
-                transactionId=fulfilment_request.transactionId,
+                fulfilment_request_transaction_id=fulfilment_request.transaction_id,
             )
         except PublicationFailed:
             raise IndividualResponseFulfilmentRequestPublicationFailed

--- a/app/views/handlers/individual_response.py
+++ b/app/views/handlers/individual_response.py
@@ -203,7 +203,9 @@ class IndividualResponseHandler:
         )
         try:
             return current_app.eq["publisher"].publish(
-                topic_id, message=fulfilment_request.message
+                topic_id,
+                message=fulfilment_request.message,
+                transactionId=fulfilment_request.transactionId,
             )
         except PublicationFailed:
             raise IndividualResponseFulfilmentRequestPublicationFailed

--- a/tests/app/cloud_tasks/test_cloud_task_publishers.py
+++ b/tests/app/cloud_tasks/test_cloud_task_publishers.py
@@ -1,4 +1,3 @@
-from app.data_models import fulfilment_request
 from unittest import TestCase, mock
 from unittest.mock import MagicMock, Mock, patch
 from uuid import uuid4
@@ -9,6 +8,7 @@ from google.cloud.tasks_v2.types.task import Task
 
 from app.cloud_tasks import CloudTaskPublisher
 from app.cloud_tasks.exceptions import CloudTaskCreationFailed
+from app.data_models import fulfilment_request
 
 
 class TestCloudTaskPublisher(TestCase):

--- a/tests/app/cloud_tasks/test_cloud_task_publishers.py
+++ b/tests/app/cloud_tasks/test_cloud_task_publishers.py
@@ -1,5 +1,6 @@
 from unittest import TestCase, mock
 from unittest.mock import MagicMock, Mock, patch
+from uuid import uuid4
 
 from google.api_core.exceptions import DeadlineExceeded, ServiceUnavailable
 from google.cloud.tasks_v2 import CreateTaskRequest
@@ -11,6 +12,10 @@ from app.cloud_tasks.exceptions import CloudTaskCreationFailed
 
 class TestCloudTaskPublisher(TestCase):
     PROJECT_ID = "test-project-id"
+    queue_name = "test"
+    function_name = "test"
+    body = bytes("test", "utf-8")
+    transactionId=str(uuid4())
 
     def setUp(self) -> None:
         with patch(
@@ -20,10 +25,6 @@ class TestCloudTaskPublisher(TestCase):
             self.cloud_task_publisher = CloudTaskPublisher()
 
     def test_create_task(self):
-        queue_name = "test"
-        function_name = "test"
-        body = bytes("test", "utf-8")
-
         # Mock the actual call within the gRPC stub, and fake the request.
         with mock.patch.object(
             type(self.cloud_task_publisher._client.transport.create_task), "__call__"
@@ -31,10 +32,10 @@ class TestCloudTaskPublisher(TestCase):
 
             # Designate an appropriate return value for the call.
             call.return_value = self.cloud_task_publisher._get_task(
-                body=body, function_name=function_name
+                body=self.body, function_name=self.function_name
             )
             self.cloud_task_publisher.create_task(
-                body=body, queue_name=queue_name, function_name=function_name
+                body=self.body, queue_name=self.queue_name, function_name=self.function_name, transactionId=self.transactionId
             )
 
             # Establish that the underlying gRPC stub method was called.
@@ -44,35 +45,27 @@ class TestCloudTaskPublisher(TestCase):
                 mapping={
                     "parent": f"projects/{self.PROJECT_ID}/locations/europe-west2/queues/test",
                     "task": self.cloud_task_publisher._get_task(
-                        body=body, function_name=function_name
+                        body=self.body, function_name=self.function_name
                     ),
                 }
             )
 
     def test_create_task_raises_exception_on_non_transient_error(self):
-        queue_name = "test"
-        function_name = "test"
-        body = bytes("test", "utf-8")
-
         mock_create_task = MagicMock()
         mock_create_task.side_effect = DeadlineExceeded("test")
         self.cloud_task_publisher._client.create_task = mock_create_task
 
         with self.assertRaises(CloudTaskCreationFailed):
             self.cloud_task_publisher.create_task(
-                body=body, queue_name=queue_name, function_name=function_name
+                body=self.body, queue_name=self.queue_name, function_name=self.function_name, transactionId=self.transactionId
             )
 
     def test_create_task_transient_error_retries(self):
-        queue_name = "test"
-        function_name = "test"
-        body = bytes("test", "utf-8")
-
         mock_create_task = MagicMock()
         mock_create_task.side_effect = [ServiceUnavailable("test"), Task()]
         self.cloud_task_publisher._client.create_task = mock_create_task
         self.cloud_task_publisher.create_task(
-            body=body, queue_name=queue_name, function_name=function_name
+            body=self.body, queue_name=self.queue_name, function_name=self.function_name, transactionId=self.transactionId
         )
 
         self.assertEqual(mock_create_task.call_count, 2)

--- a/tests/app/cloud_tasks/test_cloud_task_publishers.py
+++ b/tests/app/cloud_tasks/test_cloud_task_publishers.py
@@ -15,7 +15,7 @@ class TestCloudTaskPublisher(TestCase):
     queue_name = "test"
     function_name = "test"
     body = bytes("test", "utf-8")
-    transactionId=str(uuid4())
+    transactionId = str(uuid4())
 
     def setUp(self) -> None:
         with patch(
@@ -35,7 +35,10 @@ class TestCloudTaskPublisher(TestCase):
                 body=self.body, function_name=self.function_name
             )
             self.cloud_task_publisher.create_task(
-                body=self.body, queue_name=self.queue_name, function_name=self.function_name, transactionId=self.transactionId
+                body=self.body,
+                queue_name=self.queue_name,
+                function_name=self.function_name,
+                transactionId=self.transactionId,
             )
 
             # Establish that the underlying gRPC stub method was called.
@@ -57,7 +60,10 @@ class TestCloudTaskPublisher(TestCase):
 
         with self.assertRaises(CloudTaskCreationFailed):
             self.cloud_task_publisher.create_task(
-                body=self.body, queue_name=self.queue_name, function_name=self.function_name, transactionId=self.transactionId
+                body=self.body,
+                queue_name=self.queue_name,
+                function_name=self.function_name,
+                transactionId=self.transactionId,
             )
 
     def test_create_task_transient_error_retries(self):
@@ -65,7 +71,10 @@ class TestCloudTaskPublisher(TestCase):
         mock_create_task.side_effect = [ServiceUnavailable("test"), Task()]
         self.cloud_task_publisher._client.create_task = mock_create_task
         self.cloud_task_publisher.create_task(
-            body=self.body, queue_name=self.queue_name, function_name=self.function_name, transactionId=self.transactionId
+            body=self.body,
+            queue_name=self.queue_name,
+            function_name=self.function_name,
+            transactionId=self.transactionId,
         )
 
         self.assertEqual(mock_create_task.call_count, 2)

--- a/tests/app/cloud_tasks/test_cloud_task_publishers.py
+++ b/tests/app/cloud_tasks/test_cloud_task_publishers.py
@@ -1,3 +1,4 @@
+from app.data_models import fulfilment_request
 from unittest import TestCase, mock
 from unittest.mock import MagicMock, Mock, patch
 from uuid import uuid4
@@ -15,7 +16,7 @@ class TestCloudTaskPublisher(TestCase):
     queue_name = "test"
     function_name = "test"
     body = bytes("test", "utf-8")
-    transactionId = str(uuid4())
+    transaction_id = str(uuid4())
 
     def setUp(self) -> None:
         with patch(
@@ -38,7 +39,7 @@ class TestCloudTaskPublisher(TestCase):
                 body=self.body,
                 queue_name=self.queue_name,
                 function_name=self.function_name,
-                transactionId=self.transactionId,
+                fulfilment_request_transaction_id=self.transaction_id,
             )
 
             # Establish that the underlying gRPC stub method was called.
@@ -63,7 +64,7 @@ class TestCloudTaskPublisher(TestCase):
                 body=self.body,
                 queue_name=self.queue_name,
                 function_name=self.function_name,
-                transactionId=self.transactionId,
+                fulfilment_request_transaction_id=self.transaction_id,
             )
 
     def test_create_task_transient_error_retries(self):
@@ -74,7 +75,7 @@ class TestCloudTaskPublisher(TestCase):
             body=self.body,
             queue_name=self.queue_name,
             function_name=self.function_name,
-            transactionId=self.transactionId,
+            fulfilment_request_transaction_id=self.transaction_id,
         )
 
         self.assertEqual(mock_create_task.call_count, 2)

--- a/tests/app/publisher/test_publisher.py
+++ b/tests/app/publisher/test_publisher.py
@@ -1,5 +1,6 @@
 from unittest import TestCase, mock
 from unittest.mock import Mock, patch, sentinel
+from uuid import uuid4
 
 from google.pubsub_v1.types.pubsub import PubsubMessage
 
@@ -41,6 +42,8 @@ class TestPubSub(TestCase):
     def test_resolving_message_raises_exception_on_error(self):
         with self.assertRaises(PublicationFailed) as ex:
             # Try resolve the future with an invalid credentials
-            self.publisher.publish(self.topic_id, b"test-message")
+            self.publisher.publish(
+                self.topic_id, b"test-message", transactionId=str(uuid4())
+            )
 
         assert "403 The request is missing a valid API key." in str(ex.exception)

--- a/tests/app/publisher/test_publisher.py
+++ b/tests/app/publisher/test_publisher.py
@@ -43,7 +43,9 @@ class TestPubSub(TestCase):
         with self.assertRaises(PublicationFailed) as ex:
             # Try resolve the future with an invalid credentials
             self.publisher.publish(
-                self.topic_id, b"test-message", transactionId=str(uuid4())
+                self.topic_id,
+                b"test-message",
+                fulfilment_request_transaction_id=str(uuid4()),
             )
 
         assert "403 The request is missing a valid API key." in str(ex.exception)


### PR DESCRIPTION
### What is the context of this PR?
Adds the transactionId to log lines assosciated with the individual response and confirmation fulfilment requests

### How to review 
Check that the assosciated log lines are correctly emitted when requesting an IR and a confirmation email
