### PR TITLE
Add email filter to remove white space

### DIFF
--- a/app/forms/email_form.py
+++ b/app/forms/email_form.py
@@ -14,6 +14,7 @@ class EmailForm(FlaskForm):
             EmailTLDCheck(error_messages["INVALID_EMAIL_FORMAT"]),
             Email(error_messages["INVALID_EMAIL_FORMAT"]),
         ],
+        filters=[lambda x: x.strip() if x else None],
     )
 
     def map_errors(self):

--- a/tests/app/forms/test_email_form.py
+++ b/tests/app/forms/test_email_form.py
@@ -1,0 +1,12 @@
+from werkzeug.datastructures import MultiDict
+
+from app.forms.email_form import EmailForm
+from tests.app.app_context_test_case import AppContextTestCase
+
+
+class TestEmailForm(AppContextTestCase):
+    def test_email_filters_strip(self):
+        with self._app.test_request_context():
+            email_form = EmailForm(MultiDict({"email": " email@example.com "}))
+
+            assert email_form.email.data == "email@example.com"

--- a/tests/integration/routes/test_confirmation_email.py
+++ b/tests/integration/routes/test_confirmation_email.py
@@ -134,6 +134,17 @@ class TestEmailConfirmation(IntegrationTestCase):
         self.assertInUrl("confirmation-email/sent")
         self.assertInBody("A confirmation email has been sent")
 
+    def test_thank_you_page_confirmation_email_white_space(self):
+        # Given I launch and complete the test_confirmation_email questionnaire
+        self._launch_and_complete_questionnaire()
+
+        # When I enter a valid email which has leading and trailing whitespace
+        self.post({"email": " email@example.com "})
+
+        # Then I get confirmation that the email has been sent
+        self.assertInUrl("confirmation-email/sent")
+        self.assertInBody("A confirmation email has been sent to email@example.com")
+
     def test_thank_you_page_confirmation_email_show_warning(self):
         # Given I launch and complete the test_confirmation_email questionnaire
         self._launch_and_complete_questionnaire()
@@ -261,6 +272,19 @@ class TestEmailConfirmation(IntegrationTestCase):
         # When I go to the confirmation email page and submit with a valid email
         self.get("/submitted/confirmation-email/send/")
         self.post({"email": "email@example.com"})
+
+        # Then I get confirmation that the email has been sent
+        self.assertInUrl("confirmation-email/sent")
+        self.assertInBody("A confirmation email has been sent to email@example.com")
+
+    def test_confirmation_email_page_white_space(self):
+        # Given I launch and complete the test_confirmation_email questionnaire and submit with a valid email from the thank you page
+        self._launch_and_complete_questionnaire()
+        self.post({"email": "email@example.com"})
+
+        # When I go to the confirmation email page and submit with a valid email which has leading and trailing whitespace
+        self.get("/submitted/confirmation-email/send/")
+        self.post({"email": " email@example.com "})
 
         # Then I get confirmation that the email has been sent
         self.assertInUrl("confirmation-email/sent")


### PR DESCRIPTION
### What is the context of this PR?
This PR adds a filter to the email form which strips leading and trailing white space from the email address

### How to review 
Using test_confirmation_email.json complete the questionnaire and enter a valid email which has leading/trailing whitespace. Make sure it submits and the email is in the right format (white space removed). Repeat on the send another email page

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
