### PR TITLE
Update sign out logic to check for the existence of session data

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -3,7 +3,8 @@ name: PR
 on:
   pull_request:
     branches:
-      - master
+      - "master"
+      - "branch-v*"
 
 jobs:
   python-dependencies:

--- a/app/routes/session.py
+++ b/app/routes/session.py
@@ -139,7 +139,9 @@ def get_sign_out():
     ):
         session_store = get_session_store()
         language_code = (
-            session_store.session_data.language_code if session_store else None
+            session_store.session_data.language_code
+            if session_store and session_store.session_data
+            else None
         )
         log_out_url = get_census_base_url(theme, language_code)
 


### PR DESCRIPTION
### What is the context of this PR?
Updates the sign out endpoints logic also check for the existence of the session data to prevent the error: `"AttributeError: 'NoneType' object has no attribute 'language_code'"`

No tests have been added as we could not recreate this issue from a user's perspective. The implications of this has been understood and agreed with Andrew, James and Mark.

### How to review 
- Ensure sign out behaviour still works as expected and this change has not adverse effects.
- Submit a census themed survey, then delete your eq-session object from Datastore and ensure that when you click `Exit` then you are redirected to the census website.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
