### PR TITLE
Handle HTTP HEAD requests

### DIFF
--- a/app/routes/questionnaire.py
+++ b/app/routes/questionnaire.py
@@ -254,7 +254,7 @@ def relationships(
             return redirect(block_handler.get_last_location_url())
         return redirect(block_handler.get_first_location_url())
 
-    if request.method == "GET" or (
+    if request.method != "POST" or (
         hasattr(block_handler, "form") and not block_handler.form.validate()
     ):
         return _render_page(

--- a/app/routes/questionnaire.py
+++ b/app/routes/questionnaire.py
@@ -146,7 +146,7 @@ def get_section(schema, questionnaire_store, section_id, list_item_id=None):
     except InvalidLocationException:
         raise NotFound
 
-    if request.method == "GET":
+    if request.method != "POST":
         if section_handler.can_display_summary():
             section_context = section_handler.context()
             return _render_page(
@@ -189,7 +189,7 @@ def block(schema, questionnaire_store, block_id, list_name=None, list_item_id=No
         block_handler.clear_radio_answers()
         return redirect(block_handler.current_location.url())
 
-    if request.method == "GET" or (
+    if request.method != "POST" or (
         hasattr(block_handler, "form") and not block_handler.form.validate()
     ):
         return _render_page(

--- a/app/routes/session.py
+++ b/app/routes/session.py
@@ -120,7 +120,9 @@ def validate_jti(decrypted_token):
 
 @session_blueprint.route("/session-expired", methods=["GET"])
 def get_session_expired():
-    logout_user()
+    # Check for GET as we don't want to log out for HEAD requests
+    if request.method == "GET":
+        logout_user()
 
     return render_template("errors/session-expired")
 
@@ -150,7 +152,10 @@ def get_sign_out():
             "account_service_log_out_url", url_for(".get_signed_out")
         )
 
-    logout_user()
+    # Check for GET as we don't want to log out for HEAD requests
+    if request.method == "GET":
+        logout_user()
+
     return redirect(log_out_url)
 
 

--- a/tests/integration/integration_test_case.py
+++ b/tests/integration/integration_test_case.py
@@ -203,6 +203,16 @@ class IntegrationTestCase(unittest.TestCase):  # pylint: disable=too-many-public
 
         self._cache_response(environ, response)
 
+    def head(self, url, **kwargs):
+        """
+        Send a HEAD request to the specified URL.
+
+        :param url: the URL to send a HEAD request to
+        """
+        environ, response = self._client.head(url, as_tuple=True, **kwargs)
+
+        self._cache_response(environ, response)
+
     def sign_out(self):
         selected = self.getHtmlSoup().find("a", {"name": "btn-save-sign-out"})
         return self.get(selected["href"])

--- a/tests/integration/questionnaire/test_questionnaire_relationships.py
+++ b/tests/integration/questionnaire/test_questionnaire_relationships.py
@@ -126,3 +126,13 @@ class TestQuestionnaireRelationships(QuestionnaireTestCase):
         self.post({"anyone-else": "No"})
         self.post(url="/questionnaire/relationships")
         self.assertStatusOK()
+
+    def test_head_request_on_relationships_url(self):
+        self.launchSurvey("test_relationships")
+        first_list_item_id = self.add_person("Marie", "Doe")
+        second_list_item_id = self.add_person("John", "Doe")
+        self.post({"anyone-else": "No"})
+        self.head(
+            f"/questionnaire/relationships/people/{first_list_item_id}/to/{second_list_item_id}"
+        )
+        self.assertStatusOK()

--- a/tests/integration/routes/test_confirmation_email.py
+++ b/tests/integration/routes/test_confirmation_email.py
@@ -489,3 +489,23 @@ class TestEmailConfirmation(IntegrationTestCase):
         # Then a BadRequest error is returned
         self.assertBadRequest()
         self.assertEqualPageTitle("An error has occurred - Census 2021")
+
+    def test_head_request_on_email_confirmation(self):
+        self._launch_and_complete_questionnaire()
+        self.post({"email": "email@example.com"})
+        self.head(self.last_url)
+        self.assertStatusOK()
+
+    def test_head_request_on_email_send(self):
+        self._launch_and_complete_questionnaire()
+        self.post({"email": "email@example.com"})
+        self.post({"confirm-email": "No, I need to change it"})
+        self.head(self.last_url)
+        self.assertStatusOK()
+
+    def test_head_request_on_email_sent(self):
+        self._launch_and_complete_questionnaire()
+        self.post({"email": "email@example.com"})
+        self.post({"confirm-email": "Yes, send the confirmation email"})
+        self.head(self.last_url)
+        self.assertStatusOK()

--- a/tests/integration/routes/test_feedback.py
+++ b/tests/integration/routes/test_feedback.py
@@ -367,6 +367,23 @@ class TestFeedback(IntegrationTestCase):
         self.get(retry_url)
         self.assertInUrl("/submitted/feedback/send")
 
+    def test_head_request_on_feedback(self):
+        self._launch_and_complete_questionnaire()
+        self.head("/submitted/feedback/send")
+        self.assertStatusOK()
+
+    def test_head_request_on_feedback_sent(self):
+        self._launch_and_complete_questionnaire()
+        self.get("/submitted/feedback/send")
+        self.post(
+            {
+                "feedback-type": "General feedback about this service",
+                "feedback-text": "Some feedback",
+            }
+        )
+        self.head("/submitted/feedback/sent")
+        self.assertStatusOK()
+
     def _launch_and_complete_questionnaire(self):
         self.launchSurvey("test_feedback")
         self.post({"answer_id": "Yes"})

--- a/tests/integration/routes/test_questionnaire.py
+++ b/tests/integration/routes/test_questionnaire.py
@@ -1,24 +1,31 @@
-import simplejson as json
-from mock import Mock
-
-from app.data_models import QuestionnaireStore
 from tests.integration.integration_test_case import IntegrationTestCase
 
 
 class TestQuestionnaire(IntegrationTestCase):
-    def setUp(self):
-        super().setUp()
-        self._application_context = self._application.app_context()
-        self._application_context.push()
-
-        storage = Mock()
-        data = {"METADATA": "test", "ANSWERS": [], "PROGRESS": []}
-        storage.get_user_data = Mock(
-            return_value=(json.dumps(data), QuestionnaireStore.LATEST_VERSION)
+    def test_head_request_on_optional_date(self):
+        self.launchSurvey("test_dates")
+        self.post(
+            {
+                "date-range-from-answer-day": "1",
+                "date-range-from-answer-month": "1",
+                "date-range-from-answer-year": "1900",
+                "date-range-to-answer-day": "1",
+                "date-range-to-answer-month": "1",
+                "date-range-to-answer-year": "1901",
+            }
         )
-
-        self.question_store = QuestionnaireStore(storage)
-        self.mock_context = {"block": {"question": {"title": "Testing title"}}}
-
-    def tearDown(self):
-        self._application_context.pop()
+        self.post(
+            {
+                "month-year-answer-month": "1",
+                "month-year-answer-year": "1900",
+            }
+        )
+        self.post(
+            {
+                "single-date-answer-day": "1",
+                "single-date-answer-month": "1",
+                "single-date-answer-year": "1900",
+            }
+        )
+        self.head("/questionnaire/date-non-mandatory-block/")
+        self.assertStatusCode(200)

--- a/tests/integration/routes/test_questionnaire.py
+++ b/tests/integration/routes/test_questionnaire.py
@@ -2,7 +2,22 @@ from tests.integration.integration_test_case import IntegrationTestCase
 
 
 class TestQuestionnaire(IntegrationTestCase):
-    def test_head_request_on_optional_date(self):
+    def test_head_request_on_root_url(self):
+        self.launchSurvey("test_hub_and_spoke")
+        self.head("/questionnaire/")
+        self.assertStatusOK()
+
+    def test_head_request_on_section_url(self):
+        self.launchSurvey("test_hub_and_spoke")
+        self.head("/questionnaire/sections/employment-section")
+        self.assertStatusCode(302)
+
+    def test_head_request_on_block_url(self):
+        self.launchSurvey("test_textfield")
+        self.head("/questionnaire/name-block")
+        self.assertStatusOK()
+
+    def test_head_request_on_block_with_optional_date_answer(self):
         self.launchSurvey("test_dates")
         self.post(
             {
@@ -28,4 +43,4 @@ class TestQuestionnaire(IntegrationTestCase):
             }
         )
         self.head("/questionnaire/date-non-mandatory-block/")
-        self.assertStatusCode(200)
+        self.assertStatusOK()

--- a/tests/integration/routes/test_session.py
+++ b/tests/integration/routes/test_session.py
@@ -20,3 +20,11 @@ class TestSession(IntegrationTestCase):
     def test_session_jti_token_expired(self):
         self.launchSurvey(exp=time.time() - float(60))
         self.assertStatusUnauthorised()
+
+    def test_head_request_on_session_expired(self):
+        self.head("/session-expired")
+        self.assertStatusOK()
+
+    def test_head_request_on_session_signed_out(self):
+        self.head("/signed-out")
+        self.assertStatusOK()

--- a/tests/integration/routes/test_thank_you.py
+++ b/tests/integration/routes/test_thank_you.py
@@ -55,3 +55,10 @@ class TestThankYou(IntegrationTestCase):
         # Ensure translation is now in Welsh
         self.assertInBody("English")
         self.assertNotInBody("Cymraeg")
+
+    def test_head_request_on_thank_you(self):
+        self.launchSurvey("test_confirmation_email")
+        self.post()
+        self.post()
+        self.head("/submitted/thank-you")
+        self.assertStatusOK()

--- a/tests/integration/session/test_login.py
+++ b/tests/integration/session/test_login.py
@@ -75,9 +75,7 @@ class TestLoginWithGetRequest(IntegrationTestCase):
         token = self.token_generator.create_token("test_checkbox")
 
         # When
-        self._client.head(
-            "/session?token=" + token, as_tuple=True, follow_redirects=True
-        )
+        self.head("/session?token=" + token)
         self.get(url=f"/session?token={token}")
 
         # Then
@@ -170,7 +168,7 @@ class TestLoginWithGetRequest(IntegrationTestCase):
         return response(404)
 
 
-class TestLoginWIthPostRequest(IntegrationTestCase):
+class TestLoginWithPostRequest(IntegrationTestCase):
     def test_login_with_no_token_should_be_unauthorized(self):
         # Given
         token = ""
@@ -226,9 +224,7 @@ class TestLoginWIthPostRequest(IntegrationTestCase):
         token = self.token_generator.create_token("test_checkbox")
 
         # When
-        self._client.head(
-            "/session?token=" + token, as_tuple=True, follow_redirects=True
-        )
+        self.head("/session?token=" + token)
         self.post(url=f"/session?token={token}")
 
         # Then

--- a/tests/integration/session/test_sign_out_and_exit.py
+++ b/tests/integration/session/test_sign_out_and_exit.py
@@ -36,6 +36,13 @@ class TestSaveAndSignOut(IntegrationTestCase):
                 self.get(SIGN_OUT_URL_PATH)
                 self.assertInUrl(ACCOUNT_SERVICE_LOG_OUT_URL_PATH)
 
+    def test_head_request_doesnt_sign_out(self):
+        self.launchSurvey("test_textfield")
+        self.head(SIGN_OUT_URL_PATH)
+        self.assertStatusCode(302)
+        self.get("/questionnaire/name-block")
+        self.assertStatusOK()
+
 
 class TestExitPostSubmissionTestCase(IntegrationTestCase):
     def _launch_and_submit_questionnaire(self, schema, **kwargs):


### PR DESCRIPTION
### What is the context of this PR?
Some errors were observed when HTTP HEAD requests were sent to questionnaire endpoints. It was identified that this was because a HEAD request was following the expected path of a POST request and calling form validation. In most instances this doesn't result in an error, but in the case of an optional `Date` type answer it does. 

This pull request changes the route logic so that HEAD requests follow the same path as a GET request.

### How to review 
- Check that the changes fix the issue
- Are there any other scenarios we should consider?

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
