### PR TITLE
Fix GTM auth duplication

### DIFF
--- a/app/helpers/template_helpers.py
+++ b/app/helpers/template_helpers.py
@@ -212,7 +212,7 @@ def render_template(template: str, **kwargs: Mapping) -> str:
 
 
 def get_google_tag_manager_context() -> Mapping:
-    if google_tag_manager_id := current_app.config["EQ_GOOGLE_TAG_MANAGER_ID"] and (
+    if (google_tag_manager_id := current_app.config["EQ_GOOGLE_TAG_MANAGER_ID"]) and (
         google_tag_manager_auth := current_app.config["EQ_GOOGLE_TAG_MANAGER_AUTH"]
     ):
         return {

--- a/tests/integration/test_application_variables.py
+++ b/tests/integration/test_application_variables.py
@@ -15,7 +15,7 @@ class TestApplicationVariables(IntegrationTestCase):
         settings.EQ_GOOGLE_TAG_MANAGER_ID = None
         settings.EQ_GOOGLE_TAG_MANAGER_AUTH = None
 
-    def test_google_analytics_code_is_present(self):
+    def test_google_analytics_code_and_credentials_are_present(self):
         self.launchSurvey("test_textfield")
         self._client.set_cookie(
             "localhost", key="ons_cookie_policy", value="'usage':true"
@@ -25,6 +25,8 @@ class TestApplicationVariables(IntegrationTestCase):
         self.assertInHead("gtm.start")
         self.assertInHead("dataLayer = []")
         self.assertInBody("https://www.googletagmanager.com")
+        self.assertInBody(settings.EQ_GOOGLE_TAG_MANAGER_AUTH)
+        self.assertInBody(settings.EQ_GOOGLE_TAG_MANAGER_ID)
 
     def test_google_analytics_data_layer_is_set_to_nisra_false(self):
         self.launchSurvey("test_thank_you_census_individual")

--- a/tests/integration/test_application_variables.py
+++ b/tests/integration/test_application_variables.py
@@ -25,8 +25,8 @@ class TestApplicationVariables(IntegrationTestCase):
         self.assertInHead("gtm.start")
         self.assertInHead("dataLayer = []")
         self.assertInBody("https://www.googletagmanager.com")
-        self.assertInBody(settings.EQ_GOOGLE_TAG_MANAGER_AUTH)
-        self.assertInBody(settings.EQ_GOOGLE_TAG_MANAGER_ID)
+        self.assertInHead(settings.EQ_GOOGLE_TAG_MANAGER_AUTH)
+        self.assertInHead(settings.EQ_GOOGLE_TAG_MANAGER_ID)
 
     def test_google_analytics_data_layer_is_set_to_nisra_false(self):
         self.launchSurvey("test_thank_you_census_individual")


### PR DESCRIPTION
### What is the context of this PR?
Due to a scoping issue, the value of GTM AUTH is currently used as the value of GTM ID in the page source for the GTM scripts.

### How to review 
- Set the values for `EQ_GOOGLE_TAG_MANAGER_ID` and `EQ_GOOGLE_TAG_MANAGER_AUTH` then ensure they are both present in the source as expected.
- Testing this on v3.77.0 should highlight that the value of `AUTH` is duplicated and `ID` is missing from the source.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
