### PR TITLE
Return None from get_session_store if no session data

### DIFF
--- a/app/authentication/authenticator.py
+++ b/app/authentication/authenticator.py
@@ -86,7 +86,7 @@ def load_user():
     """
     session_store = get_session_store()
 
-    if session_store and session_store.user_id and _is_session_valid(session_store):
+    if session_store and _is_session_valid(session_store):
         logger.debug("session exists")
 
         user_id = session_store.user_id

--- a/app/data_models/app_models.py
+++ b/app/data_models/app_models.py
@@ -14,7 +14,7 @@ class QuestionnaireState:
 
 
 class EQSession:
-    def __init__(self, eq_session_id, user_id, expires_at, session_data=None):
+    def __init__(self, eq_session_id, user_id, expires_at, session_data):
         self.eq_session_id = eq_session_id
         self.user_id = user_id
         self.session_data = session_data

--- a/app/globals.py
+++ b/app/globals.py
@@ -46,7 +46,7 @@ def get_session_store() -> Union[SessionStore, None]:
             cookie_session[USER_IK], pepper, cookie_session[EQ_SESSION_ID]
         )
 
-    return store
+    return store if store.session_data else None
 
 
 def get_session_timeout_in_seconds(schema: QuestionnaireSchema) -> int:

--- a/app/routes/session.py
+++ b/app/routes/session.py
@@ -141,9 +141,7 @@ def get_sign_out():
     ):
         session_store = get_session_store()
         language_code = (
-            session_store.session_data.language_code
-            if session_store and session_store.session_data
-            else None
+            session_store.session_data.language_code if session_store else None
         )
         log_out_url = get_census_base_url(theme, language_code)
 

--- a/app/setup.py
+++ b/app/setup.py
@@ -452,11 +452,7 @@ def setup_babel(application):
     @application.babel.localeselector
     def get_locale():  # pylint: disable=unused-variable
         session = get_session_store()
-
-        if session and session.session_data:
-            return session.session_data.language_code
-
-        return None
+        return session.session_data.language_code if session else None
 
     @application.babel.timezoneselector
     def get_timezone():  # pylint: disable=unused-variable


### PR DESCRIPTION
### What is the context of this PR?
Changes the `get_session_store` method to only return a `SessionStore` object if a session exists. Prior to this, when a session didn't exist an 'empty' `SessionStore` object was returned with no `session_data`.

### How to review 
- Are the changes appropriate?
- Are there nay gaps?

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
