### PR TITLE
Use v3-census branch and tags

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -3,7 +3,7 @@ name: PR
 on:
   pull_request:
     branches:
-      - "master"
+      - "v3-census"
       - "branch-v*"
 
 jobs:

--- a/.github/workflows/v3_census.yml
+++ b/.github/workflows/v3_census.yml
@@ -14,9 +14,9 @@ jobs:
           run: printf "$GITHUB_SHA" > .application-version
         - name: Build
           run: >
-            docker build -t onsdigital/eq-questionnaire-runner:v3-census .
+            docker build -t onsdigital/eq-questionnaire-runner:v3-census-latest .
         - name: Push to Docker Hub
           run: |
             echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
             echo "Pushing with tag [v3-census]"
-            docker push onsdigital/eq-questionnaire-runner:v3-census
+            docker push onsdigital/eq-questionnaire-runner:v3-census-latest

--- a/.github/workflows/v3_census.yml
+++ b/.github/workflows/v3_census.yml
@@ -18,5 +18,5 @@ jobs:
         - name: Push to Docker Hub
           run: |
             echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
-            echo "Pushing with tag [v3-census]"
+            echo "Pushing with tag [v3-census-latest]"
             docker push onsdigital/eq-questionnaire-runner:v3-census-latest

--- a/.github/workflows/v3_census.yml
+++ b/.github/workflows/v3_census.yml
@@ -3,7 +3,7 @@ name: Master
 on:
   push:
     branches:
-      - master
+      - "v3-census"
 
 jobs:
   docker-push:
@@ -14,9 +14,9 @@ jobs:
           run: printf "$GITHUB_SHA" > .application-version
         - name: Build
           run: >
-            docker build -t onsdigital/eq-questionnaire-runner:latest .
+            docker build -t onsdigital/eq-questionnaire-runner:v3-census .
         - name: Push to Docker Hub
           run: |
             echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
-            echo "Pushing with tag [latest]"
-            docker push onsdigital/eq-questionnaire-runner:latest
+            echo "Pushing with tag [v3-census]"
+            docker push onsdigital/eq-questionnaire-runner:v3-census

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - eq-env
 
   eq-questionnaire-runner:
-    image: onsdigital/eq-questionnaire-runner:latest
+    image: onsdigital/eq-questionnaire-runner:v3-census
     build: ./
     env_file:
       - .development.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - eq-env
 
   eq-questionnaire-runner:
-    image: onsdigital/eq-questionnaire-runner:v3-census
+    image: onsdigital/eq-questionnaire-runner:v3-census-latest
     build: ./
     env_file:
       - .development.env


### PR DESCRIPTION
### What is the context of this PR?
Updates runner to use v3-census as the base branch and Docker tags.

### How to review 
Ensure:
- the `v3-branch` matches the latest release
- no references were missed.
- branch protection has been set up
- The docket tag is `v3-census-latest` for clarity

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
