### PR TITLE
Update chromedriver to 89

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "babel-preset-env": "^1.7.0",
     "babel-register": "^6.26.0",
     "chai": "^4.2.0",
-    "chromedriver": "^88.0.0",
+    "chromedriver": "^89.0.0",
     "eslint": "^6.8.0",
     "eslint-cli": "^1.1.1",
     "eslint-config-standard": "^14.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1362,10 +1362,10 @@ chrome-launcher@^0.13.1:
     mkdirp "^0.5.3"
     rimraf "^3.0.2"
 
-chromedriver@^88.0.0:
-  version "88.0.0"
-  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-88.0.0.tgz#6833fffd516db23c811eeafa1ee1069b5a12fd2f"
-  integrity sha512-EE8rXh7mikxk3VWKjUsz0KCUX8d3HkQ4HgMNJhWrWjzju12dKPPVHO9MY+YaAI5ryXrXGNf0Y4HcNKgW36P/CA==
+chromedriver@^89.0.0:
+  version "89.0.0"
+  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-89.0.0.tgz#a6f27aa306400651a20dc04976fe5b2c4e65d61a"
+  integrity sha512-+DVYp3+m6tZUYTMl9fEgCZIDk9YBTcHws82nIV1JYwusu51zRITA0oeNzuPyFhuK7ageFnnKCDviH2BL5I4M0w==
   dependencies:
     "@testim/chrome-version" "^1.0.7"
     axios "^0.21.1"


### PR DESCRIPTION
### What is the context of this PR?
Updates chromedriver to 89 so it will match the future version of Chrome installed in the github actions. It'll prevent pull requests  from failing when the chromedriver version and the installed version of Chrome are different in future.

### How to review 
- Run functional tests locally
- Check that the functional tests run successfully in this pull request


