### PR TITLE
Use released validator version v1.0.0 (v3-census)

### DIFF
--- a/scripts/run_validator.sh
+++ b/scripts/run_validator.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-tag=latest
+tag=v1.0.0
 docker pull onsdigital/eq-questionnaire-validator:$tag
 docker run -d -p 5001:5000 "onsdigital/eq-questionnaire-validator:$tag"


### PR DESCRIPTION
### What is the context of this PR?
Use released validator version v1.0.0 so that future changes to validator don't break the build on the `v3-census` branch.

### How to review 
Check the build passes.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
