### PR TITLE
Move remaining imports to top-level

### DIFF
--- a/app/setup.py
+++ b/app/setup.py
@@ -26,8 +26,16 @@ from app.authentication.user_id_generator import UserIDGenerator
 from app.cloud_tasks import CloudTaskPublisher, LogCloudTaskPublisher
 from app.globals import get_session_store
 from app.helpers import get_span_and_trace
+from app.jinja_filters import blueprint as filter_blueprint
 from app.keys import KEY_PURPOSE_SUBMISSION
 from app.publisher import LogPublisher, PubSubPublisher
+from app.routes.dump import dump_blueprint
+from app.routes.errors import errors_blueprint
+from app.routes.flush import flush_blueprint
+from app.routes.individual_response import individual_response_blueprint
+from app.routes.questionnaire import post_submission_blueprint, questionnaire_blueprint
+from app.routes.schema import schema_blueprint
+from app.routes.session import session_blueprint
 from app.secrets import SecretStore, validate_required_secrets
 from app.storage import Datastore, Dynamodb, Redis
 from app.submitter import (
@@ -386,56 +394,36 @@ def setup_feedback(application):
         raise Exception("Unknown EQ_FEEDBACK_BACKEND")
 
 
-# pylint: disable=import-outside-toplevel
 def add_blueprints(application):
     csrf = CSRFProtect(application)
-
-    # import and register the main application blueprint
-    from app.routes.questionnaire import questionnaire_blueprint
 
     application.register_blueprint(questionnaire_blueprint)
     questionnaire_blueprint.config = application.config.copy()
 
-    from app.routes.questionnaire import post_submission_blueprint
-
     application.register_blueprint(post_submission_blueprint)
     post_submission_blueprint.config = application.config.copy()
-
-    from app.routes.session import session_blueprint
 
     csrf.exempt(session_blueprint)
     application.register_blueprint(session_blueprint)
     session_blueprint.config = application.config.copy()
 
-    from app.routes.flush import flush_blueprint
-
     csrf.exempt(flush_blueprint)
     application.register_blueprint(flush_blueprint)
     flush_blueprint.config = application.config.copy()
 
-    from app.routes.dump import dump_blueprint
-
     application.register_blueprint(dump_blueprint)
     dump_blueprint.config = application.config.copy()
-
-    from app.routes.errors import errors_blueprint
 
     application.register_blueprint(errors_blueprint)
     errors_blueprint.config = application.config.copy()
 
-    from app.jinja_filters import blueprint as filter_blueprint
-
     application.register_blueprint(filter_blueprint)
-
-    from app.routes.schema import schema_blueprint
 
     application.register_blueprint(schema_blueprint)
     schema_blueprint.config = application.config.copy()
 
-    from app.routes.individual_response import individual_response_blueprint
-
     application.register_blueprint(individual_response_blueprint)
-    individual_response_blueprint = application.config.copy()
+    individual_response_blueprint.config = application.config.copy()
 
 
 def setup_secure_cookies(application):

--- a/tests/integration/integration_test_case.py
+++ b/tests/integration/integration_test_case.py
@@ -56,8 +56,6 @@ class IntegrationTestCase(unittest.TestCase):  # pylint: disable=too-many-public
         self._redis = patch("app.setup.redis.Redis", fakeredis.FakeStrictRedis)
         self._redis.start()
 
-
-
         configure_logging()
 
         setting_overrides = {

--- a/tests/integration/integration_test_case.py
+++ b/tests/integration/integration_test_case.py
@@ -13,6 +13,7 @@ from sdc.crypto.key_store import KeyStore
 
 from app.keys import KEY_PURPOSE_AUTHENTICATION, KEY_PURPOSE_SUBMISSION
 from app.setup import create_app
+from application import configure_logging
 from tests.app.app_context_test_case import MockDatastore
 from tests.integration.create_token import TokenGenerator
 
@@ -55,9 +56,7 @@ class IntegrationTestCase(unittest.TestCase):  # pylint: disable=too-many-public
         self._redis = patch("app.setup.redis.Redis", fakeredis.FakeStrictRedis)
         self._redis.start()
 
-        from application import (  # pylint: disable=import-outside-toplevel
-            configure_logging,
-        )
+
 
         configure_logging()
 


### PR DESCRIPTION
### What is the context of this PR?
This moves imports to top-level in `setup.py` and `test_integration_case.py` as requested on this [Trello](https://trello.com/c/ILGQUcJW). It also fixes error `individual_response_blueprint` config setup which got highlighted after completing move imports task. `test_roles.py` is the only file were we still ignore top-level imports rule.

### How to review 
To find places where `pylint` top level imports check is ignored search for `pylint: disable=import-outside-toplevel`.
