### PR TITLE
Make case_id mandatory

### DIFF
--- a/app/authentication/authenticator.py
+++ b/app/authentication/authenticator.py
@@ -121,7 +121,7 @@ def _create_session_data_from_metadata(metadata):
         ru_name=metadata.get("ru_name"),
         ru_ref=metadata.get("ru_ref"),
         response_id=metadata.get("response_id"),
-        case_id=metadata.get("case_id"),
+        case_id=metadata["case_id"],
         case_ref=metadata.get("case_ref"),
         trad_as=metadata.get("trad_as"),
         account_service_url=metadata.get("account_service_url"),

--- a/app/data_models/session_data.py
+++ b/app/data_models/session_data.py
@@ -10,7 +10,7 @@ class SessionData:
         ru_name,
         ru_ref,
         response_id,
-        case_id=None,
+        case_id,
         case_ref=None,
         account_service_url=None,
         account_service_log_out_url=None,

--- a/app/routes/flush.py
+++ b/app/routes/flush.py
@@ -75,7 +75,7 @@ def _submit_data(user):
         sent = current_app.eq["submitter"].send_message(
             encrypted_message,
             tx_id=metadata.get("tx_id"),
-            case_id=metadata.get("case_id"),
+            case_id=metadata["case_id"],
         )
 
         if not sent:

--- a/app/routes/session.py
+++ b/app/routes/session.py
@@ -75,11 +75,13 @@ def login():
     schema_name = claims["schema_name"]
     tx_id = claims["tx_id"]
     ru_ref = claims["ru_ref"]
+    case_id = claims["case_id"]
 
     logger.bind(
         schema_name=schema_name,
         tx_id=tx_id,
         ru_ref=ru_ref,
+        case_id=case_id,
     )
     logger.info("decrypted token and parsed metadata")
 

--- a/app/storage/metadata_parser.py
+++ b/app/storage/metadata_parser.py
@@ -77,7 +77,7 @@ class RunnerMetadataSchema(Schema, StripWhitespaceMixin):
     response_id = VALIDATORS["string"](validate=validate.Length(min=1))  # type:ignore
 
     account_service_url = VALIDATORS["url"](required=False)  # type:ignore
-    case_id = VALIDATORS["uuid"](required=False)  # type:ignore
+    case_id = VALIDATORS["uuid"]()  # type:ignore
     account_service_log_out_url = VALIDATORS["url"](required=False)  # type:ignore
     roles = fields.List(fields.String(), required=False)
     survey_url = VALIDATORS["url"](required=False)  # type:ignore

--- a/app/submitter/converter.py
+++ b/app/submitter/converter.py
@@ -65,6 +65,7 @@ def convert_answers(schema, questionnaire_store, routing_path, flushed=False):
     submitted_at = datetime.utcnow()
 
     payload = {
+        "case_id": metadata["case_id"],
         "tx_id": metadata["tx_id"],
         "type": "uk.gov.ons.edc.eq:surveyresponse",
         "version": schema.json["data_version"],
@@ -87,8 +88,6 @@ def convert_answers(schema, questionnaire_store, routing_path, flushed=False):
         payload["region_code"] = metadata["region_code"]
     if response_metadata.get("started_at"):
         payload["started_at"] = response_metadata["started_at"]
-    if metadata.get("case_id"):
-        payload["case_id"] = metadata["case_id"]
     if metadata.get("case_ref"):
         payload["case_ref"] = metadata["case_ref"]
 

--- a/app/views/handlers/submission.py
+++ b/app/views/handlers/submission.py
@@ -29,7 +29,7 @@ class SubmissionHandler:
         )
         submitted = current_app.eq["submitter"].send_message(
             encrypted_message,
-            case_id=self._metadata.get("case_id"),
+            case_id=self._metadata["case_id"],
             tx_id=self._metadata.get("tx_id"),
         )
 

--- a/tests/app/parser/conftest.py
+++ b/tests/app/parser/conftest.py
@@ -15,6 +15,7 @@ def fake_metadata_runner():
         "collection_exercise_sid": "test-sid",
         "response_id": str(uuid.uuid4()),
         "account_service_url": "https://ras.ons.gov.uk",
+        "case_id": str(uuid.uuid4()),
     }
 
 

--- a/tests/app/submitter/test_submitter.py
+++ b/tests/app/submitter/test_submitter.py
@@ -182,23 +182,6 @@ class TestRabbitMQSubmitter(TestCase):
             self.assertEqual(headers["tx_id"], "12345")
             self.assertEqual(headers["case_id"], "98765")
 
-    def test_when_message_sent_then_case_id_not_in_header_if_missing(self):
-        # Given
-        channel = Mock()
-        connection = Mock()
-        connection.channel.side_effect = Mock(return_value=channel)
-        with patch(
-            "app.submitter.submitter.BlockingConnection", return_value=connection
-        ):
-            # When
-            self.submitter.send_message(message={}, tx_id="12345")
-
-            # Then
-            call_args = channel.basic_publish.call_args
-            properties = call_args[1]["properties"]
-            headers = properties.headers
-            self.assertEqual(headers["tx_id"], "12345")
-
 
 class TestGCSSubmitter(TestCase):
     @staticmethod

--- a/tests/app/views/handlers/test_submission_handler.py
+++ b/tests/app/views/handlers/test_submission_handler.py
@@ -25,6 +25,7 @@ class TestSubmissionPayload(AppContextTestCase):
             survey_url=None,
             ru_name="ru_name",
             ru_ref="ru_ref",
+            case_id="0123456789000000",
         )
         self.session_store = SessionStore("user_ik", "pepper", "eq_session_id")
         self.expires_at = datetime.now(tzutc()) + timedelta(seconds=5)

--- a/tests/integration/session/test_login.py
+++ b/tests/integration/session/test_login.py
@@ -136,14 +136,6 @@ class TestLoginWithGetRequest(IntegrationTestCase):
         # Then
         self.assertStatusNotFound()
 
-    def test_login_without_case_id_in_token_is_authorised(self):
-        # Given
-        token = self.token_generator.create_token_without_case_id("test_textfield")
-        self.get(url=f"/session?token={token}")
-
-        # Then
-        self.assertStatusOK()
-
     @staticmethod
     @urlmatch(netloc=r"eq-survey-register", path=r"\/my-test-schema")
     def survey_url_mock(_url, _request):
@@ -275,13 +267,13 @@ class TestLoginWithPostRequest(IntegrationTestCase):
         # Then
         self.assertStatusNotFound()
 
-    def test_login_without_case_id_in_token_is_authorised(self):
+    def test_login_without_case_id_in_token_is_unauthorised(self):
         # Given
         token = self.token_generator.create_token_without_case_id("test_textfield")
         self.post(url=f"/session?token={token}")
 
         # Then
-        self.assertStatusOK()
+        self.assertStatusForbidden()
 
     @staticmethod
     @urlmatch(netloc=r"eq-survey-register", path=r"\/my-test-schema")


### PR DESCRIPTION
### What is the context of this PR?
For census case_id was made optional, this PR reverts it back to mandatory for business surveys

### How to review 
Make sure everything still works, that case_id is now mandatory and tests have been changed. Also check that condition statements and defaults involving case_id have all been updated and nothing has been missed

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
