### PR TITLE
Set submission_language_code to -9 on flush

### DIFF
--- a/app/routes/flush.py
+++ b/app/routes/flush.py
@@ -62,12 +62,12 @@ def _submit_data(user):
         router = Router(schema, answer_store, list_store, progress_store, metadata)
         full_routing_path = router.full_routing_path()
 
-        message = json.dumps(
-            convert_answers(
-                schema, questionnaire_store, full_routing_path, flushed=True
-            ),
-            for_json=True,
+        payload = convert_answers(
+            schema, questionnaire_store, full_routing_path, flushed=True
         )
+        payload["submission_language_code"] = "-9"
+
+        message = json.dumps(payload, for_json=True)
 
         encrypted_message = encrypt(
             message, current_app.eq["key_store"], KEY_PURPOSE_SUBMISSION

--- a/tests/integration/test_flush_data.py
+++ b/tests/integration/test_flush_data.py
@@ -105,6 +105,16 @@ class TestFlushData(IntegrationTestCase):
 
         self.assertTrue('"flushed": true' in args[0])
 
+    def test_flush_sets_submission_language_code(self):
+
+        self.post(
+            url="/flush?token="
+            + self.token_generator.generate_token(self.get_payload())
+        )
+        args = self.encrypt_instance.call_args[0]  # pylint: disable=no-member
+
+        self.assertTrue('"submission_language_code": "-9"' in args[0])
+
     @staticmethod
     def get_payload():
         return {


### PR DESCRIPTION
### What is the context of this PR?
On flushing the submission_language_code should be set to -9

### How to review 
Check that the submission_language_code is -9 when flushing

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
