### PR TITLE
Use answer labels for date field labels if provided

### DIFF
--- a/templates/partials/answers/date.html
+++ b/templates/partials/answers/date.html
@@ -4,11 +4,18 @@
 {%- set month_field = form.fields[answer['id']]['month'] -%}
 {%- set year_field = form.fields[answer['id']]['year'] -%}
 
+{% if answer.label %}
+  {% set legend = answer.label %}
+{% else %}
+  {% set legend = question_title %}
+  {% set legendClasses = "u-vh" %}
+{% endif %}
+
 {%- set config = {
   "id": answer.id,
   "description": answer.description,
-  "legend": question_title,
-  "legendClasses": "u-vh",
+  "legend": legend,
+  "legendClasses": legendClasses,
   "attributes": {
     "data-qa": "widget-date"
   },

--- a/test_schemas/en/test_dates.json
+++ b/test_schemas/en/test_dates.json
@@ -69,7 +69,6 @@
                                 "answers": [
                                     {
                                         "id": "month-year-answer",
-                                        "label": "Date",
                                         "mandatory": true,
                                         "q_code": "11",
                                         "type": "MonthYearDate"

--- a/tests/functional/base_pages/question.page.js
+++ b/tests/functional/base_pages/question.page.js
@@ -22,6 +22,10 @@ class QuestionPage extends BasePage {
     return ".js-inpagelink";
   }
 
+  legend() {
+    return "legend";
+  }
+
   errorHeader() {
     return '[data-qa="error-header"]';
   }

--- a/tests/functional/spec/dates.spec.js
+++ b/tests/functional/spec/dates.spec.js
@@ -10,6 +10,25 @@ describe("Date checks", () => {
     browser.openQuestionnaire("test_dates.json");
   });
 
+  it("Given an answer label is provided for a date question when the question page is loaded then the label should be displayed ", () => {
+    expect($(DateRangePage.legend()).getText()).to.contain("Period from");
+  });
+
+  it("Given an answer label is not provided for a date question when the question page is loaded then the question title should be used as a label but not displayed ", () => {
+    $(DateRangePage.dateRangeFromday()).setValue(1);
+    $(DateRangePage.dateRangeFrommonth()).setValue(1);
+    $(DateRangePage.dateRangeFromyear()).setValue(1901);
+
+    $(DateRangePage.dateRangeToday()).setValue(3);
+    $(DateRangePage.dateRangeTomonth()).setValue(5);
+    $(DateRangePage.dateRangeToyear()).setValue(2017);
+
+    $(DateRangePage.submit()).click();
+
+    expect($(DateMonthYearPage.legend()).getText()).to.contain("Date with month and year");
+    expect($(DateMonthYearPage.legend()).isDisplayed()).to.be.true;
+  });
+
   it("Given the test_dates survey is selected when dates are entered then the summary screen shows the dates entered formatted", () => {
     // When dates are entered
     $(DateRangePage.dateRangeFromday()).setValue(1);

--- a/tests/functional/spec/dates.spec.js
+++ b/tests/functional/spec/dates.spec.js
@@ -26,7 +26,6 @@ describe("Date checks", () => {
     $(DateRangePage.submit()).click();
 
     expect($(DateMonthYearPage.legend()).getText()).to.contain("Date with month and year");
-    expect($(DateMonthYearPage.legend()).isDisplayed()).to.be.true;
   });
 
   it("Given the test_dates survey is selected when dates are entered then the summary screen shows the dates entered formatted", () => {

--- a/tests/functional/spec/dates.spec.js
+++ b/tests/functional/spec/dates.spec.js
@@ -12,7 +12,7 @@ describe("Date checks", () => {
 
   it("Given an answer label is provided for a date question when the question page is loaded then the label should be displayed ", () => {
     expect($(DateRangePage.legend()).getText()).to.contain("Period from");
-    expect($(DateMonthYearPage.legend()).getAttribute('class')).not.to.contain("u-vh");
+    expect($(DateMonthYearPage.legend()).getAttribute("class")).not.to.contain("u-vh");
   });
 
   it("Given an answer label is not provided for a date question when the question page is loaded then the question title should be used as a label but not displayed ", () => {
@@ -27,7 +27,7 @@ describe("Date checks", () => {
     $(DateRangePage.submit()).click();
 
     expect($(DateMonthYearPage.legend()).getText()).to.contain("Date with month and year");
-    expect($(DateMonthYearPage.legend()).getAttribute('class')).to.contain("u-vh");
+    expect($(DateMonthYearPage.legend()).getAttribute("class")).to.contain("u-vh");
   });
 
   it("Given the test_dates survey is selected when dates are entered then the summary screen shows the dates entered formatted", () => {

--- a/tests/functional/spec/dates.spec.js
+++ b/tests/functional/spec/dates.spec.js
@@ -12,6 +12,7 @@ describe("Date checks", () => {
 
   it("Given an answer label is provided for a date question when the question page is loaded then the label should be displayed ", () => {
     expect($(DateRangePage.legend()).getText()).to.contain("Period from");
+    expect($(DateMonthYearPage.legend()).getAttribute('class')).not.to.contain("u-vh");
   });
 
   it("Given an answer label is not provided for a date question when the question page is loaded then the question title should be used as a label but not displayed ", () => {
@@ -26,6 +27,7 @@ describe("Date checks", () => {
     $(DateRangePage.submit()).click();
 
     expect($(DateMonthYearPage.legend()).getText()).to.contain("Date with month and year");
+    expect($(DateMonthYearPage.legend()).getAttribute('class')).to.contain("u-vh");
   });
 
   it("Given the test_dates survey is selected when dates are entered then the summary screen shows the dates entered formatted", () => {


### PR DESCRIPTION
### What is the context of this PR?

For date questions, if an answer label is provided then it should be used for the Design System component legend for date field labels. Otherwise, the question title should be used, and the field should be visually hidden.

### How to review 

Use `test-dates` to check that the answer label is displayed in the date field label if provided. Check that no field is displayed if no answer label is present.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
