### PR TITLE
Remove empty routing rules lists

### DIFF
--- a/scripts/run_validator.sh
+++ b/scripts/run_validator.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-tag=v2.0.0
+tag=latest
 docker pull onsdigital/eq-questionnaire-validator:$tag
 docker run -d -p 5001:5000 "onsdigital/eq-questionnaire-validator:$tag"

--- a/test_schemas/en/test_big_list_naughty_strings.json
+++ b/test_schemas/en/test_big_list_naughty_strings.json
@@ -30,7 +30,6 @@
                     "blocks": [
                         {
                             "type": "Question",
-                            "routing_rules": [],
                             "question": {
                                 "answers": [
                                     {

--- a/test_schemas/en/test_checkbox_detail_answer_multiple.json
+++ b/test_schemas/en/test_checkbox_detail_answer_multiple.json
@@ -112,8 +112,7 @@
                                 "id": "mandatory-checkbox-question",
                                 "title": "Which pizza toppings would you like?",
                                 "type": "General"
-                            },
-                            "routing_rules": []
+                            }
                         }
                     ],
                     "id": "checkboxes"

--- a/test_schemas/en/test_checkbox_detail_answer_numeric.json
+++ b/test_schemas/en/test_checkbox_detail_answer_numeric.json
@@ -88,8 +88,7 @@
                                 "id": "checkbox-question-numeric-detail",
                                 "title": "How many pizza toppings would you like?",
                                 "type": "General"
-                            },
-                            "routing_rules": []
+                            }
                         }
                     ],
                     "id": "checkboxes"

--- a/test_schemas/en/test_currency.json
+++ b/test_schemas/en/test_currency.json
@@ -102,8 +102,7 @@
                                 "id": "question",
                                 "title": "Currency Input Test",
                                 "type": "General"
-                            },
-                            "routing_rules": []
+                            }
                         }
                     ],
                     "id": "group"

--- a/test_schemas/en/test_instructions.json
+++ b/test_schemas/en/test_instructions.json
@@ -70,8 +70,7 @@
                                 "id": "favourite-lunch-question",
                                 "title": "Title",
                                 "type": "General"
-                            },
-                            "routing_rules": []
+                            }
                         }
                     ],
                     "id": "favourite-foods",

--- a/test_schemas/en/test_interstitial_page.json
+++ b/test_schemas/en/test_interstitial_page.json
@@ -56,8 +56,7 @@
                                 "id": "favourite-breakfast-question",
                                 "title": "What is your favourite breakfast food",
                                 "type": "General"
-                            },
-                            "routing_rules": []
+                            }
                         },
                         {
                             "id": "breakfast-interstitial",
@@ -87,8 +86,7 @@
                                 "id": "favourite-lunch-question",
                                 "title": "Title",
                                 "type": "General"
-                            },
-                            "routing_rules": []
+                            }
                         }
                     ],
                     "id": "favourite-foods",

--- a/test_schemas/en/test_interviewer_note.json
+++ b/test_schemas/en/test_interviewer_note.json
@@ -61,8 +61,7 @@
                                 "id": "favourite-team-question",
                                 "title": "Who is your favourite team?",
                                 "type": "General"
-                            },
-                            "routing_rules": []
+                            }
                         },
                         {
                             "type": "Question",
@@ -93,8 +92,7 @@
                                     ]
                                 },
                                 "type": "General"
-                            },
-                            "routing_rules": []
+                            }
                         },
                         {
                             "id": "final-interstitial-block",

--- a/test_schemas/en/test_percentage.json
+++ b/test_schemas/en/test_percentage.json
@@ -59,8 +59,7 @@
                                 "id": "question",
                                 "title": "Title",
                                 "type": "General"
-                            },
-                            "routing_rules": []
+                            }
                         }
                     ],
                     "id": "group"

--- a/test_schemas/en/test_placeholder_metadata.json
+++ b/test_schemas/en/test_placeholder_metadata.json
@@ -55,8 +55,7 @@
                                 "id": "question",
                                 "title": "Title",
                                 "type": "General"
-                            },
-                            "routing_rules": []
+                            }
                         }
                     ],
                     "id": "group"

--- a/test_schemas/en/test_placeholder_playback_list.json
+++ b/test_schemas/en/test_placeholder_playback_list.json
@@ -96,8 +96,7 @@
                                 "id": "mandatory-checkbox-question",
                                 "title": "Which pizza toppings would you like?",
                                 "type": "General"
-                            },
-                            "routing_rules": []
+                            }
                         },
                         {
                             "type": "ConfirmationQuestion",

--- a/test_schemas/en/test_question_description.json
+++ b/test_schemas/en/test_question_description.json
@@ -58,8 +58,7 @@
                                 "id": "name-question",
                                 "title": "Title",
                                 "type": "General"
-                            },
-                            "routing_rules": []
+                            }
                         }
                     ],
                     "id": "checkboxes",

--- a/test_schemas/en/test_question_title_in_error.json
+++ b/test_schemas/en/test_question_title_in_error.json
@@ -84,8 +84,7 @@
                                 "id": "mandatory-checkbox-question",
                                 "title": "Which pizza toppings would you like?",
                                 "type": "General"
-                            },
-                            "routing_rules": []
+                            }
                         },
                         {
                             "type": "Question",

--- a/test_schemas/en/test_routing_checkbox_set_not_set.json
+++ b/test_schemas/en/test_routing_checkbox_set_not_set.json
@@ -89,8 +89,7 @@
                                 "id": "topping-checkbox-question",
                                 "title": "What extra toppings would you like?",
                                 "type": "General"
-                            },
-                            "routing_rules": []
+                            }
                         },
                         {
                             "id": "topping-interstitial-set",

--- a/test_schemas/en/test_routing_group.json
+++ b/test_schemas/en/test_routing_group.json
@@ -94,7 +94,6 @@
                         {
                             "type": "Question",
                             "id": "group1-block",
-                            "routing_rules": [],
                             "question": {
                                 "id": "group1-question",
                                 "title": "Did you want Group 1?",
@@ -118,7 +117,6 @@
                         {
                             "type": "Question",
                             "id": "group2-block",
-                            "routing_rules": [],
                             "question": {
                                 "id": "group2-question",
                                 "title": "Did you want Group 2?",

--- a/test_schemas/en/test_skip_condition.json
+++ b/test_schemas/en/test_skip_condition.json
@@ -62,8 +62,7 @@
                                 "id": "food-question",
                                 "title": "Title",
                                 "type": "General"
-                            },
-                            "routing_rules": []
+                            }
                         },
                         {
                             "type": "Question",

--- a/test_schemas/en/test_skip_condition_block.json
+++ b/test_schemas/en/test_skip_condition_block.json
@@ -39,7 +39,6 @@
                         {
                             "type": "Question",
                             "id": "do-you-want-to-skip",
-                            "routing_rules": [],
                             "question": {
                                 "id": "do-you-want-to-skip-question",
                                 "title": "Do you want to skip?",
@@ -70,7 +69,6 @@
                         {
                             "type": "Question",
                             "id": "should-skip",
-                            "routing_rules": [],
                             "question": {
                                 "id": "should-skip-question",
                                 "title": "Do you want to skip?",

--- a/test_schemas/en/test_skip_condition_group.json
+++ b/test_schemas/en/test_skip_condition_group.json
@@ -39,7 +39,6 @@
                         {
                             "type": "Question",
                             "id": "do-you-want-to-skip",
-                            "routing_rules": [],
                             "question": {
                                 "id": "do-you-want-to-skip-question",
                                 "title": "Do you want to skip?",
@@ -87,7 +86,6 @@
                         {
                             "type": "Question",
                             "id": "should-skip",
-                            "routing_rules": [],
                             "question": {
                                 "id": "should-skip-question",
                                 "title": "Do you want to skip?",

--- a/test_schemas/en/test_skip_condition_not_set.json
+++ b/test_schemas/en/test_skip_condition_not_set.json
@@ -62,8 +62,7 @@
                                 "id": "food-question",
                                 "title": "Title",
                                 "type": "General"
-                            },
-                            "routing_rules": []
+                            }
                         },
                         {
                             "type": "Question",

--- a/test_schemas/en/test_skip_condition_set.json
+++ b/test_schemas/en/test_skip_condition_set.json
@@ -62,8 +62,7 @@
                                 "id": "food-question",
                                 "title": "Title",
                                 "type": "General"
-                            },
-                            "routing_rules": []
+                            }
                         },
                         {
                             "type": "Question",

--- a/test_schemas/en/test_submit_with_custom_submission_text.json
+++ b/test_schemas/en/test_submit_with_custom_submission_text.json
@@ -61,8 +61,7 @@
                                 "id": "breakfast-question",
                                 "title": "What is your favourite breakfast food",
                                 "type": "General"
-                            },
-                            "routing_rules": []
+                            }
                         }
                     ],
                     "id": "final-confirmation",

--- a/test_schemas/en/test_textfield.json
+++ b/test_schemas/en/test_textfield.json
@@ -57,8 +57,7 @@
                                 "id": "name-question",
                                 "title": "Title",
                                 "type": "General"
-                            },
-                            "routing_rules": []
+                            }
                         }
                     ],
                     "id": "group"


### PR DESCRIPTION
### What is the context of this PR?
Empty routing rule lists will currently break validator. This removes them

### How to review 
Make sure it works with the latest version of validator

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
