### PR TITLE
Fix survey title in header and page title

### DIFF
--- a/app/helpers/template_helpers.py
+++ b/app/helpers/template_helpers.py
@@ -66,10 +66,13 @@ class ContextHelper:
         self._language = language
         self._is_post_submission = is_post_submission
         self._include_csrf_token = include_csrf_token
-        self.survey_config = survey_config
+        self._survey_config = survey_config
+        self._survey_title = cookie_session.get(
+            "survey_title", self._survey_config.survey_title
+        )
         self._sign_out_url = url_for("session.get_sign_out")
         self._account_service_url = cookie_session.get(
-            "account_service_url", self.survey_config.account_service_url
+            "account_service_url", self._survey_config.account_service_url
         )
         self._account_service_log_out_url = cookie_session.get(
             "account_service_log_out_url"
@@ -91,18 +94,18 @@ class ContextHelper:
             "account_service_log_out_url": self._account_service_log_out_url,
             "contact_us_url": Link(
                 lazy_gettext("Contact us"),
-                f"{self.survey_config.base_url}/contact-us/",
+                f"{self._survey_config.base_url}/contact-us/",
             ).__dict__,
             "cookie_settings_url": self._cookie_settings_url,
             "page_header": self.page_header_context,
             "footer": self.footer_context,
             "languages": get_languages_context(self._language),
-            "theme": self.survey_config.design_system_theme,
+            "theme": self._survey_config.design_system_theme,
             "language_code": self._language,
-            "survey_title": self.survey_config.survey_title,
+            "survey_title": self._survey_title,
             "cdn_url": self._cdn_url,
             "address_lookup_api_url": self._address_lookup_api,
-            "data_layer": self.survey_config.data_layer,
+            "data_layer": self._survey_config.data_layer,
             "include_csrf_token": self._include_csrf_token,
             "google_tag_manager_id": self._google_tag_manager_id,
             "google_tag_manager_auth": self._google_tag_manager_auth,
@@ -111,18 +114,20 @@ class ContextHelper:
     @property
     def page_header_context(self) -> dict[str, str]:
         context = {
-            "logo": f"{self.survey_config.page_header_logo}",
-            "logoAlt": f"{self.survey_config.page_header_logo_alt}",
+            "logo": f"{self._survey_config.page_header_logo}",
+            "logoAlt": f"{self._survey_config.page_header_logo_alt}",
         }
 
-        if self.survey_config.title_logo:
-            context["titleLogo"] = f"{self.survey_config.title_logo}"
-        if self.survey_config.title_logo_alt:
-            context["titleLogoAlt"] = f"{self.survey_config.title_logo_alt}"
-        if self.survey_config.header_logo:
-            context["customHeaderLogo"] = self.survey_config.header_logo
-        if self.survey_config.mobile_logo:
-            context["mobileLogo"] = self.survey_config.mobile_logo
+        if self._survey_title:
+            context["title"] = self._survey_title
+        if self._survey_config.title_logo:
+            context["titleLogo"] = f"{self._survey_config.title_logo}"
+        if self._survey_config.title_logo_alt:
+            context["titleLogoAlt"] = f"{self._survey_config.title_logo_alt}"
+        if self._survey_config.header_logo:
+            context["customHeaderLogo"] = self._survey_config.header_logo
+        if self._survey_config.mobile_logo:
+            context["mobileLogo"] = self._survey_config.mobile_logo
 
         return context
 
@@ -130,27 +135,30 @@ class ContextHelper:
     def footer_context(self) -> dict[str, Any]:
         context = {
             "lang": self._language,
-            "crest": self.survey_config.crest,
+            "crest": self._survey_config.crest,
             "newTabWarning": lazy_gettext("The following links open in a new tab"),
             "copyrightDeclaration": {
-                "copyright": self.survey_config.copyright_declaration,
-                "text": self.survey_config.copyright_text,
+                "copyright": self._survey_config.copyright_declaration,
+                "text": self._survey_config.copyright_text,
             },
         }
 
         if self._footer_warning:
             context["footerWarning"] = self._footer_warning
 
-        if self.survey_config.footer_links:
-            context["rows"] = [{"itemsList": self.survey_config.footer_links}]
+        if self._survey_config.footer_links:
+            context["rows"] = [{"itemsList": self._survey_config.footer_links}]
 
-        if self.survey_config.footer_legal_links:
-            context["legal"] = [{"itemsList": self.survey_config.footer_legal_links}]
+        if self._survey_config.footer_legal_links:
+            context["legal"] = [{"itemsList": self._survey_config.footer_legal_links}]
 
-        if self.survey_config.powered_by_logo or self.survey_config.powered_by_logo_alt:
+        if (
+            self._survey_config.powered_by_logo
+            or self._survey_config.powered_by_logo_alt
+        ):
             context["poweredBy"] = {
-                "logo": self.survey_config.powered_by_logo,
-                "alt": self.survey_config.powered_by_logo_alt,
+                "logo": self._survey_config.powered_by_logo,
+                "alt": self._survey_config.powered_by_logo_alt,
             }
 
         return context

--- a/app/routes/session.py
+++ b/app/routes/session.py
@@ -84,6 +84,7 @@ def login():
     store_session(claims)
 
     cookie_session["theme"] = g.schema.json["theme"]
+    cookie_session["survey_title"] = g.schema.json["title"]
     cookie_session["expires_in"] = get_session_timeout_in_seconds(g.schema)
 
     if claims.get("account_service_url"):

--- a/tests/app/helpers/test_template_helpers.py
+++ b/tests/app/helpers/test_template_helpers.py
@@ -205,6 +205,7 @@ def test_get_page_header_context_business(app: Flask):
 
 def test_get_page_header_context_census(app: Flask):
     expected = {
+        "title": "Census 2021",
         "logo": "ons-logo-pos-en",
         "logoAlt": "Office for National Statistics logo",
         "titleLogo": "census-logo-en",
@@ -226,6 +227,7 @@ def test_get_page_header_context_census(app: Flask):
 
 def test_get_page_header_context_census_nisra(app: Flask):
     expected = {
+        "title": "Census 2021",
         "logo": "nisra-logo-en",
         "logoAlt": "Northern Ireland Statistics and Research Agency logo",
         "titleLogo": "census-logo-en",
@@ -338,6 +340,7 @@ def test_account_service_url_context(
         ("census", "cy", WelshCensusSurveyConfig),
         ("census-nisra", "en", CensusNISRASurveyConfig),
         ("census-nisra", "cy", CensusNISRASurveyConfig),
+        (None, None, CensusSurveyConfig),
     ],
 )
 def test_get_survey_config(

--- a/tests/app/questionnaire/test_questionnaire_submission.py
+++ b/tests/app/questionnaire/test_questionnaire_submission.py
@@ -46,7 +46,7 @@ class TestQuestionnaireSubmission(SubmissionTestCase):
 
         # Then I should see an error page
         self.assertStatusCode(500)
-        self.assertEqualPageTitle("Sorry, there is a problem")
+        self.assertEqualPageTitle("Sorry, there is a problem - Submit without summary")
 
         self.get(self.retry_url)
         self.assertInUrl(SUBMIT_URL_PATH)
@@ -89,7 +89,7 @@ class TestQuestionnaireSubmissionHub(SubmissionTestCase):
 
         # Then I should see an error page
         self.assertStatusCode(500)
-        self.assertEqualPageTitle("Sorry, there is a problem")
+        self.assertEqualPageTitle("Sorry, there is a problem - Hub & Spoke")
 
         self.get(self.retry_url)
         self.assertInUrl(HUB_URL_PATH)
@@ -130,7 +130,7 @@ class TestQuestionnaireSubmissionWithSummary(SubmissionTestCase):
 
         # Then I should see an error page
         self.assertStatusCode(500)
-        self.assertEqualPageTitle("Sorry, there is a problem")
+        self.assertEqualPageTitle("Sorry, there is a problem - Other input fields")
 
         self.get(self.retry_url)
         self.assertInUrl(SUBMIT_URL_PATH)

--- a/tests/functional/spec/custom_page_titles.spec.js
+++ b/tests/functional/spec/custom_page_titles.spec.js
@@ -18,14 +18,14 @@ describe("Feature: Custom Page Titles", () => {
     it("When I navigate to the list collector page, Then I should see the custom page title", () => {
       $(HubPage.submit()).click();
       const expectedPageTitle = browser.getTitle();
-      expect(expectedPageTitle).to.equal("Custom page title");
+      expect(expectedPageTitle).to.equal("Custom page title - Test Custom Page Titles");
     });
 
     it("When I navigate to the add person page, Then I should see the custom page title", () => {
       $(ListCollectorPage.yes()).click();
       $(ListCollectorPage.submit()).click();
       let expectedPageTitle = browser.getTitle();
-      expect(expectedPageTitle).to.equal("Add person 1");
+      expect(expectedPageTitle).to.equal("Add person 1 - Test Custom Page Titles");
 
       $(ListCollectorAddPage.firstName()).setValue("Marcus");
       $(ListCollectorAddPage.lastName()).setValue("Twin");
@@ -33,7 +33,7 @@ describe("Feature: Custom Page Titles", () => {
       $(ListCollectorPage.yes()).click();
       $(ListCollectorPage.submit()).click();
       expectedPageTitle = browser.getTitle();
-      expect(expectedPageTitle).to.equal("Add person 2");
+      expect(expectedPageTitle).to.equal("Add person 2 - Test Custom Page Titles");
     });
 
     it("When I navigate to relationship collector pages, Then I should see the custom page titles", () => {
@@ -48,44 +48,44 @@ describe("Feature: Custom Page Titles", () => {
       $(ListCollectorPage.no()).click();
       $(ListCollectorPage.submit()).click();
       let expectedPageTitle = browser.getTitle();
-      expect(expectedPageTitle).to.equal("How Person 1 is related to Person 2");
+      expect(expectedPageTitle).to.equal("How Person 1 is related to Person 2 - Test Custom Page Titles");
 
       $(RelationshipsPage.husbandOrWife()).click();
       $(RelationshipsPage.submit()).click();
       expectedPageTitle = browser.getTitle();
-      expect(expectedPageTitle).to.equal("How Person 1 is related to Person 3");
+      expect(expectedPageTitle).to.equal("How Person 1 is related to Person 3 - Test Custom Page Titles");
 
       $(RelationshipsPage.sonOrDaughter()).click();
       $(RelationshipsPage.submit()).click();
       expectedPageTitle = browser.getTitle();
-      expect(expectedPageTitle).to.equal("How Person 2 is related to Person 3");
+      expect(expectedPageTitle).to.equal("How Person 2 is related to Person 3 - Test Custom Page Titles");
 
       $(RelationshipsPage.sonOrDaughter()).click();
       $(RelationshipsPage.submit()).click();
       expectedPageTitle = browser.getTitle();
-      expect(expectedPageTitle).to.equal("Custom section summary page title");
+      expect(expectedPageTitle).to.equal("Custom section summary page title - Test Custom Page Titles");
     });
 
     it("When I navigate to list edit and remove pages Then I should see the custom page titles", () => {
       $(ListCollectorPage.listEditLink(1)).click();
       let expectedPageTitle = browser.getTitle();
-      expect(expectedPageTitle).to.equal("Edit person 1");
+      expect(expectedPageTitle).to.equal("Edit person 1 - Test Custom Page Titles");
       $(ListCollectorEditPage.previous()).click();
       $(ListCollectorPage.listRemoveLink(1)).click();
       expectedPageTitle = browser.getTitle();
-      expect(expectedPageTitle).to.equal("Remove person 1");
+      expect(expectedPageTitle).to.equal("Remove person 1 - Test Custom Page Titles");
     });
 
     it("When I navigate to a repeating section which has custom page title, Then all page titles in the section should have the correct prefix", () => {
       browser.url(HubPage.url());
       $(HubPage.submit()).click();
-      expect(browser.getTitle()).to.equal("Individual interstitial: Person 1");
+      expect(browser.getTitle()).to.equal("Individual interstitial: Person 1 - Test Custom Page Titles");
       $(IndividualInterstitialPage.submit()).click();
-      expect(browser.getTitle()).to.equal("Proxy question: Person 1");
+      expect(browser.getTitle()).to.equal("Proxy question: Person 1 - Test Custom Page Titles");
       $(ProxyPage.submit()).click();
-      expect(browser.getTitle()).to.equal("What is your date of birth?: Person 1");
+      expect(browser.getTitle()).to.equal("What is your date of birth?: Person 1 - Test Custom Page Titles");
       $(DateOfBirthPage.submit()).click();
-      expect(browser.getTitle()).to.equal("Summary: Person 1");
+      expect(browser.getTitle()).to.equal("Summary: Person 1 - Test Custom Page Titles");
     });
   });
 });

--- a/tests/functional/spec/features/conditional_question_title/conditional_checkbox_title.spec.js
+++ b/tests/functional/spec/features/conditional_question_title/conditional_checkbox_title.spec.js
@@ -27,7 +27,7 @@ describe("Feature: Conditional checkbox and radio question titles", () => {
       $(NameEntryPage.name()).setValue("Mary");
       $(NameEntryPage.submit()).click();
 
-      expect(browser.getTitle()).to.contain("Did Mary make changes to this business?");
+      expect(browser.getTitle()).to.contain("Did Mary make changes to this business? - Test Survey - Checkbox and Radio titles");
     });
 
     it("When I enter another known name and go to the summary", () => {

--- a/tests/functional/spec/features/hub_and_spoke/hub_and_spoke.spec.js
+++ b/tests/functional/spec/features/hub_and_spoke/hub_and_spoke.spec.js
@@ -45,7 +45,7 @@ describe("Feature: Hub and Spoke", () => {
 
     it("When a user views the Hub, Then the page title should be Choose another section to complete", () => {
       const pageTitle = browser.getTitle();
-      expect(pageTitle).to.equal("Choose another section to complete");
+      expect(pageTitle).to.equal("Choose another section to complete - Hub & Spoke");
     });
   });
 

--- a/tests/functional/spec/features/repeating_sections/repeating_sections_with_hub_and_spoke.spec.js
+++ b/tests/functional/spec/features/repeating_sections/repeating_sections_with_hub_and_spoke.spec.js
@@ -145,7 +145,7 @@ describe("Feature: Repeating Sections with Hub and Spoke", () => {
 
     it("When the user views the summary for a repeating section, Then the page title is shown", () => {
       $(HubPage.summaryRowLink("personal-details-section-2")).click();
-      expect(browser.getTitle()).to.equal("…");
+      expect(browser.getTitle()).to.equal("… - Hub & Spoke");
     });
 
     it("When the user adds 2 visitors to the household then a section for each visitor should be display on the hub", () => {

--- a/tests/integration/individual_response/test_individual_response.py
+++ b/tests/integration/individual_response/test_individual_response.py
@@ -180,7 +180,7 @@ class TestIndividualResponseErrorStatus(IndividualResponseTestCase):
         )
         # Then a BadRequest error is returned
         self.assertBadRequest()
-        self.assertEqualPageTitle("An error has occurred - Census 2021")
+        self.assertEqualPageTitle("An error has occurred - Test Individual Response")
 
     def test_ir_raises_400_confirm_number_missing_mobile_param(self):
         # Given I request an individual response by mobile phone
@@ -197,7 +197,7 @@ class TestIndividualResponseErrorStatus(IndividualResponseTestCase):
 
         # Then a BadRequest error is returned
         self.assertBadRequest()
-        self.assertEqualPageTitle("An error has occurred - Census 2021")
+        self.assertEqualPageTitle("An error has occurred - Test Individual Response")
 
     def test_ir_raises_400_confirmation_bad_signature(self):
         # Given I request an individual response by mobile phone
@@ -216,7 +216,7 @@ class TestIndividualResponseErrorStatus(IndividualResponseTestCase):
 
         # Then a BadRequest error is returned
         self.assertBadRequest()
-        self.assertEqualPageTitle("An error has occurred - Census 2021")
+        self.assertEqualPageTitle("An error has occurred - Test Individual Response")
 
     def test_ir_raises_400_confirmation_missing_mobile_param(self):
         # Given I request an individual response by mobile phone
@@ -233,7 +233,7 @@ class TestIndividualResponseErrorStatus(IndividualResponseTestCase):
 
         # Then a BadRequest error is returned
         self.assertBadRequest()
-        self.assertEqualPageTitle("An error has occurred - Census 2021")
+        self.assertEqualPageTitle("An error has occurred - Test Individual Response")
 
     def test_ir_raises_401_without_session(self):
         # Given the hub is enabled
@@ -386,7 +386,7 @@ class TestIndividualResponseErrorStatus(IndividualResponseTestCase):
         self._request_individual_response_by_text()
         self.assertStatusCode(500)
         self.assertEqualPageTitle(
-            "Sorry, there was a problem sending the access code - Census 2021"
+            "Sorry, there was a problem sending the access code - Test Individual Response"
         )
         self.assertInSelector(self.last_url, "p[data-qa=retry]")
 
@@ -397,7 +397,7 @@ class TestIndividualResponseErrorStatus(IndividualResponseTestCase):
         # Given I add a household member
         self._request_individual_response_by_post()
         self.assertEqualPageTitle(
-            "Sorry, there was a problem sending the access code - Census 2021"
+            "Sorry, there was a problem sending the access code - Test Individual Response"
         )
         self.assertInSelector(self.last_url, "p[data-qa=retry]")
 
@@ -413,7 +413,7 @@ class TestIndividualResponseIndividualSection(IndividualResponseTestCase):
 
         # I should see the correct page title
         self.assertEqualPageTitle(
-            "Cannot answer questions for others in your household: Person 1 - Census 2021"
+            "Cannot answer questions for others in your household: Person 1 - Test Individual Response"
         )
 
     def test_ir_guidance_not_displayed_when_primary(self):

--- a/tests/integration/questionnaire/test_questionnaire_custom_page_titles.py
+++ b/tests/integration/questionnaire/test_questionnaire_custom_page_titles.py
@@ -5,29 +5,37 @@ class TestQuestionnaireCustomPageTitles(QuestionnaireTestCase):
     def test_custom_page_titles(self):
         self.launchSurvey("test_custom_page_titles")
         self.post()
-        self.assertEqualPageTitle("Custom page title")
+        self.assertEqualPageTitle("Custom page title - Test Custom Page Titles")
 
         self.post({"anyone-else": "Yes"})
-        self.assertEqualPageTitle("Add person 1")
+        self.assertEqualPageTitle("Add person 1 - Test Custom Page Titles")
 
         self.post({"first-name": "Marie", "last-name": "Doe"})
         self.post({"anyone-else": "Yes"})
-        self.assertEqualPageTitle("Add person 2")
+        self.assertEqualPageTitle("Add person 2 - Test Custom Page Titles")
 
         self.post({"first-name": "John", "last-name": "Doe"})
         self.add_person("Susan", "Doe")
         self.post({"anyone-else": "No"})
 
-        self.assertEqualPageTitle("How Person 1 is related to Person 2")
+        self.assertEqualPageTitle(
+            "How Person 1 is related to Person 2 - Test Custom Page Titles"
+        )
         self.post({"relationship-answer": "Husband or Wife"})
 
-        self.assertEqualPageTitle("How Person 1 is related to Person 3")
+        self.assertEqualPageTitle(
+            "How Person 1 is related to Person 3 - Test Custom Page Titles"
+        )
         self.post({"relationship-answer": "Husband or Wife"})
 
-        self.assertEqualPageTitle("How Person 2 is related to Person 3")
+        self.assertEqualPageTitle(
+            "How Person 2 is related to Person 3 - Test Custom Page Titles"
+        )
         self.post({"relationship-answer": "Husband or Wife"})
 
-        self.assertEqualPageTitle("Custom section summary page title")
+        self.assertEqualPageTitle(
+            "Custom section summary page title - Test Custom Page Titles"
+        )
 
     def test_custom_repeating_page_titles(self):
         self.launchSurvey("test_custom_page_titles")
@@ -39,26 +47,34 @@ class TestQuestionnaireCustomPageTitles(QuestionnaireTestCase):
         self.post({"relationship-answer": "Husband or Wife"})
         self.post()
         self.post()
-        self.assertEqualPageTitle("Individual interstitial: Person 1")
+        self.assertEqualPageTitle(
+            "Individual interstitial: Person 1 - Test Custom Page Titles"
+        )
 
         self.post()
-        self.assertEqualPageTitle("Proxy question: Person 1")
+        self.assertEqualPageTitle("Proxy question: Person 1 - Test Custom Page Titles")
 
         self.post()
-        self.assertEqualPageTitle("What is your date of birth?: Person 1")
+        self.assertEqualPageTitle(
+            "What is your date of birth?: Person 1 - Test Custom Page Titles"
+        )
 
         self.post()
-        self.assertEqualPageTitle("Summary: Person 1")
+        self.assertEqualPageTitle("Summary: Person 1 - Test Custom Page Titles")
 
         self.post()
         self.post()
-        self.assertEqualPageTitle("Individual interstitial: Person 2")
+        self.assertEqualPageTitle(
+            "Individual interstitial: Person 2 - Test Custom Page Titles"
+        )
 
         self.post()
-        self.assertEqualPageTitle("Proxy question: Person 2")
+        self.assertEqualPageTitle("Proxy question: Person 2 - Test Custom Page Titles")
 
         self.post()
-        self.assertEqualPageTitle("What is your date of birth?: Person 2")
+        self.assertEqualPageTitle(
+            "What is your date of birth?: Person 2 - Test Custom Page Titles"
+        )
 
         self.post()
-        self.assertEqualPageTitle("Summary: Person 2")
+        self.assertEqualPageTitle("Summary: Person 2 - Test Custom Page Titles")

--- a/tests/integration/questionnaire/test_questionnaire_page_titles.py
+++ b/tests/integration/questionnaire/test_questionnaire_page_titles.py
@@ -6,7 +6,7 @@ class TestQuestionnairePageTitles(IntegrationTestCase):
         # Given, When
         self.launchSurvey("test_submit_with_custom_submission_text")
         # Then
-        self.assertEqualPageTitle("Introduction")
+        self.assertEqualPageTitle("Introduction - Submit without summary")
 
     def test_should_have_question_in_page_title_when_loading_questionnaire(self):
         # Given
@@ -14,7 +14,9 @@ class TestQuestionnairePageTitles(IntegrationTestCase):
         # When
         self.post(action="start_questionnaire")
         # Then
-        self.assertEqualPageTitle("What is your favourite breakfast food")
+        self.assertEqualPageTitle(
+            "What is your favourite breakfast food - Submit without summary"
+        )
 
     def test_should_have_question_in_page_title_on_submit_page(self):
         # Given
@@ -23,7 +25,7 @@ class TestQuestionnairePageTitles(IntegrationTestCase):
         self.post(action="start_questionnaire")
         self.post({"breakfast-answer": ""})
         # Then
-        self.assertEqualPageTitle("Submit your questionnaire")
+        self.assertEqualPageTitle("Submit your questionnaire - Submit without summary")
 
     def test_should_have_question_in_page_title_on_submit_page_with_summary(self):
         # Given
@@ -31,7 +33,9 @@ class TestQuestionnairePageTitles(IntegrationTestCase):
         # When
         self.post({"answer": ""})
         # Then
-        self.assertEqualPageTitle("Check your answers and submit")
+        self.assertEqualPageTitle(
+            "Check your answers and submit - Percentage Field Demo"
+        )
 
     def test_should_have_survey_in_page_title_on_thank_you(self):
         # Given
@@ -41,7 +45,9 @@ class TestQuestionnairePageTitles(IntegrationTestCase):
         # When submit
         self.post()
         # Then
-        self.assertEqualPageTitle("We’ve received your answers")
+        self.assertEqualPageTitle(
+            "We’ve received your answers - Submit without summary"
+        )
 
     def test_session_timed_out_page_title(self):
         # Given
@@ -49,7 +55,7 @@ class TestQuestionnairePageTitles(IntegrationTestCase):
         # When
         self.get("/session-expired")
         # Then
-        self.assertEqualPageTitle("Session timed out")
+        self.assertEqualPageTitle("Session timed out - Submit without summary")
 
     def test_should_have_content_title_in_page_title_on_interstitial(self):
         # Given
@@ -58,21 +64,23 @@ class TestQuestionnairePageTitles(IntegrationTestCase):
         # When
         self.post({"favourite-breakfast": ""})
         # Then
-        self.assertEqualPageTitle("Breakfast interstitial")
+        self.assertEqualPageTitle("Breakfast interstitial - Interstitial Pages")
 
     def test_html_stripped_from_page_titles(self):
         # Given
         self.launchSurvey("test_markup")
         # When
         # Then
-        self.assertEqualPageTitle("This is a title with emphasis")
+        self.assertEqualPageTitle("This is a title with emphasis - Markup test")
 
     def test_should_have_question_title_in_page_title_on_question(self):
         # Given
         self.launchSurvey("test_checkbox")
         # When
         # Then
-        self.assertEqualPageTitle("Which pizza toppings would you like?")
+        self.assertEqualPageTitle(
+            "Which pizza toppings would you like? - Other input fields"
+        )
 
     def test_should_not_use_names_in_question_page_titles(self):
         # Given
@@ -82,7 +90,7 @@ class TestQuestionnairePageTitles(IntegrationTestCase):
         # When
         self.post({"first-name": "Kevin", "last-name": "Bacon"})
         # Then
-        self.assertEqualPageTitle("What is … date of birth?")
+        self.assertEqualPageTitle("What is … date of birth? - Placeholder Test")
 
     def test_content_page_should_use_nested_content_text_in_page_title_if_it_exists(
         self,
@@ -91,7 +99,9 @@ class TestQuestionnairePageTitles(IntegrationTestCase):
         self.launchSurvey("test_interstitial_page_title")
         # When
         # Then
-        self.assertEqualPageTitle("This is the content title …")
+        self.assertEqualPageTitle(
+            "This is the content title … - Interstitial Page Titles"
+        )
 
     def test_should_have_error_in_page_title_when_fail_validation(self):
         # Given
@@ -99,4 +109,6 @@ class TestQuestionnairePageTitles(IntegrationTestCase):
         # When
         self.post()
         # Then
-        self.assertEqualPageTitle("Error: Which pizza toppings would you like?")
+        self.assertEqualPageTitle(
+            "Error: Which pizza toppings would you like? - Other input fields"
+        )

--- a/tests/integration/questionnaire/test_questionnaire_plurals.py
+++ b/tests/integration/questionnaire/test_questionnaire_plurals.py
@@ -7,7 +7,9 @@ class TestQuestionnairePlurals(IntegrationTestCase):
 
         self.post({"number-of-people-answer": 0})
 
-        self.assertEqualPageTitle("… people live here, is this correct?")
+        self.assertEqualPageTitle(
+            "… people live here, is this correct? - Test Plural Forms"
+        )
         self.assertInBody("0 people live here, is this correct?")
         self.assertInBody("Yes, 0 people live here")
 

--- a/tests/integration/routes/test_confirmation_email.py
+++ b/tests/integration/routes/test_confirmation_email.py
@@ -26,7 +26,9 @@ class TestEmailConfirmation(IntegrationTestCase):
 
         # Then a BadRequest error is returned
         self.assertBadRequest()
-        self.assertEqualPageTitle("An error has occurred - Census 2021")
+        self.assertEqualPageTitle(
+            "An error has occurred - Confirmation email test schema"
+        )
 
     def test_missing_email_param_confirmation_email_sent(self):
         # Given I launch and complete the test_confirmation_email questionnaire
@@ -50,7 +52,9 @@ class TestEmailConfirmation(IntegrationTestCase):
 
         # Then a BadRequest error is returned
         self.assertBadRequest()
-        self.assertEqualPageTitle("An error has occurred - Census 2021")
+        self.assertEqualPageTitle(
+            "An error has occurred - Confirmation email test schema"
+        )
 
     def test_missing_email_param_confirm_email(self):
         # Given I launch and complete the test_confirmation_email questionnaire
@@ -98,7 +102,9 @@ class TestEmailConfirmation(IntegrationTestCase):
 
         # Then a BadRequest error is returned
         self.assertBadRequest()
-        self.assertEqualPageTitle("An error has occurred - Census 2021")
+        self.assertEqualPageTitle(
+            "An error has occurred - Confirmation email test schema"
+        )
 
     def test_thank_you_page_get_not_allowed(self):
         # Given I launch the test_confirmation_email questionnaire
@@ -137,7 +143,9 @@ class TestEmailConfirmation(IntegrationTestCase):
         # When I am on the thank you page, Then there is an confirmation email form
         self.assertInUrl("/submitted/thank-you/")
         self.assertInBody("Get confirmation email")
-        self.assertEqualPageTitle("Thank you for completing the census - Census 2021")
+        self.assertEqualPageTitle(
+            "Thank you for completing the census - Confirmation email test schema"
+        )
 
     def test_census_themed_schema_with_confirmation_email_not_set(self):
         # Given I launch the test_thank_you_census_individual questionnaire, which doesn't have email confirmation set in the schema
@@ -174,7 +182,9 @@ class TestEmailConfirmation(IntegrationTestCase):
         self.post()
 
         # Then I get an error on the confirm email page
-        self.assertEqualPageTitle("Error: Confirm your email address - Census 2021")
+        self.assertEqualPageTitle(
+            "Error: Confirm your email address - Confirmation email test schema"
+        )
         self.assertInBody("There is a problem with your answer")
         self.assertInBody("Select an answer")
 
@@ -248,7 +258,7 @@ class TestEmailConfirmation(IntegrationTestCase):
         self.assertInBody("There is a problem with this page")
         self.assertInBody("Enter an email address")
         self.assertEqualPageTitle(
-            "Error: Thank you for completing the census - Census 2021"
+            "Error: Thank you for completing the census - Confirmation email test schema"
         )
 
     def test_thank_you_incorrect_email_format(self):
@@ -266,7 +276,7 @@ class TestEmailConfirmation(IntegrationTestCase):
         )
 
         self.assertEqualPageTitle(
-            "Error: Thank you for completing the census - Census 2021"
+            "Error: Thank you for completing the census - Confirmation email test schema"
         )
 
     def test_thank_you_email_invalid_tld(self):
@@ -311,7 +321,9 @@ class TestEmailConfirmation(IntegrationTestCase):
         self.assertInUrl("/submitted/confirmation-email/send/")
         self.assertInBody("There is a problem with this page")
         self.assertInBody("Enter an email address")
-        self.assertEqualPageTitle("Error: Confirmation email - Census 2021")
+        self.assertEqualPageTitle(
+            "Error: Confirmation email - Confirmation email test schema"
+        )
 
     def test_confirmation_email_page_incorrect_email_format(self):
         # Given I launch and complete the test_confirmation_email questionnaire and submit with a valid email from the thank you page
@@ -328,7 +340,9 @@ class TestEmailConfirmation(IntegrationTestCase):
         self.assertInBody(
             "Enter an email address in a valid format, for example name@example.com"
         )
-        self.assertEqualPageTitle("Error: Confirmation email - Census 2021")
+        self.assertEqualPageTitle(
+            "Error: Confirmation email - Confirmation email test schema"
+        )
 
     def test_confirmation_email_page(self):
         # Given I launch and complete the test_confirmation_email questionnaire and submit with a valid email from the thank you page
@@ -468,7 +482,7 @@ class TestEmailConfirmation(IntegrationTestCase):
 
         # Then an error page is shown
         self.assertEqualPageTitle(
-            "Sorry, there was a problem sending the confirmation email - Census 2021"
+            "Sorry, there was a problem sending the confirmation email - Confirmation email test schema"
         )
         self.assertInSelector(self.last_url, "p[data-qa=retry]")
 
@@ -488,7 +502,9 @@ class TestEmailConfirmation(IntegrationTestCase):
 
         # Then a BadRequest error is returned
         self.assertBadRequest()
-        self.assertEqualPageTitle("An error has occurred - Census 2021")
+        self.assertEqualPageTitle(
+            "An error has occurred - Confirmation email test schema"
+        )
 
     def test_head_request_on_email_confirmation(self):
         self._launch_and_complete_questionnaire()

--- a/tests/integration/routes/test_cookie.py
+++ b/tests/integration/routes/test_cookie.py
@@ -11,9 +11,10 @@ class TestCookie(IntegrationTestCase):
         self.assertIsNotNone(cookie.get("eq-session-id"))
         self.assertIsNotNone(cookie.get("expires_in"))
         self.assertIsNotNone(cookie.get("theme"))
+        self.assertIsNotNone(cookie.get("survey_title"))
         self.assertIsNotNone(cookie.get("user_ik"))
         self.assertIsNotNone(cookie.get("account_service_url"))
-        self.assertEqual(len(cookie), 7)
+        self.assertEqual(len(cookie), 8)
 
         self.assertIsNone(cookie.get("user_id"))
         self.assertIsNone(cookie.get("_permanent"))

--- a/tests/integration/routes/test_feedback.py
+++ b/tests/integration/routes/test_feedback.py
@@ -200,7 +200,7 @@ class TestFeedback(IntegrationTestCase):
         self.assertInUrl(self.SEND_FEEDBACK_URL)
         self.assertInBody("There is a problem with your feedback")
         self.assertInBody("Select what your feedback is about")
-        self.assertEqualPageTitle("Error: Feedback - Census 2021")
+        self.assertEqualPageTitle("Error: Feedback - Feedback test schema")
 
     def test_feedback_text_missing(self):
         # Given I launch and complete the test_feedback questionnaire
@@ -214,7 +214,7 @@ class TestFeedback(IntegrationTestCase):
         self.assertInUrl(self.SEND_FEEDBACK_URL)
         self.assertInBody("There is a problem with your feedback")
         self.assertInBody("Enter your feedback")
-        self.assertEqualPageTitle("Error: Feedback - Census 2021")
+        self.assertEqualPageTitle("Error: Feedback - Feedback test schema")
 
     def test_feedback_question_category_missing(self):
         # Given I launch and complete the test_feedback questionnaire
@@ -230,7 +230,7 @@ class TestFeedback(IntegrationTestCase):
         self.assertInUrl(self.SEND_FEEDBACK_URL)
         self.assertInBody("There is a problem with your feedback")
         self.assertInBody("Select an option")
-        self.assertEqualPageTitle("Error: Feedback - Census 2021")
+        self.assertEqualPageTitle("Error: Feedback - Feedback test schema")
 
     def test_feedback_type_and_text_missing(self):
         # Given I launch and complete the test_feedback questionnaire
@@ -245,7 +245,7 @@ class TestFeedback(IntegrationTestCase):
         self.assertInBody("There are 2 problems with your feedback")
         self.assertInBody("Select what your feedback is about")
         self.assertInBody("Enter your feedback")
-        self.assertEqualPageTitle("Error: Feedback - Census 2021")
+        self.assertEqualPageTitle("Error: Feedback - Feedback test schema")
 
     def test_feedback_page_previous(self):
         # Given I launch and complete the test_feedback questionnaire
@@ -358,7 +358,7 @@ class TestFeedback(IntegrationTestCase):
 
         # Then I should see an error page
         self.assertStatusCode(500)
-        self.assertEqualPageTitle("Sorry, there is a problem - Census 2021")
+        self.assertEqualPageTitle("Sorry, there is a problem - Feedback test schema")
         self.assertInBody("submit your feedback again")
 
         retry_url = (

--- a/tests/integration/session/test_timeout.py
+++ b/tests/integration/session/test_timeout.py
@@ -38,7 +38,7 @@ class TestTimeout(IntegrationTestCase):
         self.get(self.last_url)
         self.assertStatusUnauthorised()
         self.assertInBody("To help protect your information we have timed you out")
-        self.assertEqualPageTitle("Session timed out")
+        self.assertEqualPageTitle("Session timed out - Timeout test")
 
     def test_submission_complete_timeout(self):
         self.launchSurvey("test_timeout")
@@ -48,4 +48,4 @@ class TestTimeout(IntegrationTestCase):
         self.get(self.last_url)
         self.assertStatusUnauthorised()
         self.assertInBody("This page is no longer available")
-        self.assertEqualPageTitle("Submission Complete")
+        self.assertEqualPageTitle("Submission Complete - Timeout test")


### PR DESCRIPTION
### What is the context of this PR?
The recent refactoring of template helpers in https://github.com/ONSdigital/eq-questionnaire-runner/pull/601 broke the survey title for non-census questionnaires. This pull request fixes it.

To fix the issue the survey title has been added to the cookie on authentication. Although this doesn't align with the decision to not store schema properties in the cookie (https://github.com/ONSdigital/eq-questionnaire-runner/blob/master/doc/architecture/decisions/0010-cookies.md), that would require wider changes to ensure the schema is always in scope when we have a session cookie, and should be done separately.

### How to review 
Check that the page title and page header title contain the survey title for non-census questionnaires.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
