### PR TITLE
Push to GCR on PRs

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -14,19 +14,9 @@ jobs:
           run: printf "$GITHUB_SHA" > .application-version
         - name: Build
           run: >
-            docker build -t onsdigital/eq-questionnaire-runner:latest
-            -t eu.gcr.io/${{ secrets.GCLOUD_PROJECT_ID }}/eq-questionnaire-runner:latest .
+            docker build -t onsdigital/eq-questionnaire-runner:latest .
         - name: Push to Docker Hub
           run: |
             echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
             echo "Pushing with tag [latest]"
             docker push onsdigital/eq-questionnaire-runner:latest
-        - name: Push to GCR
-          env:
-            DOCKER_BUILDKIT: 1
-            GCLOUD_SERVICE_JSON: ${{ secrets.GCLOUD_SERVICE_KEY }}
-            PROJECT_ID: ${{ secrets.GCLOUD_PROJECT_ID }}
-          run: |
-            echo $GCLOUD_SERVICE_JSON | docker login -u _json_key --password-stdin https://eu.gcr.io
-            echo "Pushing with tag [latest]"
-            docker push eu.gcr.io/${{ secrets.GCLOUD_PROJECT_ID }}/eq-questionnaire-runner:latest

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -15,8 +15,18 @@ jobs:
         - name: Build
           run: >
             docker build -t onsdigital/eq-questionnaire-runner:latest .
+            -t eu.gcr.io/${{ secrets.GCLOUD_PROJECT_ID }}/eq-questionnaire-runner:latest .
         - name: Push to Docker Hub
           run: |
             echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
             echo "Pushing with tag [latest]"
             docker push onsdigital/eq-questionnaire-runner:latest
+        - name: Push to GCR
+          env:
+            DOCKER_BUILDKIT: 1
+            GCLOUD_SERVICE_JSON: ${{ secrets.GCLOUD_SERVICE_KEY }}
+            PROJECT_ID: ${{ secrets.GCLOUD_PROJECT_ID }}
+          run: |
+            echo $GCLOUD_SERVICE_JSON | docker login -u _json_key --password-stdin https://eu.gcr.io
+            echo "Pushing with tag [latest]"
+            docker push eu.gcr.io/${{ secrets.GCLOUD_PROJECT_ID }}/eq-questionnaire-runner:latest

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -14,7 +14,7 @@ jobs:
           run: printf "$GITHUB_SHA" > .application-version
         - name: Build
           run: >
-            docker build -t onsdigital/eq-questionnaire-runner:latest .
+            docker build -t onsdigital/eq-questionnaire-runner:latest
             -t eu.gcr.io/${{ secrets.GCLOUD_PROJECT_ID }}/eq-questionnaire-runner:latest .
         - name: Push to Docker Hub
           run: |

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -169,11 +169,7 @@ jobs:
           echo "Pushing to DockerHub with tag $TAG"
           docker push onsdigital/eq-questionnaire-runner:$TAG
       - name: Push to GCR
-        env:
-          DOCKER_BUILDKIT: 1
-          GCLOUD_SERVICE_JSON: ${{ secrets.GCLOUD_SERVICE_KEY }}
-          PROJECT_ID: ${{ secrets.GCLOUD_PROJECT_ID }}
         run: |
-          echo $GCLOUD_SERVICE_JSON | docker login -u _json_key --password-stdin https://eu.gcr.io
+          echo ${{ secrets.GCLOUD_SERVICE_KEY }} | docker login -u _json_key --password-stdin https://eu.gcr.io
           echo "Pushing to GCR with tag $TAG"
           docker push eu.gcr.io/${{ secrets.GCLOUD_PROJECT_ID }}/eq-questionnaire-runner:$TAG

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -161,7 +161,7 @@ jobs:
           printf $SHA > .application-version
       - name: Build
         run: >
-          docker build -t onsdigital/eq-questionnaire-runner:$TAG .
+          docker build -t onsdigital/eq-questionnaire-runner:$TAG
           -t eu.gcr.io/${{ secrets.GCLOUD_PROJECT_ID }}/eq-questionnaire-runner:$TAG .
       - name: Push to Docker Hub
         run: |

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -169,7 +169,9 @@ jobs:
           echo "Pushing to DockerHub with tag $TAG"
           docker push onsdigital/eq-questionnaire-runner:$TAG
       - name: Push to GCR
+        env:
+            GCLOUD_SERVICE_KEY: ${{ secrets.GCLOUD_SERVICE_KEY }}
         run: |
-          echo ${{ secrets.GCLOUD_SERVICE_KEY }} | docker login -u _json_key --password-stdin https://eu.gcr.io
+          echo $GCLOUD_SERVICE_KEY | docker login -u _json_key --password-stdin https://eu.gcr.io
           echo "Pushing to GCR with tag $TAG"
           docker push eu.gcr.io/${{ secrets.GCLOUD_PROJECT_ID }}/eq-questionnaire-runner:$TAG

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -162,8 +162,18 @@ jobs:
       - name: Build
         run: >
           docker build -t onsdigital/eq-questionnaire-runner:$TAG .
+          -t eu.gcr.io/${{ secrets.GCLOUD_PROJECT_ID }}/eq-questionnaire-runner:$TAG .
       - name: Push to Docker Hub
         run: |
           echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
           echo "Pushing to DockerHub with tag $TAG"
           docker push onsdigital/eq-questionnaire-runner:$TAG
+      - name: Push to GCR
+        env:
+          DOCKER_BUILDKIT: 1
+          GCLOUD_SERVICE_JSON: ${{ secrets.GCLOUD_SERVICE_KEY }}
+          PROJECT_ID: ${{ secrets.GCLOUD_PROJECT_ID }}
+        run: |
+          echo $GCLOUD_SERVICE_JSON | docker login -u _json_key --password-stdin https://eu.gcr.io
+          echo "Pushing to GCR with tag $TAG"
+          docker push eu.gcr.io/${{ secrets.GCLOUD_PROJECT_ID }}/eq-questionnaire-runner:$TAG

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -162,7 +162,7 @@ jobs:
       - name: Build
         run: >
           docker build -t onsdigital/eq-questionnaire-runner:$TAG
-          -t eu.gcr.io/${{ secrets.GCLOUD_PROJECT_ID }}/eq-questionnaire-runner:$TAG .
+          -t eu.gcr.io/${{ secrets.GCR_PROJECT_ID }}/eq-questionnaire-runner:$TAG .
       - name: Push to Docker Hub
         run: |
           echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
@@ -170,8 +170,8 @@ jobs:
           docker push onsdigital/eq-questionnaire-runner:$TAG
       - name: Push to GCR
         env:
-            GCLOUD_SERVICE_KEY: ${{ secrets.GCLOUD_SERVICE_KEY }}
+            GCR_SERVICE_KEY: ${{ secrets.GCR_SERVICE_KEY }}
         run: |
-          echo $GCLOUD_SERVICE_KEY | docker login -u _json_key --password-stdin https://eu.gcr.io
+          echo $GCR_SERVICE_KEY | docker login -u _json_key --password-stdin https://eu.gcr.io
           echo "Pushing to GCR with tag $TAG"
-          docker push eu.gcr.io/${{ secrets.GCLOUD_PROJECT_ID }}/eq-questionnaire-runner:$TAG
+          docker push eu.gcr.io/${{ secrets.GCR_PROJECT_ID }}/eq-questionnaire-runner:$TAG


### PR DESCRIPTION
### What is the context of this PR?
This reintroduces `Push to GCR` task to both `pull-request` and `master` workflows. New service account with `Storage Legacy Bucket Reader`(storage.buckets.get, storage.objects.list, storage.multipartUploads.list) and `Storage Object Admin` roles was created in the gcp project. This change requires two new secrets to be added to the repository: `GCLOUD_SERVICE_KEY` and `GCLOUD_PROJECT_ID`. This has been tested in [this fork of launcher](https://github.com/petechd/eq-questionnaire-launcher/pulls). Container Registry with pushed images can be found [here](https://console.cloud.google.com/gcr/images/pete-test-env-on-release).
EDIT: These Runner and Launcher PRs are now pushing images tagged with branch name to our dev repository too.

### How to review 
- Fork the repository 
- in gcp (your project) create new service account with `Storage Legacy Bucket Reader` and `Storage Object Admin` roles
- add service account's json key as `GCLOUD_SERVICE_KEY` and your gcp project name as `GCLOUD_PROJECT_ID` to your forked repo secrets
-  create some pull requests or make some changes to master of your forked repository
### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
