### PR TITLE
Add view_submitted_response to submission handler

### DIFF
--- a/app/views/handlers/submission.py
+++ b/app/views/handlers/submission.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Mapping
 
 from flask import current_app
 from flask import session as cookie_session
@@ -39,7 +40,10 @@ class SubmissionHandler:
         cookie_session["submitted"] = True
 
         self._store_submitted_time_and_display_address_in_session()
-        self._questionnaire_store.delete()
+        submission_schema: Mapping = self._schema.get_submission() or {}
+
+        if not submission_schema.get("view_submitted_response"):
+            self._questionnaire_store.delete()
 
     def get_payload(self):
         payload = convert_answers(

--- a/tests/app/views/handlers/test_submission_handler.py
+++ b/tests/app/views/handlers/test_submission_handler.py
@@ -47,7 +47,7 @@ class TestSubmissionPayload(AppContextTestCase):
                     submission_handler.get_payload()["submission_language_code"] == "cy"
                 )
 
-    def test_submit_questionnaire_store_delete_called(self):
+    def test_questionnaire_store_delete_called(self):
         questionnaire_store = self.questionnaire_store_mock()
         self.questionnaire_store_delete_mock(questionnaire_store)
 


### PR DESCRIPTION
### What is the context of this PR?
This PR reintroduces view_submitted_response, which if true means the question store is not deleted on submission

### How to review 
I haven't added an integration/functional test or a schema, but I have tested the handler. My theory is until we have the feature that allows the visualisation of answers on post submission, there isn't a great deal to test integration/functional wise. We already have a test that checks the store is deleted so don't need to check that again, just that it is being called or not

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
