### PR TITLE
Introduce a common interface for resolving value sources

### DIFF
--- a/app/data_models/answer.py
+++ b/app/data_models/answer.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass, field
+from decimal import Decimal
 from typing import Optional, Union
+
+AnswerValueTypes = Union[str, int, Decimal, dict, list[str]]
 
 
 @dataclass
 class Answer:
     answer_id: str
-    value: Union[str, int, float, list, dict]
+    value: AnswerValueTypes
     list_item_id: Optional[str] = field(default=None)
 
     @classmethod

--- a/app/data_models/answer.py
+++ b/app/data_models/answer.py
@@ -4,7 +4,7 @@ from dataclasses import asdict, dataclass, field
 from decimal import Decimal
 from typing import Optional, Union
 
-AnswerValueTypes = Union[str, int, Decimal, dict, list[str]]
+AnswerValueTypes = Union[str, int, Decimal, dict[str, Union[int, str]], list[str]]
 
 
 @dataclass

--- a/app/data_models/answer.py
+++ b/app/data_models/answer.py
@@ -47,22 +47,22 @@ class Answer:
 
 @overload
 def escape_answer_value(value: ListAnswer) -> ListAnswerEscaped:
-    ...
+    ...  # pragma: no cover
 
 
 @overload
 def escape_answer_value(value: DictAnswer) -> DictAnswerEscaped:
-    ...
+    ...  # pragma: no cover
 
 
 @overload
 def escape_answer_value(value: str) -> Markup:
-    ...
+    ...  # pragma: no cover
 
 
 @overload
 def escape_answer_value(value: Union[None, int, Decimal]) -> Union[None, int, Decimal]:
-    ...
+    ...  # pragma: no cover
 
 
 def escape_answer_value(

--- a/app/data_models/answer.py
+++ b/app/data_models/answer.py
@@ -2,9 +2,23 @@ from __future__ import annotations
 
 from dataclasses import asdict, dataclass, field
 from decimal import Decimal
-from typing import Optional, Union
+from typing import Optional, Union, overload
 
-AnswerValueTypes = Union[str, int, Decimal, dict[str, Union[int, str]], list[str]]
+from markupsafe import Markup, escape
+
+DictAnswer = dict[str, Union[int, str]]
+ListAnswer = list[str]
+DictAnswerEscaped = dict[str, Union[int, Markup]]
+ListAnswerEscaped = list[Markup]
+
+AnswerValueTypes = Union[str, int, Decimal, DictAnswer, ListAnswer]
+AnswerValueEscapedTypes = Union[
+    Markup,
+    int,
+    Decimal,
+    DictAnswerEscaped,
+    ListAnswerEscaped,
+]
 
 
 @dataclass
@@ -29,3 +43,38 @@ class Answer:
 
     def to_dict(self) -> dict:
         return asdict(self)
+
+
+@overload
+def escape_answer_value(value: ListAnswer) -> ListAnswerEscaped:
+    ...
+
+
+@overload
+def escape_answer_value(value: DictAnswer) -> DictAnswerEscaped:
+    ...
+
+
+@overload
+def escape_answer_value(value: str) -> Markup:
+    ...
+
+
+@overload
+def escape_answer_value(value: Union[None, int, Decimal]) -> Union[None, int, Decimal]:
+    ...
+
+
+def escape_answer_value(
+    value: Optional[AnswerValueTypes],
+) -> Optional[AnswerValueEscapedTypes]:
+    if isinstance(value, list):
+        return [escape(item) for item in value]
+
+    if isinstance(value, dict):
+        return {
+            key: escape(val) if isinstance(val, str) else val
+            for key, val in value.items()
+        }
+
+    return escape(value) if isinstance(value, str) else value

--- a/app/data_models/answer.py
+++ b/app/data_models/answer.py
@@ -1,28 +1,28 @@
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass, field
-from typing import Dict, List, Mapping, Optional, Union
+from typing import Optional, Union
 
 
 @dataclass
 class Answer:
     answer_id: str
-    value: Union[str, int, float, List, Mapping]
+    value: Union[str, int, float, list, dict]
     list_item_id: Optional[str] = field(default=None)
 
     @classmethod
-    def from_dict(cls, answer_dict: Dict) -> Answer:
+    def from_dict(cls, answer_dict: dict) -> Answer:
         return cls(
             answer_id=answer_dict["answer_id"],
             value=answer_dict["value"],
             list_item_id=answer_dict.get("list_item_id"),
         )
 
-    def for_json(self) -> Dict:
+    def for_json(self) -> dict:
         output = self.to_dict()
         if not self.list_item_id:
             del output["list_item_id"]
         return output
 
-    def to_dict(self) -> Dict:
+    def to_dict(self) -> dict:
         return asdict(self)

--- a/app/data_models/answer_store.py
+++ b/app/data_models/answer_store.py
@@ -2,9 +2,8 @@ from __future__ import annotations
 
 from typing import Dict, List, Optional
 
-from markupsafe import escape
-
 from app.data_models.answer import Answer
+from app.libs.utils import escape_value
 
 
 class AnswerStore:
@@ -139,24 +138,6 @@ class AnswerStore:
 
     def get_escaped_answer_value(self, answer_id, list_item_id=None):
         if answer := self.get_answer(answer_id, list_item_id):
-            if isinstance(answer.value, list):
-                return [
-                    escape(list_item)
-                    if list_item and isinstance(list_item, str)
-                    else list_item
-                    for list_item in answer.value
-                ]
-
-            if isinstance(answer.value, dict):
-                escaped_dict = {}
-                for key, value in answer.value.items():
-                    escaped_dict[key] = (
-                        escape(value) if isinstance(value, str) else value
-                    )
-                return escaped_dict
-
-            return (
-                escape(answer.value) if isinstance(answer.value, str) else answer.value
-            )
+            return escape_value(answer.value)
 
         return None

--- a/app/data_models/answer_store.py
+++ b/app/data_models/answer_store.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 from typing import Dict, List, Optional
 
-from app.data_models.answer import Answer
-from app.libs.utils import escape_value
+from app.data_models.answer import Answer, escape_answer_value
 
 
 class AnswerStore:
@@ -138,6 +137,6 @@ class AnswerStore:
 
     def get_escaped_answer_value(self, answer_id, list_item_id=None):
         if answer := self.get_answer(answer_id, list_item_id):
-            return escape_value(answer.value)
+            return escape_answer_value(answer.value)
 
         return None

--- a/app/libs/utils.py
+++ b/app/libs/utils.py
@@ -1,10 +1,3 @@
-from typing import Optional, Union
-
-from markupsafe import Markup, escape
-
-from app.data_models.answer import AnswerValueTypes
-
-
 def convert_tx_id(tx_id: str) -> str:
     """
     Converts the guid tx_id to string of 16 characters with a dash between every 4 characters
@@ -12,20 +5,3 @@ def convert_tx_id(tx_id: str) -> str:
     :return: String in the form of xxxx-xxxx-xxxx-xxxx
     """
     return (tx_id[:4] + "-" + tx_id[4:])[:19]
-
-
-def escape_value(
-    value: Optional[AnswerValueTypes],
-) -> Union[None, Markup, AnswerValueTypes]:
-    if isinstance(value, list):
-        return [
-            escape(item) if item and isinstance(item, str) else item for item in value
-        ]
-
-    if isinstance(value, dict):
-        return {
-            key: escape(val) if isinstance(val, str) else val
-            for key, val in value.items()
-        }
-
-    return escape(value) if isinstance(value, str) else value

--- a/app/libs/utils.py
+++ b/app/libs/utils.py
@@ -1,7 +1,11 @@
-from markupsafe import escape
+from typing import Union
+
+from markupsafe import Markup, escape
+
+from app.data_models.answer import AnswerValueTypes
 
 
-def convert_tx_id(tx_id):
+def convert_tx_id(tx_id: str) -> str:
     """
     Converts the guid tx_id to string of 16 characters with a dash between every 4 characters
     :param tx_id: tx_id to be converted
@@ -10,13 +14,7 @@ def convert_tx_id(tx_id):
     return (tx_id[:4] + "-" + tx_id[4:])[:19]
 
 
-# Converts a dict into an object with the key names as property names
-class ObjectFromDict:
-    def __init__(self, properties):
-        self.__dict__ = properties
-
-
-def escape_value(value):
+def escape_value(value: AnswerValueTypes) -> Union[None, Markup, AnswerValueTypes]:
     if isinstance(value, list):
         return [
             escape(item) if item and isinstance(item, str) else item for item in value

--- a/app/libs/utils.py
+++ b/app/libs/utils.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Optional, Union
 
 from markupsafe import Markup, escape
 
@@ -14,7 +14,9 @@ def convert_tx_id(tx_id: str) -> str:
     return (tx_id[:4] + "-" + tx_id[4:])[:19]
 
 
-def escape_value(value: AnswerValueTypes) -> Union[None, Markup, AnswerValueTypes]:
+def escape_value(
+    value: Optional[AnswerValueTypes],
+) -> Union[None, Markup, AnswerValueTypes]:
     if isinstance(value, list):
         return [
             escape(item) if item and isinstance(item, str) else item for item in value

--- a/app/libs/utils.py
+++ b/app/libs/utils.py
@@ -1,3 +1,6 @@
+from markupsafe import escape
+
+
 def convert_tx_id(tx_id):
     """
     Converts the guid tx_id to string of 16 characters with a dash between every 4 characters
@@ -11,3 +14,18 @@ def convert_tx_id(tx_id):
 class ObjectFromDict:
     def __init__(self, properties):
         self.__dict__ = properties
+
+
+def escape_value(value):
+    if isinstance(value, list):
+        return [
+            escape(item) if item and isinstance(item, str) else item for item in value
+        ]
+
+    if isinstance(value, dict):
+        return {
+            key: escape(val) if isinstance(val, str) else val
+            for key, val in value.items()
+        }
+
+    return escape(value) if isinstance(value, str) else value

--- a/app/questionnaire/placeholder_parser.py
+++ b/app/questionnaire/placeholder_parser.py
@@ -43,7 +43,7 @@ class PlaceholderParser:
             schema=self._schema,
             location=self._location,
             list_item_id=self._list_item_id,
-            escape_answer_value=True,
+            escape_answer_values=True,
         )
 
     def __call__(self, placeholder_list: Sequence[Mapping]) -> Mapping:

--- a/app/questionnaire/placeholder_parser.py
+++ b/app/questionnaire/placeholder_parser.py
@@ -1,6 +1,5 @@
-from typing import Any, Dict, Mapping, Optional, Sequence
+from typing import Any, Mapping, Optional, Sequence
 
-from app.data_models.answer import AnswerValueTypes
 from app.data_models.answer_store import AnswerStore
 from app.questionnaire import QuestionnaireSchema
 from app.questionnaire.placeholder_transforms import PlaceholderTransforms
@@ -65,7 +64,7 @@ class PlaceholderParser:
         transformed_value = None
 
         for transform in transform_list:
-            transform_args: Dict[str, Optional[AnswerValueTypes]] = {}
+            transform_args: dict[str, Any] = {}
 
             for arg_key, arg_value in transform["arguments"].items():
                 if isinstance(arg_value, list):

--- a/app/questionnaire/placeholder_parser.py
+++ b/app/questionnaire/placeholder_parser.py
@@ -2,9 +2,10 @@ from decimal import Decimal
 from typing import Dict, Mapping, Sequence, Union
 
 from app.data_models.answer_store import AnswerStore
-from app.data_models.list_store import ListModel
+from app.libs.utils import escape_value
 from app.questionnaire import QuestionnaireSchema
 from app.questionnaire.placeholder_transforms import PlaceholderTransforms
+from app.questionnaire.value_source_resolver import ValueSourceResolver
 
 
 class PlaceholderParser:
@@ -33,6 +34,15 @@ class PlaceholderParser:
         self._transformer = PlaceholderTransforms(language)
         self._placeholder_map = {}
 
+        self._value_source_resolver = ValueSourceResolver(
+            answer_store=self._answer_store,
+            list_store=self._list_store,
+            metadata=self._metadata,
+            schema=self._schema,
+            location=self._location,
+            list_item_id=self._list_item_id,
+        )
+
     def __call__(self, placeholder_list: Sequence[Mapping]) -> Mapping:
         placeholder_list = QuestionnaireSchema.get_mutable_deepcopy(placeholder_list)
         for placeholder in placeholder_list:
@@ -42,41 +52,12 @@ class PlaceholderParser:
                 ] = self._parse_placeholder(placeholder)
         return self._placeholder_map
 
-    def _resolve_value_source(self, value_source):
-        if value_source["source"] == "answers":
-            return self._resolve_answer_value(value_source)
-        if value_source["source"] == "metadata":
-            return self._metadata.get(value_source["identifier"])
-        if value_source["source"] == "list":
-            id_selector = value_source.get("id_selector")
-            list_model: ListModel = self._list_store[value_source["identifier"]]
-
-            if id_selector:
-                return getattr(list_model, id_selector)
-
-            return len(list_model)
-        if (
-            value_source["source"] == "location"
-            and value_source["identifier"] == "list_item_id"
-        ):
-            return self._list_item_id
-
-    def _resolve_answer_value(self, value_source):
-        list_item_id = self._get_list_item_id_from_value_source(value_source)
-        answer = self._answer_store.get_escaped_answer_value(
-            value_source["identifier"], list_item_id
-        )
-        return (
-            answer.get(value_source["selector"])
-            if "selector" in value_source
-            else answer
-        )
-
     def _parse_placeholder(self, placeholder: Mapping) -> Mapping:
         try:
             return self._parse_transforms(placeholder["transforms"])
         except KeyError:
-            return self._resolve_value_source(placeholder["value"])
+            resolved_value = self._value_source_resolver.resolve(placeholder["value"])
+            return escape_value(resolved_value)
 
     def _parse_transforms(self, transform_list: Sequence[Mapping]):
         transformed_value = None
@@ -88,41 +69,23 @@ class PlaceholderParser:
 
             for arg_key, arg_value in transform["arguments"].items():
                 if isinstance(arg_value, list):
-                    transform_args[arg_key] = self._resolve_value_source_list(arg_value)
+                    transformed_value = self._value_source_resolver.resolve(arg_value)
                 elif isinstance(arg_value, dict):
                     if "value" in arg_value:
-                        transform_args[arg_key] = arg_value["value"]
+                        transformed_value = arg_value["value"]
                     elif arg_value["source"] == "previous_transform":
-                        transform_args[arg_key] = transformed_value
+                        transformed_value = transformed_value
                     else:
-                        transform_args[arg_key] = self._resolve_value_source(arg_value)
+                        transformed_value = self._value_source_resolver.resolve(
+                            arg_value
+                        )
                 else:
-                    transform_args[arg_key] = arg_value
+                    transformed_value = arg_value
+
+                transform_args[arg_key] = escape_value(transformed_value)
 
             transformed_value = getattr(self._transformer, transform["transform"])(
                 **transform_args
             )
 
         return transformed_value
-
-    def _resolve_value_source_list(self, value_source_list: list[dict]) -> list[str]:
-        values: list[str] = []
-        for value_source in value_source_list:
-            value = self._resolve_value_source(value_source)
-            if isinstance(value, list):
-                values.extend(value)
-            else:
-                values.append(value)
-        return values
-
-    def _get_list_item_id_from_value_source(self, value_source):
-        list_item_selector = value_source.get("list_item_selector")
-        if list_item_selector:
-            if list_item_selector["source"] == "location":
-                return getattr(self._location, list_item_selector["id"])
-            if list_item_selector["source"] == "list":
-                return getattr(
-                    self._list_store[list_item_selector["id"]],
-                    list_item_selector["id_selector"],
-                )
-        return self._list_item_id

--- a/app/questionnaire/placeholder_parser.py
+++ b/app/questionnaire/placeholder_parser.py
@@ -1,6 +1,6 @@
-from decimal import Decimal
-from typing import Dict, Mapping, Sequence, Union
+from typing import Any, Dict, Mapping, Optional, Sequence
 
+from app.data_models.answer import AnswerValueTypes
 from app.data_models.answer_store import AnswerStore
 from app.libs.utils import escape_value
 from app.questionnaire import QuestionnaireSchema
@@ -52,7 +52,7 @@ class PlaceholderParser:
                 ] = self._parse_placeholder(placeholder)
         return self._placeholder_map
 
-    def _parse_placeholder(self, placeholder: Mapping) -> Mapping:
+    def _parse_placeholder(self, placeholder: Mapping) -> Any:
         try:
             return self._parse_transforms(placeholder["transforms"])
         except KeyError:
@@ -63,9 +63,7 @@ class PlaceholderParser:
         transformed_value = None
 
         for transform in transform_list:
-            transform_args: Dict[
-                str, Union[None, str, int, Decimal, dict, list[str]]
-            ] = {}
+            transform_args: Dict[str, Optional[AnswerValueTypes]] = {}
 
             for arg_key, arg_value in transform["arguments"].items():
                 if isinstance(arg_value, list):

--- a/app/questionnaire/placeholder_parser.py
+++ b/app/questionnaire/placeholder_parser.py
@@ -4,7 +4,10 @@ from app.data_models.answer import AnswerValueTypes
 from app.data_models.answer_store import AnswerStore
 from app.questionnaire import QuestionnaireSchema
 from app.questionnaire.placeholder_transforms import PlaceholderTransforms
-from app.questionnaire.value_source_resolver import ValueSourceResolver
+from app.questionnaire.value_source_resolver import (
+    ValueSourceResolver,
+    ValueSourceTypes,
+)
 
 
 class PlaceholderParser:
@@ -58,6 +61,18 @@ class PlaceholderParser:
         except KeyError:
             return self._value_source_resolver.resolve(placeholder["value"])
 
+    def _resolve_value_source_list(
+        self, value_source_list: list[dict]
+    ) -> Optional[ValueSourceTypes]:
+        values = []
+        for value_source in value_source_list:
+            value = self._value_source_resolver.resolve(value_source)
+            if isinstance(value, list):
+                values.extend(value)
+            else:
+                values.append(value)
+        return values
+
     def _parse_transforms(self, transform_list: Sequence[Mapping]):
         transformed_value = None
 
@@ -66,7 +81,7 @@ class PlaceholderParser:
 
             for arg_key, arg_value in transform["arguments"].items():
                 if isinstance(arg_value, list):
-                    transformed_value = self._value_source_resolver.resolve(arg_value)
+                    transformed_value = self._resolve_value_source_list(arg_value)
                 elif isinstance(arg_value, dict):
                     if "value" in arg_value:
                         transformed_value = arg_value["value"]

--- a/app/questionnaire/placeholder_parser.py
+++ b/app/questionnaire/placeholder_parser.py
@@ -61,18 +61,6 @@ class PlaceholderParser:
         except KeyError:
             return self._value_source_resolver.resolve(placeholder["value"])
 
-    def _resolve_value_source_list(
-        self, value_source_list: list[dict]
-    ) -> Optional[ValueSourceTypes]:
-        values = []
-        for value_source in value_source_list:
-            value = self._value_source_resolver.resolve(value_source)
-            if isinstance(value, list):
-                values.extend(value)
-            else:
-                values.append(value)
-        return values
-
     def _parse_transforms(self, transform_list: Sequence[Mapping]):
         transformed_value = None
 
@@ -101,3 +89,15 @@ class PlaceholderParser:
             )
 
         return transformed_value
+
+    def _resolve_value_source_list(
+        self, value_source_list: list[dict]
+    ) -> Optional[ValueSourceTypes]:
+        values = []
+        for value_source in value_source_list:
+            value = self._value_source_resolver.resolve(value_source)
+            if isinstance(value, list):
+                values.extend(value)
+            else:
+                values.append(value)
+        return values

--- a/app/questionnaire/placeholder_parser.py
+++ b/app/questionnaire/placeholder_parser.py
@@ -2,7 +2,6 @@ from typing import Any, Dict, Mapping, Optional, Sequence
 
 from app.data_models.answer import AnswerValueTypes
 from app.data_models.answer_store import AnswerStore
-from app.libs.utils import escape_value
 from app.questionnaire import QuestionnaireSchema
 from app.questionnaire.placeholder_transforms import PlaceholderTransforms
 from app.questionnaire.value_source_resolver import ValueSourceResolver
@@ -41,6 +40,7 @@ class PlaceholderParser:
             schema=self._schema,
             location=self._location,
             list_item_id=self._list_item_id,
+            escape_answer_value=True,
         )
 
     def __call__(self, placeholder_list: Sequence[Mapping]) -> Mapping:
@@ -56,8 +56,7 @@ class PlaceholderParser:
         try:
             return self._parse_transforms(placeholder["transforms"])
         except KeyError:
-            resolved_value = self._value_source_resolver.resolve(placeholder["value"])
-            return escape_value(resolved_value)
+            return self._value_source_resolver.resolve(placeholder["value"])
 
     def _parse_transforms(self, transform_list: Sequence[Mapping]):
         transformed_value = None
@@ -80,7 +79,7 @@ class PlaceholderParser:
                 else:
                     transformed_value = arg_value
 
-                transform_args[arg_key] = escape_value(transformed_value)
+                transform_args[arg_key] = transformed_value
 
             transformed_value = getattr(self._transformer, transform["transform"])(
                 **transform_args

--- a/app/questionnaire/questionnaire_schema.py
+++ b/app/questionnaire/questionnaire_schema.py
@@ -366,17 +366,14 @@ class QuestionnaireSchema:  # pylint: disable=too-many-public-methods
         if block := self.get_block_for_answer_id(answer_id):
             return self.is_block_in_repeating_section(block_id=block["id"])
 
-    def get_list_item_id_for_answer_id(
-        self, answer_id: str, list_item_id: Optional[str]
-    ) -> Optional[str]:
-        if (
-            list_item_id
-            and not self.is_answer_in_list_collector_block(answer_id)
-            and not self.is_answer_in_repeating_section(answer_id)
-        ):
-            return None
-
-        return list_item_id
+    def answer_should_have_list_item_id(
+        self,
+        answer_id: str,
+    ) -> bool:
+        return bool(
+            self.is_answer_in_list_collector_block(answer_id)
+            or self.is_answer_in_repeating_section(answer_id)
+        )
 
     def get_answers_by_answer_id(self, answer_id: str) -> Optional[list[ImmutableDict]]:
         """Return answers matching answer id, including all matching answers inside

--- a/app/questionnaire/questionnaire_schema.py
+++ b/app/questionnaire/questionnaire_schema.py
@@ -366,7 +366,7 @@ class QuestionnaireSchema:  # pylint: disable=too-many-public-methods
         if block := self.get_block_for_answer_id(answer_id):
             return self.is_block_in_repeating_section(block_id=block["id"])
 
-    def should_answer_have_list_item_id(
+    def is_repeating_answer(
         self,
         answer_id: str,
     ) -> bool:

--- a/app/questionnaire/questionnaire_schema.py
+++ b/app/questionnaire/questionnaire_schema.py
@@ -366,7 +366,7 @@ class QuestionnaireSchema:  # pylint: disable=too-many-public-methods
         if block := self.get_block_for_answer_id(answer_id):
             return self.is_block_in_repeating_section(block_id=block["id"])
 
-    def answer_should_have_list_item_id(
+    def should_answer_have_list_item_id(
         self,
         answer_id: str,
     ) -> bool:

--- a/app/questionnaire/rules.py
+++ b/app/questionnaire/rules.py
@@ -342,7 +342,7 @@ def evaluate_when_rules(
 def get_answer_for_answer_id(answer_id, answer_store, schema, list_item_id):
     list_item_id = (
         list_item_id
-        if list_item_id and schema.answer_should_have_list_item_id(answer_id)
+        if list_item_id and schema.should_answer_have_list_item_id(answer_id)
         else None
     )
 

--- a/app/questionnaire/rules.py
+++ b/app/questionnaire/rules.py
@@ -341,9 +341,7 @@ def evaluate_when_rules(
 
 def get_answer_for_answer_id(answer_id, answer_store, schema, list_item_id):
     list_item_id = (
-        list_item_id
-        if list_item_id and schema.should_answer_have_list_item_id(answer_id)
-        else None
+        list_item_id if list_item_id and schema.is_repeating_answer(answer_id) else None
     )
 
     answer = answer_store.get_answer(

--- a/app/questionnaire/rules.py
+++ b/app/questionnaire/rules.py
@@ -1,6 +1,7 @@
 import logging
 import re
 from datetime import datetime
+from typing import Optional
 
 from dateutil.relativedelta import relativedelta
 
@@ -134,14 +135,18 @@ def get_date_match_value(date_comparison, answer_store, schema, metadata):
     return match_value
 
 
-def convert_to_datetime(value):
-    date_format = "%Y-%m"
-    if value and re.match(r"\d{4}-\d{2}-\d{2}", value):
-        date_format = "%Y-%m-%d"
-    if value and re.match(r"\d{4}$", value):
-        date_format = "%Y"
+def convert_to_datetime(value: Optional[str]) -> Optional[datetime]:
+    if not value:
+        return None
 
-    return datetime.strptime(value, date_format) if value else None
+    if re.match(r"\d{4}-\d{2}-\d{2}", value):
+        date_format = "%Y-%m-%d"
+    elif re.match(r"\d{4}$", value):
+        date_format = "%Y"
+    else:
+        date_format = "%Y-%m"
+
+    return datetime.strptime(value, date_format)
 
 
 def evaluate_goto(
@@ -335,7 +340,11 @@ def evaluate_when_rules(
 
 
 def get_answer_for_answer_id(answer_id, answer_store, schema, list_item_id):
-    list_item_id = schema.get_list_item_id_for_answer_id(answer_id, list_item_id)
+    list_item_id = (
+        list_item_id
+        if list_item_id and schema.answer_should_have_list_item_id(answer_id)
+        else None
+    )
 
     answer = answer_store.get_answer(
         answer_id, list_item_id

--- a/app/questionnaire/value_source_resolver.py
+++ b/app/questionnaire/value_source_resolver.py
@@ -25,7 +25,7 @@ class ValueSourceResolver:
     list_item_id: Optional[str]
     routing_path_block_ids: Optional[list] = None
     use_default_answer: bool = False
-    escape_answer_value: bool = False
+    escape_answer_values: bool = False
 
     def _is_answer_on_path(self, answer_id: str) -> bool:
         if self.routing_path_block_ids:
@@ -90,7 +90,7 @@ class ValueSourceResolver:
                 else None
             )
 
-        if answer_value is not None and self.escape_answer_value:
+        if answer_value is not None and self.escape_answer_values:
             return escape_answer_value(answer_value)
 
         return answer_value

--- a/app/questionnaire/value_source_resolver.py
+++ b/app/questionnaire/value_source_resolver.py
@@ -4,11 +4,7 @@ from typing import Optional, Union
 
 from markupsafe import Markup
 
-from app.data_models.answer import (
-    AnswerValueEscapedTypes,
-    AnswerValueTypes,
-    escape_answer_value,
-)
+from app.data_models.answer import AnswerValueTypes, escape_answer_value
 from app.data_models.answer_store import AnswerStore
 from app.data_models.list_store import ListModel, ListStore
 from app.questionnaire import Location, QuestionnaireSchema

--- a/app/questionnaire/value_source_resolver.py
+++ b/app/questionnaire/value_source_resolver.py
@@ -2,16 +2,17 @@ from dataclasses import dataclass
 from decimal import Decimal
 from typing import Optional, Union
 
-from markupsafe import Markup
-
-from app.data_models.answer import AnswerValueTypes
+from app.data_models.answer import (
+    AnswerValueEscapedTypes,
+    AnswerValueTypes,
+    escape_answer_value,
+)
 from app.data_models.answer_store import AnswerStore
 from app.data_models.list_store import ListModel, ListStore
-from app.libs.utils import escape_value
 from app.questionnaire import Location, QuestionnaireSchema
 from app.questionnaire.relationship_location import RelationshipLocation
 
-ValueSourceTypes = Union[None, str, int, Decimal, list[str]]
+ValueSourceTypes = Union[None, str, int, Decimal, list]
 
 
 @dataclass
@@ -74,7 +75,7 @@ class ValueSourceResolver:
 
     def _resolve_answer_value(
         self, value_source: dict
-    ) -> Union[Markup, ValueSourceTypes]:
+    ) -> Union[AnswerValueEscapedTypes, ValueSourceTypes]:
         list_item_id = self._resolve_list_item_id_for_value_source(value_source)
         answer_id = value_source["identifier"]
 
@@ -90,11 +91,13 @@ class ValueSourceResolver:
             )
 
         if answer_value is not None and self.escape_answer_value:
-            return escape_value(answer_value)  # type: ignore
+            return escape_answer_value(answer_value)
 
         return answer_value
 
-    def resolve(self, value_source: dict) -> ValueSourceTypes:
+    def resolve(
+        self, value_source: dict
+    ) -> Union[AnswerValueEscapedTypes, ValueSourceTypes]:
         source = value_source["source"]
         identifier = value_source.get("identifier")
 

--- a/app/questionnaire/value_source_resolver.py
+++ b/app/questionnaire/value_source_resolver.py
@@ -1,0 +1,124 @@
+from dataclasses import dataclass
+from typing import Optional, Union
+
+from app.data_models import AnswerStore, ListStore
+from app.data_models.list_store import ListModel
+from app.questionnaire import Location, QuestionnaireSchema
+from app.questionnaire.relationship_location import RelationshipLocation
+
+answer_value_types = Union[str, int, float, list, dict, None]
+value_source_types = Union[str, int, float, list, None]
+
+
+@dataclass
+class ValueSourceResolver:
+    answer_store: AnswerStore
+    list_store: ListStore
+    metadata: dict
+    schema: QuestionnaireSchema
+    location: Union[Location, RelationshipLocation]
+    list_item_id: Optional[str]
+    routing_path_block_ids: Optional[list] = None
+    use_default_answer: bool = False
+
+    def _get_list_item_id_from_value_source(self, value_source: dict) -> Optional[str]:
+        if not (list_item_selector := value_source.get("list_item_selector")):
+            return None
+
+        value: Optional[str] = None
+        if list_item_selector["source"] == "location":
+            value = getattr(self.location, list_item_selector["id"])
+
+        elif list_item_selector["source"] == "list":
+            value = getattr(
+                self.list_store[list_item_selector["id"]],
+                list_item_selector["id_selector"],
+            )
+
+        return value
+
+    def _is_answer_on_path(self, answer_id: str) -> bool:
+        if self.routing_path_block_ids:
+            block = self.schema.get_block_for_answer_id(answer_id)
+            return block is not None and block["id"] in self.routing_path_block_ids
+
+        return True
+
+    def _get_answer_value(
+        self, answer_id: str, list_item_id: Optional[str]
+    ) -> answer_value_types:
+        if not self._is_answer_on_path(answer_id):
+            return None
+
+        if answer := self.answer_store.get_answer(answer_id, list_item_id):
+            return answer.value
+
+        if self.use_default_answer and (
+            answer := self.schema.get_default_answer(answer_id)
+        ):
+            return answer.value
+
+    def _resolve_answer_value(self, value_source: dict) -> value_source_types:
+        list_item_id = self._get_list_item_id_from_value_source(value_source)
+        answer_id = value_source["identifier"]
+        if not list_item_id:
+            list_item_id = (
+                self.list_item_id
+                if self.list_item_id
+                and self.schema.answer_should_have_list_item_id(answer_id)
+                else None
+            )
+
+        answer_value = self._get_answer_value(
+            answer_id=answer_id, list_item_id=list_item_id
+        )
+
+        if isinstance(answer_value, dict):
+            return (
+                answer_value.get(value_source["selector"])
+                if "selector" in value_source
+                else None
+            )
+
+        return answer_value
+
+    def _resolve_value_source_list(
+        self, value_source_list: list[dict]
+    ) -> list[Union[str, int, float, None]]:
+        values: list[Union[str, int, float, None]] = []
+        for value_source in value_source_list:
+            value = self._resolve(value_source)
+            if isinstance(value, list):
+                values.extend(value)
+            else:
+                values.append(value)
+        return values
+
+    def _resolve(self, value_source: dict) -> value_source_types:
+        source = value_source["source"]
+        identifier = value_source.get("identifier")
+
+        if source == "answers":
+            return self._resolve_answer_value(value_source)
+        if source == "metadata":
+            return self.metadata.get(identifier)
+        if source == "list":
+            list_model: ListModel = self.list_store[identifier]
+
+            if id_selector := value_source.get("id_selector"):
+                value: Union[str, list] = getattr(list_model, id_selector)
+                return value
+
+            return len(list_model)
+
+        if source == "location" and identifier == "list_item_id":
+            # :TODO: Resolve value from location object to be consistent with location id_selector in answer sources.
+            # This has been kept as is to keep placeholder parser functioning.
+            # This is a side-effect of not having a location object for routes such as individual response.
+            return self.list_item_id
+
+    def resolve(self, value_source: Union[list, dict]) -> value_source_types:
+        if isinstance(value_source, list):
+            return self._resolve_value_source_list(value_source)
+
+        return self._resolve(value_source)

--- a/app/questionnaire/value_source_resolver.py
+++ b/app/questionnaire/value_source_resolver.py
@@ -43,7 +43,7 @@ class ValueSourceResolver:
         return (
             self.list_item_id
             if self.list_item_id
-            and self.schema.should_answer_have_list_item_id(value_source["identifier"])
+            and self.schema.is_repeating_answer(value_source["identifier"])
             else None
         )
 

--- a/app/questionnaire/value_source_resolver.py
+++ b/app/questionnaire/value_source_resolver.py
@@ -73,7 +73,7 @@ class ValueSourceResolver:
             else None
         )
 
-    def _resolve_answer_value(
+    def _resolve_answer_value_source(
         self, value_source: dict
     ) -> Union[AnswerValueEscapedTypes, ValueSourceTypes]:
         list_item_id = self._resolve_list_item_id_for_value_source(value_source)
@@ -102,7 +102,7 @@ class ValueSourceResolver:
         identifier = value_source.get("identifier")
 
         if source == "answers":
-            return self._resolve_answer_value(value_source)
+            return self._resolve_answer_value_source(value_source)
         if source == "metadata":
             return self.metadata.get(identifier)
         if source == "list":

--- a/app/questionnaire/value_source_resolver.py
+++ b/app/questionnaire/value_source_resolver.py
@@ -85,17 +85,17 @@ class ValueSourceResolver:
 
     def _resolve_value_source_list(
         self, value_source_list: list[dict]
-    ) -> Optional[ValueSourceTypes]:
+    ) -> ValueSourceTypes:
         values = []
         for value_source in value_source_list:
-            value = self._resolve(value_source)
+            value = self._resolve_value_source_dict(value_source)
             if isinstance(value, list):
                 values.extend(value)
             else:
                 values.append(value)
         return values
 
-    def _resolve(self, value_source: dict) -> ValueSourceTypes:
+    def _resolve_value_source_dict(self, value_source: dict) -> ValueSourceTypes:
         source = value_source["source"]
         identifier = value_source.get("identifier")
 
@@ -121,4 +121,4 @@ class ValueSourceResolver:
         if isinstance(value_source, list):
             return self._resolve_value_source_list(value_source)
 
-        return self._resolve(value_source)
+        return self._resolve_value_source_dict(value_source)

--- a/app/questionnaire/value_source_resolver.py
+++ b/app/questionnaire/value_source_resolver.py
@@ -97,26 +97,31 @@ class ValueSourceResolver:
 
         return answer_value
 
+    def _resolve_list_value_source(self, value_source: dict) -> Union[int, str, list]:
+        identifier = value_source["identifier"]
+        list_model: ListModel = self.list_store[identifier]
+
+        if id_selector := value_source.get("id_selector"):
+            value: Union[str, list] = getattr(list_model, id_selector)
+            return value
+
+        return len(list_model)
+
     def resolve(
         self, value_source: dict
     ) -> Union[ValueSourceEscapedTypes, ValueSourceTypes]:
         source = value_source["source"]
-        identifier = value_source.get("identifier")
 
         if source == "answers":
             return self._resolve_answer_value_source(value_source)
-        if source == "metadata":
-            return self.metadata.get(identifier)
+
         if source == "list":
-            list_model: ListModel = self.list_store[identifier]
+            return self._resolve_list_value_source(value_source)
 
-            if id_selector := value_source.get("id_selector"):
-                value: Union[str, list] = getattr(list_model, id_selector)
-                return value
+        if source == "metadata":
+            return self.metadata.get(value_source.get("identifier"))
 
-            return len(list_model)
-
-        if source == "location" and identifier == "list_item_id":
+        if source == "location" and value_source.get("identifier") == "list_item_id":
             # This does not use the location object because
             # routes such as individual response does not have the concept of location.
             return self.list_item_id

--- a/app/questionnaire/value_source_resolver.py
+++ b/app/questionnaire/value_source_resolver.py
@@ -43,7 +43,7 @@ class ValueSourceResolver:
         return (
             self.list_item_id
             if self.list_item_id
-            and self.schema.answer_should_have_list_item_id(value_source["identifier"])
+            and self.schema.should_answer_have_list_item_id(value_source["identifier"])
             else None
         )
 

--- a/app/questionnaire/value_source_resolver.py
+++ b/app/questionnaire/value_source_resolver.py
@@ -113,9 +113,8 @@ class ValueSourceResolver:
             return len(list_model)
 
         if source == "location" and identifier == "list_item_id":
-            # :TODO: Resolve value from location object to be consistent with location id_selector in answer sources.
-            # This has been kept as is to keep placeholder parser functioning.
-            # This is a side-effect of not having a location object for routes such as individual response.
+            # This does not use the location object because
+            # routes such as individual response does not have the concept of location.
             return self.list_item_id
 
     def resolve(self, value_source: Union[list, dict]) -> ValueSourceTypes:

--- a/app/questionnaire/value_source_resolver.py
+++ b/app/questionnaire/value_source_resolver.py
@@ -2,6 +2,8 @@ from dataclasses import dataclass
 from decimal import Decimal
 from typing import Optional, Union
 
+from markupsafe import Markup
+
 from app.data_models.answer import (
     AnswerValueEscapedTypes,
     AnswerValueTypes,
@@ -13,6 +15,10 @@ from app.questionnaire import Location, QuestionnaireSchema
 from app.questionnaire.relationship_location import RelationshipLocation
 
 ValueSourceTypes = Union[None, str, int, Decimal, list]
+ValueSourceEscapedTypes = Union[
+    Markup,
+    list[Markup],
+]
 
 
 @dataclass
@@ -75,7 +81,7 @@ class ValueSourceResolver:
 
     def _resolve_answer_value_source(
         self, value_source: dict
-    ) -> Union[AnswerValueEscapedTypes, ValueSourceTypes]:
+    ) -> Union[ValueSourceEscapedTypes, ValueSourceTypes]:
         list_item_id = self._resolve_list_item_id_for_value_source(value_source)
         answer_id = value_source["identifier"]
 
@@ -97,7 +103,7 @@ class ValueSourceResolver:
 
     def resolve(
         self, value_source: dict
-    ) -> Union[AnswerValueEscapedTypes, ValueSourceTypes]:
+    ) -> Union[ValueSourceEscapedTypes, ValueSourceTypes]:
         source = value_source["source"]
         identifier = value_source.get("identifier")
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -25,3 +25,7 @@ warn_return_any = True
 [mypy-app.questionnaire.value_source_resolver]
 disallow_untyped_defs = True
 warn_return_any = True
+
+[mypy-app.libs.utils]
+disallow_untyped_defs = True
+warn_return_any = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -21,3 +21,7 @@ warn_return_any = True
 [mypy-app.views.contexts.submit_context]
 disallow_untyped_defs = True
 warn_return_any = True
+
+[mypy-app.questionnaire.value_source_resolver]
+disallow_untyped_defs = True
+warn_return_any = True

--- a/tests/app/data_model/test_answer.py
+++ b/tests/app/data_model/test_answer.py
@@ -1,4 +1,10 @@
+import pytest
+
+from app.data_models.answer import escape_answer_value
 from app.data_models.answer_store import Answer
+
+HTML_CONTENT = '"><b>some html</b>'
+ESCAPED_CONTENT = "&#34;&gt;&lt;b&gt;some html&lt;/b&gt;"
 
 
 def test_from_dict():
@@ -7,3 +13,17 @@ def test_from_dict():
     expected_answer = Answer(answer_id="test1", value="avalue", list_item_id="123321")
 
     assert Answer.from_dict(test_answer) == expected_answer
+
+
+@pytest.mark.parametrize(
+    "value_to_escape, escaped_value",
+    [
+        (HTML_CONTENT, ESCAPED_CONTENT),
+        ([HTML_CONTENT, "some value"], [ESCAPED_CONTENT, "some value"]),
+        ({"key_1": HTML_CONTENT, "key_2": 1}, {"key_1": ESCAPED_CONTENT, "key_2": 1}),
+        (1, 1),
+        (None, None),
+    ],
+)
+def test_escape_value(value_to_escape, escaped_value):
+    assert escape_answer_value(value_to_escape) == escaped_value

--- a/tests/app/data_model/test_answer_store.py
+++ b/tests/app/data_model/test_answer_store.py
@@ -29,9 +29,13 @@ def basic_answer_store():
     answer_store.add_or_update(Answer(answer_id="another-answer3", value=35))
 
     answer_store.add_or_update(Answer(answer_id="answer4", value="<p>abc123</p>"))
-    answer_store.add_or_update(Answer(answer_id="answer5", value=["<p>abc123</p>", 1]))
     answer_store.add_or_update(
-        Answer(answer_id="answer6", value={"item1": "<p>abc123</p>", "item2": 1})
+        Answer(answer_id="answer5", value=["<p>abc123</p>", "some value"])
+    )
+    answer_store.add_or_update(
+        Answer(
+            answer_id="answer6", value={"item1": "<p>abc123</p>", "item2": "some value"}
+        )
     )
 
     answer_store.add_or_update(Answer(answer_id="to-escape", value="'Twenty Five'"))
@@ -220,9 +224,9 @@ def test_escaped_answer_value_method(basic_answer_store):
     )
     assert basic_answer_store.get_escaped_answer_value("answer5") == [
         "&lt;p&gt;abc123&lt;/p&gt;",
-        1,
+        "some value",
     ]
     assert basic_answer_store.get_escaped_answer_value("answer6") == {
         "item1": "&lt;p&gt;abc123&lt;/p&gt;",
-        "item2": 1,
+        "item2": "some value",
     }

--- a/tests/app/forms/field_handlers/test_date_handler.py
+++ b/tests/app/forms/field_handlers/test_date_handler.py
@@ -133,8 +133,8 @@ def test_get_referenced_offset_value_for_answer_id(app):
     "app.utilities.schema.load_schema_from_name", return_value=QuestionnaireSchema({})
 )
 @patch(
-    "app.questionnaire.questionnaire_schema.QuestionnaireSchema.get_list_item_id_for_answer_id",
-    return_value="abcde",
+    "app.questionnaire.questionnaire_schema.QuestionnaireSchema.answer_should_have_list_item_id",
+    return_value=True,
 )
 def test_get_referenced_offset_value_with_list_item_id(app, schema_mock):
     list_item_id = "abcde"

--- a/tests/app/forms/field_handlers/test_date_handler.py
+++ b/tests/app/forms/field_handlers/test_date_handler.py
@@ -133,7 +133,7 @@ def test_get_referenced_offset_value_for_answer_id(app):
     "app.utilities.schema.load_schema_from_name", return_value=QuestionnaireSchema({})
 )
 @patch(
-    "app.questionnaire.questionnaire_schema.QuestionnaireSchema.should_answer_have_list_item_id",
+    "app.questionnaire.questionnaire_schema.QuestionnaireSchema.is_repeating_answer",
     return_value=True,
 )
 def test_get_referenced_offset_value_with_list_item_id(app, schema_mock):

--- a/tests/app/forms/field_handlers/test_date_handler.py
+++ b/tests/app/forms/field_handlers/test_date_handler.py
@@ -133,7 +133,7 @@ def test_get_referenced_offset_value_for_answer_id(app):
     "app.utilities.schema.load_schema_from_name", return_value=QuestionnaireSchema({})
 )
 @patch(
-    "app.questionnaire.questionnaire_schema.QuestionnaireSchema.answer_should_have_list_item_id",
+    "app.questionnaire.questionnaire_schema.QuestionnaireSchema.should_answer_have_list_item_id",
     return_value=True,
 )
 def test_get_referenced_offset_value_with_list_item_id(app, schema_mock):

--- a/tests/app/libs/test_utils.py
+++ b/tests/app/libs/test_utils.py
@@ -1,20 +1,29 @@
-import unittest
+import pytest
 
-from app.libs.utils import ObjectFromDict
+from app.helpers.uuid_helper import is_valid_uuid
+from app.libs.utils import convert_tx_id, escape_value
 
 
-class ObjectFromDictTest(unittest.TestCase):
-    def test_simple_object(self):
-        simple_dict = {
-            "property_one": "string",
-            "property_two": 2,
-            "property_three": [],
-        }
+def test_convert_tx_id():
+    tx_id_to_convert = "bc26d5ef-8475-4710-ac82-753a0a150708"
 
-        obj = ObjectFromDict(simple_dict)
+    assert is_valid_uuid(tx_id_to_convert)
+    assert "bc26-d5ef-8475-4710" == convert_tx_id(tx_id_to_convert)
 
-        # pylint: disable=maybe-no-member
-        # Object is dynamically built and properties dynamically assigned
-        self.assertEqual(obj.property_one, "string")
-        self.assertEqual(obj.property_two, 2)
-        self.assertEqual(len(obj.property_three), 0)
+
+HTML_CONTENT = '"><b>some html</b>'
+ESCAPED_CONTENT = "&#34;&gt;&lt;b&gt;some html&lt;/b&gt;"
+
+
+@pytest.mark.parametrize(
+    "value_to_escape, escaped_value",
+    [
+        (HTML_CONTENT, ESCAPED_CONTENT),
+        ([HTML_CONTENT, 1, HTML_CONTENT], [ESCAPED_CONTENT, 1, ESCAPED_CONTENT]),
+        ({"key_1": HTML_CONTENT, "key_2": 1}, {"key_1": ESCAPED_CONTENT, "key_2": 1}),
+        (1, 1),
+        (None, None),
+    ],
+)
+def test_escape_value(value_to_escape, escaped_value):
+    assert escape_value(value_to_escape) == escaped_value

--- a/tests/app/libs/test_utils.py
+++ b/tests/app/libs/test_utils.py
@@ -1,7 +1,5 @@
-import pytest
-
 from app.helpers.uuid_helper import is_valid_uuid
-from app.libs.utils import convert_tx_id, escape_value
+from app.libs.utils import convert_tx_id
 
 
 def test_convert_tx_id():
@@ -9,21 +7,3 @@ def test_convert_tx_id():
 
     assert is_valid_uuid(tx_id_to_convert)
     assert "bc26-d5ef-8475-4710" == convert_tx_id(tx_id_to_convert)
-
-
-HTML_CONTENT = '"><b>some html</b>'
-ESCAPED_CONTENT = "&#34;&gt;&lt;b&gt;some html&lt;/b&gt;"
-
-
-@pytest.mark.parametrize(
-    "value_to_escape, escaped_value",
-    [
-        (HTML_CONTENT, ESCAPED_CONTENT),
-        ([HTML_CONTENT, 1, HTML_CONTENT], [ESCAPED_CONTENT, 1, ESCAPED_CONTENT]),
-        ({"key_1": HTML_CONTENT, "key_2": 1}, {"key_1": ESCAPED_CONTENT, "key_2": 1}),
-        (1, 1),
-        (None, None),
-    ],
-)
-def test_escape_value(value_to_escape, escaped_value):
-    assert escape_value(value_to_escape) == escaped_value

--- a/tests/app/questionnaire/conftest.py
+++ b/tests/app/questionnaire/conftest.py
@@ -1,7 +1,10 @@
 # pylint: disable=redefined-outer-name
+from unittest.mock import Mock
+
 import pytest
 
 from app.data_models.answer_store import AnswerStore
+from app.questionnaire import QuestionnaireSchema
 from app.questionnaire.location import Location
 from app.questionnaire.placeholder_parser import PlaceholderParser
 
@@ -682,3 +685,18 @@ def section_with_repeating_list():
             }
         ]
     }
+
+
+@pytest.fixture
+def mock_schema():
+    schema = Mock(
+        QuestionnaireSchema(
+            {
+                "questionnaire_flow": {
+                    "type": "Linear",
+                    "options": {"summary": {"collapsible": False}},
+                }
+            }
+        )
+    )
+    return schema

--- a/tests/app/questionnaire/test_placeholder_parser.py
+++ b/tests/app/questionnaire/test_placeholder_parser.py
@@ -1,3 +1,5 @@
+from unittest.mock import Mock
+
 from app.data_models.answer_store import AnswerStore
 from app.data_models.list_store import ListStore
 from app.questionnaire.placeholder_parser import PlaceholderParser
@@ -546,7 +548,7 @@ def test_placeholder_resolves_same_name_items():
     assert placeholders["answer"] == ["abc123", "fgh789"]
 
 
-def test_placeholder_resolves_name_is_duplicate_chain():
+def test_placeholder_resolves_name_is_duplicate_chain(mock_schema):
     list_store = ListStore(
         [
             {
@@ -630,8 +632,11 @@ def test_placeholder_resolves_name_is_duplicate_chain():
         }
     ]
 
+    mock_schema.answer_should_have_list_item_id = Mock(return_value=True)
+
     parser = PlaceholderParser(
         language="en",
+        schema=mock_schema,
         list_store=list_store,
         answer_store=answer_store,
         list_item_id="abc123",
@@ -643,6 +648,7 @@ def test_placeholder_resolves_name_is_duplicate_chain():
 
     parser = PlaceholderParser(
         language="en",
+        schema=mock_schema,
         list_store=list_store,
         answer_store=answer_store,
         list_item_id="cde456",
@@ -653,7 +659,7 @@ def test_placeholder_resolves_name_is_duplicate_chain():
     assert placeholders["persons_name"] == "Marie Smith"
 
 
-def test_placeholder_resolves_list_has_items_chain():
+def test_placeholder_resolves_list_has_items_chain(mock_schema):
     list_store = ListStore(
         [
             {
@@ -733,8 +739,11 @@ def test_placeholder_resolves_list_has_items_chain():
         }
     ]
 
+    mock_schema.answer_should_have_list_item_id = Mock(return_value=True)
+
     parser = PlaceholderParser(
         language="en",
+        schema=mock_schema,
         list_store=list_store,
         answer_store=answer_store,
         list_item_id="abc123",
@@ -746,6 +755,7 @@ def test_placeholder_resolves_list_has_items_chain():
 
     parser = PlaceholderParser(
         language="en",
+        schema=mock_schema,
         list_store=list_store,
         answer_store=answer_store,
         list_item_id="cde456",

--- a/tests/app/questionnaire/test_placeholder_parser.py
+++ b/tests/app/questionnaire/test_placeholder_parser.py
@@ -632,7 +632,7 @@ def test_placeholder_resolves_name_is_duplicate_chain(mock_schema):
         }
     ]
 
-    mock_schema.should_answer_have_list_item_id = Mock(return_value=True)
+    mock_schema.is_repeating_answer = Mock(return_value=True)
 
     parser = PlaceholderParser(
         language="en",
@@ -739,7 +739,7 @@ def test_placeholder_resolves_list_has_items_chain(mock_schema):
         }
     ]
 
-    mock_schema.should_answer_have_list_item_id = Mock(return_value=True)
+    mock_schema.is_repeating_answer = Mock(return_value=True)
 
     parser = PlaceholderParser(
         language="en",

--- a/tests/app/questionnaire/test_placeholder_parser.py
+++ b/tests/app/questionnaire/test_placeholder_parser.py
@@ -632,7 +632,7 @@ def test_placeholder_resolves_name_is_duplicate_chain(mock_schema):
         }
     ]
 
-    mock_schema.answer_should_have_list_item_id = Mock(return_value=True)
+    mock_schema.should_answer_have_list_item_id = Mock(return_value=True)
 
     parser = PlaceholderParser(
         language="en",
@@ -739,7 +739,7 @@ def test_placeholder_resolves_list_has_items_chain(mock_schema):
         }
     ]
 
-    mock_schema.answer_should_have_list_item_id = Mock(return_value=True)
+    mock_schema.should_answer_have_list_item_id = Mock(return_value=True)
 
     parser = PlaceholderParser(
         language="en",

--- a/tests/app/questionnaire/test_questionnaire_schema.py
+++ b/tests/app/questionnaire/test_questionnaire_schema.py
@@ -312,21 +312,21 @@ def test_answer_should_not_have_list_item_id_without_repeat_or_list_collector(
 ):
     schema = QuestionnaireSchema(question_schema)
 
-    assert schema.should_answer_have_list_item_id(answer_id="answer1") is False
+    assert schema.is_repeating_answer(answer_id="answer1") is False
 
 
-def test_should_answer_have_list_item_id_within_repeat(section_with_repeating_list):
+def test_is_repeating_answer_within_repeat(section_with_repeating_list):
     schema = QuestionnaireSchema(section_with_repeating_list)
 
-    assert schema.should_answer_have_list_item_id(answer_id="proxy-answer") is True
+    assert schema.is_repeating_answer(answer_id="proxy-answer") is True
 
 
-def test_should_answer_have_list_item_id_within_list_collector(
+def test_is_repeating_answer_within_list_collector(
     list_collector_variant_schema,
 ):
     schema = QuestionnaireSchema(list_collector_variant_schema)
 
-    assert schema.should_answer_have_list_item_id(answer_id="answer1") is True
+    assert schema.is_repeating_answer(answer_id="answer1") is True
 
 
 def test_get_list_collector_for_list(list_collector_variant_schema):

--- a/tests/app/questionnaire/test_questionnaire_schema.py
+++ b/tests/app/questionnaire/test_questionnaire_schema.py
@@ -307,56 +307,26 @@ def test_get_relationship_collectors_by_list_name_no_collectors(
     assert not collectors
 
 
-def test_get_list_item_id_for_answer_id_without_list_item_id(
-    section_with_repeating_list,
-):
-    schema = QuestionnaireSchema(section_with_repeating_list)
-
-    expected_list_item_id = None
-
-    list_item_id = schema.get_list_item_id_for_answer_id(
-        answer_id="answer1", list_item_id=expected_list_item_id
-    )
-
-    assert list_item_id == expected_list_item_id
-
-
-def test_get_list_item_id_for_answer_id_without_repeat_or_list_collector(
+def test_answer_should_not_have_list_item_id_without_repeat_or_list_collector(
     question_schema,
 ):
     schema = QuestionnaireSchema(question_schema)
 
-    list_item_id = schema.get_list_item_id_for_answer_id(
-        answer_id="answer1", list_item_id="abc123"
-    )
-
-    assert list_item_id is None
+    assert schema.answer_should_have_list_item_id(answer_id="answer1") is False
 
 
-def test_get_answer_within_repeat_with_list_item_id(section_with_repeating_list):
+def test_answer_should_have_list_item_id_within_repeat(section_with_repeating_list):
     schema = QuestionnaireSchema(section_with_repeating_list)
 
-    expected_list_item_id = "abc123"
-
-    list_item_id = schema.get_list_item_id_for_answer_id(
-        answer_id="proxy-answer", list_item_id=expected_list_item_id
-    )
-
-    assert list_item_id == expected_list_item_id
+    assert schema.answer_should_have_list_item_id(answer_id="proxy-answer") is True
 
 
-def test_get_answer_within_list_collector_with_list_item_id(
+def test_answer_should_have_list_item_id_within_list_collector(
     list_collector_variant_schema,
 ):
     schema = QuestionnaireSchema(list_collector_variant_schema)
 
-    expected_list_item_id = "abc123"
-
-    list_item_id = schema.get_list_item_id_for_answer_id(
-        answer_id="answer1", list_item_id=expected_list_item_id
-    )
-
-    assert list_item_id == expected_list_item_id
+    assert schema.answer_should_have_list_item_id(answer_id="answer1") is True
 
 
 def test_get_list_collector_for_list(list_collector_variant_schema):

--- a/tests/app/questionnaire/test_questionnaire_schema.py
+++ b/tests/app/questionnaire/test_questionnaire_schema.py
@@ -312,21 +312,21 @@ def test_answer_should_not_have_list_item_id_without_repeat_or_list_collector(
 ):
     schema = QuestionnaireSchema(question_schema)
 
-    assert schema.answer_should_have_list_item_id(answer_id="answer1") is False
+    assert schema.should_answer_have_list_item_id(answer_id="answer1") is False
 
 
-def test_answer_should_have_list_item_id_within_repeat(section_with_repeating_list):
+def test_should_answer_have_list_item_id_within_repeat(section_with_repeating_list):
     schema = QuestionnaireSchema(section_with_repeating_list)
 
-    assert schema.answer_should_have_list_item_id(answer_id="proxy-answer") is True
+    assert schema.should_answer_have_list_item_id(answer_id="proxy-answer") is True
 
 
-def test_answer_should_have_list_item_id_within_list_collector(
+def test_should_answer_have_list_item_id_within_list_collector(
     list_collector_variant_schema,
 ):
     schema = QuestionnaireSchema(list_collector_variant_schema)
 
-    assert schema.answer_should_have_list_item_id(answer_id="answer1") is True
+    assert schema.should_answer_have_list_item_id(answer_id="answer1") is True
 
 
 def test_get_list_collector_for_list(list_collector_variant_schema):

--- a/tests/app/questionnaire/test_rules.py
+++ b/tests/app/questionnaire/test_rules.py
@@ -820,7 +820,7 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
         )
 
         schema = Mock(get_schema())
-        schema.get_list_item_id_for_answer_id = Mock(return_value=list_item_id)
+        schema.answer_should_have_list_item_id = Mock(return_value=True)
 
         self.assertTrue(
             evaluate_when_rules(
@@ -848,7 +848,7 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
         )
 
         schema = Mock(get_schema())
-        schema.get_list_item_id_for_answer_id = Mock(return_value="123abc")
+        schema.answer_should_have_list_item_id = Mock(return_value=False)
 
         self.assertFalse(
             evaluate_when_rules(

--- a/tests/app/questionnaire/test_rules.py
+++ b/tests/app/questionnaire/test_rules.py
@@ -820,7 +820,7 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
         )
 
         schema = Mock(get_schema())
-        schema.should_answer_have_list_item_id = Mock(return_value=True)
+        schema.is_repeating_answer = Mock(return_value=True)
 
         self.assertTrue(
             evaluate_when_rules(
@@ -848,7 +848,7 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
         )
 
         schema = Mock(get_schema())
-        schema.should_answer_have_list_item_id = Mock(return_value=False)
+        schema.is_repeating_answer = Mock(return_value=False)
 
         self.assertFalse(
             evaluate_when_rules(

--- a/tests/app/questionnaire/test_rules.py
+++ b/tests/app/questionnaire/test_rules.py
@@ -820,7 +820,7 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
         )
 
         schema = Mock(get_schema())
-        schema.answer_should_have_list_item_id = Mock(return_value=True)
+        schema.should_answer_have_list_item_id = Mock(return_value=True)
 
         self.assertTrue(
             evaluate_when_rules(
@@ -848,7 +848,7 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
         )
 
         schema = Mock(get_schema())
-        schema.answer_should_have_list_item_id = Mock(return_value=False)
+        schema.should_answer_have_list_item_id = Mock(return_value=False)
 
         self.assertFalse(
             evaluate_when_rules(

--- a/tests/app/questionnaire/test_value_source_resolver.py
+++ b/tests/app/questionnaire/test_value_source_resolver.py
@@ -228,7 +228,6 @@ def test_answer_source_default_answer(use_default_answer):
 
     value_source_resolver = get_value_source_resolver(
         schema=schema,
-        answer_store=AnswerStore([{"answer_id": f"some-other-answer", "value": "No"}]),
         use_default_answer=use_default_answer,
     )
 

--- a/tests/app/questionnaire/test_value_source_resolver.py
+++ b/tests/app/questionnaire/test_value_source_resolver.py
@@ -40,7 +40,7 @@ def get_value_source_resolver(
     list_item_id: Optional[str] = None,
     routing_path_block_ids: Optional[list] = None,
     use_default_answer=False,
-    escape_answer_value=False,
+    escape_answer_values=False,
 ):
     if not schema:
         schema = get_mock_schema()
@@ -58,7 +58,7 @@ def get_value_source_resolver(
         list_item_id=list_item_id,
         routing_path_block_ids=routing_path_block_ids,
         use_default_answer=use_default_answer,
-        escape_answer_value=escape_answer_value,
+        escape_answer_values=escape_answer_values,
     )
 
 
@@ -411,7 +411,7 @@ def test_answer_value_can_be_escaped(answer_value, escaped_value):
                 }
             ]
         ),
-        escape_answer_value=True,
+        escape_answer_values=True,
     )
     assert (
         value_source_resolver.resolve(
@@ -431,7 +431,7 @@ def test_answer_value_with_selector_can_be_escaped():
                 }
             ]
         ),
-        escape_answer_value=True,
+        escape_answer_values=True,
     )
     assert (
         value_source_resolver.resolve(

--- a/tests/app/questionnaire/test_value_source_resolver.py
+++ b/tests/app/questionnaire/test_value_source_resolver.py
@@ -122,19 +122,9 @@ def test_answer_source_with_list_item_id_no_list_item_selector():
     assert value_source_resolver.resolve(answer_source) == "Yes"
 
 
-def test_answer_source_with_list_item_id_but_answer_not_in_list_collector_or_repeat():
+def test_list_item_id_ignored_if_answer_not_in_list_collector_or_repeat():
     schema = get_mock_schema()
     schema.answer_should_have_list_item_id = Mock(return_value=False)
-
-    value_source_resolver = get_value_source_resolver(
-        schema=schema,
-        answer_store=AnswerStore(
-            [{"answer_id": "some-answer", "list_item_id": "item-1", "value": "Yes"}]
-        ),
-        list_item_id="item-1",
-    )
-
-    assert value_source_resolver.resolve(answer_source) is None
 
     value_source_resolver = get_value_source_resolver(
         schema=schema,

--- a/tests/app/questionnaire/test_value_source_resolver.py
+++ b/tests/app/questionnaire/test_value_source_resolver.py
@@ -1,0 +1,371 @@
+from typing import Optional, Union
+from unittest.mock import Mock
+
+import pytest
+
+from app.data_models import AnswerStore, ListStore
+from app.data_models.answer import Answer
+from app.questionnaire import Location, QuestionnaireSchema
+from app.questionnaire.relationship_location import RelationshipLocation
+from app.questionnaire.value_source_resolver import ValueSourceResolver
+
+answer_source = {"source": "answers", "identifier": "some-answer"}
+answer_source_dict_answer_selector = {
+    **answer_source,
+    "selector": "years",
+}
+answer_source_list_item_selector_location = {
+    **answer_source,
+    "list_item_selector": {"source": "location", "id": "list_item_id"},
+}
+answer_source_list_item_selector_list_first_item = {
+    **answer_source,
+    "list_item_selector": {"source": "list", "id": "some-list", "id_selector": "first"},
+}
+
+metadata_source = {"source": "metadata", "identifier": "some-metadata"}
+
+list_source = {"source": "list", "identifier": "some-list"}
+list_source_id_selector_first = {**list_source, "id_selector": "first"}
+list_source_id_selector_primary_person = {
+    **list_source,
+    "id_selector": "primary_person",
+}
+list_source_id_selector_same_name_items = {
+    **list_source,
+    "id_selector": "same_name_items",
+}
+
+location_source = {"source": "location", "identifier": "list_item_id"}
+
+
+def get_list_items(num: int):
+    return [f"item-{i}" for i in range(1, num + 1)]
+
+
+def get_mock_schema():
+    schema = Mock(
+        QuestionnaireSchema(
+            {
+                "questionnaire_flow": {
+                    "type": "Linear",
+                    "options": {"summary": {"collapsible": False}},
+                }
+            }
+        )
+    )
+    return schema
+
+
+def get_value_source_resolver(
+    schema: QuestionnaireSchema = None,
+    answer_store: AnswerStore = AnswerStore(),
+    list_store: ListStore = ListStore(),
+    metadata: Optional[dict] = None,
+    location: Union[Location, RelationshipLocation] = Location(
+        section_id="test-section", block_id="test-block"
+    ),
+    list_item_id: Optional[str] = None,
+    routing_path_block_ids: Optional[list] = None,
+    use_default_answer=False,
+):
+    if not schema:
+        schema = get_mock_schema()
+        schema.answer_should_have_list_item_id = Mock(return_value=bool(list_item_id))
+
+    if not use_default_answer:
+        schema.get_default_answer = Mock(return_value=None)
+
+    return ValueSourceResolver(
+        answer_store=answer_store,
+        list_store=list_store,
+        metadata=metadata,
+        schema=schema,
+        location=location,
+        list_item_id=list_item_id,
+        routing_path_block_ids=routing_path_block_ids,
+        use_default_answer=use_default_answer,
+    )
+
+
+def test_answer_source():
+    value_source_resolver = get_value_source_resolver(
+        answer_store=AnswerStore([{"answer_id": "some-answer", "value": "Yes"}]),
+    )
+
+    assert value_source_resolver.resolve(answer_source) == "Yes"
+
+
+def test_answer_source_with_dict_answer_selector():
+    value_source_resolver = get_value_source_resolver(
+        answer_store=AnswerStore(
+            [
+                {
+                    "answer_id": "some-answer",
+                    "value": {"years": 1, "months": 10},
+                }
+            ]
+        ),
+    )
+
+    assert value_source_resolver.resolve(answer_source_dict_answer_selector) == 1
+
+
+def test_answer_source_with_list_item_id_no_list_item_selector():
+    value_source_resolver = get_value_source_resolver(
+        answer_store=AnswerStore(
+            [{"answer_id": "some-answer", "list_item_id": "item-1", "value": "Yes"}]
+        ),
+        list_item_id="item-1",
+    )
+
+    assert value_source_resolver.resolve(answer_source) == "Yes"
+
+
+def test_answer_source_with_list_item_id_but_answer_not_in_list_collector_or_repeat():
+    schema = get_mock_schema()
+    schema.answer_should_have_list_item_id = Mock(return_value=False)
+
+    value_source_resolver = get_value_source_resolver(
+        schema=schema,
+        answer_store=AnswerStore(
+            [{"answer_id": "some-answer", "list_item_id": "item-1", "value": "Yes"}]
+        ),
+        list_item_id="item-1",
+    )
+
+    assert value_source_resolver.resolve(answer_source) is None
+
+    value_source_resolver = get_value_source_resolver(
+        schema=schema,
+        answer_store=AnswerStore([{"answer_id": "some-answer", "value": "Yes"}]),
+        list_item_id="item-1",
+    )
+
+    assert value_source_resolver.resolve(answer_source) == "Yes"
+
+
+def test_answer_source_with_list_item_selector_location():
+    value_source_resolver = get_value_source_resolver(
+        answer_store=AnswerStore(
+            [
+                {
+                    "answer_id": "some-answer",
+                    "list_item_id": "item-1",
+                    "value": "Yes",
+                }
+            ]
+        ),
+        location=Location(
+            section_id="some-section", block_id="some-block", list_item_id="item-1"
+        ),
+    )
+
+    assert (
+        value_source_resolver.resolve(answer_source_list_item_selector_location)
+        == "Yes"
+    )
+
+
+def test_answer_source_with_list_item_selector_list_first_item():
+    value_source_resolver = get_value_source_resolver(
+        answer_store=AnswerStore(
+            [
+                {
+                    "answer_id": "some-answer",
+                    "list_item_id": "item-1",
+                    "value": "Yes",
+                }
+            ]
+        ),
+        list_store=ListStore([{"name": "some-list", "items": get_list_items(3)}]),
+    )
+
+    assert (
+        value_source_resolver.resolve(answer_source_list_item_selector_list_first_item)
+        == "Yes"
+    )
+
+
+@pytest.mark.parametrize("is_answer_on_path", [True, False])
+@pytest.mark.parametrize("is_inside_repeat", [True, False])
+def test_answer_source_with_routing_path_block_ids(is_answer_on_path, is_inside_repeat):
+    schema = get_mock_schema()
+    schema.get_block_for_answer_id = Mock(return_value={"id": f"some-block"})
+
+    location = Location(section_id="test-section", block_id="test-block")
+    id_prefix = "some" if is_answer_on_path else "some-other"
+    answer = Answer(answer_id=f"{id_prefix}-answer", value="Yes")
+
+    if is_inside_repeat:
+        location.list_item_id = answer.list_item_id = "item-1"
+        schema.answer_should_have_list_item_id = Mock(return_value=True)
+    else:
+        schema.answer_should_have_list_item_id = Mock(return_value=True)
+
+    value_source_resolver = get_value_source_resolver(
+        schema=schema,
+        answer_store=AnswerStore([answer.to_dict()]),
+        list_store=ListStore([{"name": "some-list", "items": get_list_items(3)}]),
+        location=location,
+        list_item_id=location.list_item_id,
+        routing_path_block_ids=[f"{id_prefix}-block"],
+    )
+
+    expected_result = "Yes" if is_answer_on_path else None
+    assert value_source_resolver.resolve(answer_source) == expected_result
+
+
+@pytest.mark.parametrize("use_default_answer", [True, False])
+def test_answer_source_default_answer(use_default_answer):
+    schema = get_mock_schema()
+    if use_default_answer:
+        schema.get_default_answer = Mock(
+            return_value=Answer(answer_id="some-answer", value="Yes")
+        )
+    else:
+        schema.get_default_answer = Mock(return_value=None)
+
+    value_source_resolver = get_value_source_resolver(
+        schema=schema,
+        answer_store=AnswerStore([{"answer_id": f"some-other-answer", "value": "No"}]),
+        use_default_answer=use_default_answer,
+    )
+
+    expected_result = "Yes" if use_default_answer else None
+    assert value_source_resolver.resolve(answer_source) == expected_result
+
+
+@pytest.mark.parametrize(
+    "metadata_identifier, expected_result",
+    [("region_code", "GB-ENG"), ("language_code", None)],
+)
+def test_metadata_source(metadata_identifier, expected_result):
+    value_source_resolver = get_value_source_resolver(
+        metadata={"region_code": "GB-ENG"},
+    )
+
+    source = {"source": "metadata", "identifier": metadata_identifier}
+    assert value_source_resolver.resolve(source) == expected_result
+
+
+@pytest.mark.parametrize(
+    "list_count",
+    [0, 1, 5, 10],
+)
+def test_list_source(list_count):
+    value_source_resolver = get_value_source_resolver(
+        list_store=ListStore(
+            [{"name": "some-list", "items": get_list_items(list_count)}]
+        ),
+    )
+
+    assert value_source_resolver.resolve(list_source) == list_count
+
+
+def test_list_source_with_id_selector_first():
+    value_source_resolver = get_value_source_resolver(
+        list_store=ListStore([{"name": "some-list", "items": get_list_items(3)}]),
+    )
+
+    assert value_source_resolver.resolve(list_source_id_selector_first) == "item-1"
+
+
+def test_list_source_with_id_selector_same_name_items():
+    value_source_resolver = get_value_source_resolver(
+        list_store=ListStore(
+            [
+                {
+                    "name": "some-list",
+                    "items": get_list_items(5),
+                    "same_name_items": get_list_items(3),
+                }
+            ]
+        ),
+    )
+
+    assert value_source_resolver.resolve(
+        list_source_id_selector_same_name_items
+    ) == get_list_items(3)
+
+
+@pytest.mark.parametrize(
+    "primary_person_list_item_id",
+    ["item-1", "item-2"],
+)
+def test_list_source_id_selector_primary_person(primary_person_list_item_id):
+    value_source_resolver = get_value_source_resolver(
+        list_store=ListStore(
+            [
+                {
+                    "name": "some-list",
+                    "primary_person": primary_person_list_item_id,
+                    "items": get_list_items(3),
+                }
+            ]
+        ),
+    )
+
+    assert (
+        value_source_resolver.resolve(list_source_id_selector_primary_person)
+        == primary_person_list_item_id
+    )
+
+
+def test_location_source():
+    value_source_resolver = get_value_source_resolver(list_item_id="item-1")
+    assert value_source_resolver.resolve(location_source) == "item-1"
+
+
+def test_list_of_sources():
+    value_source_resolver = get_value_source_resolver(
+        answer_store=AnswerStore(
+            [
+                {
+                    "answer_id": "first-name",
+                    "list_item_id": "item-1",
+                    "value": "John",
+                },
+                {
+                    "answer_id": "second-name",
+                    "list_item_id": "item-1",
+                    "value": "Doe",
+                },
+            ]
+        ),
+        list_item_id="item-1",
+    )
+    list_of_sources = [
+        {"source": "answers", "identifier": "first-name"},
+        {"source": "answers", "identifier": "second-name"},
+    ]
+    assert value_source_resolver.resolve(list_of_sources) == ["John", "Doe"]
+
+
+def test_list_of_sources_with_list_values_are_flattened():
+    value_source_resolver = get_value_source_resolver(
+        answer_store=AnswerStore(
+            [
+                {
+                    "answer_id": "primary-hobby",
+                    "list_item_id": "item-1",
+                    "value": "Cricket",
+                },
+                {
+                    "answer_id": "other-hobbies",
+                    "list_item_id": "item-1",
+                    "value": ["Football", "Basketball"],
+                },
+            ]
+        ),
+        list_item_id="item-1",
+    )
+    list_of_sources = [
+        {"source": "answers", "identifier": "primary-hobby"},
+        {"source": "answers", "identifier": "other-hobbies"},
+    ]
+    assert value_source_resolver.resolve(list_of_sources) == [
+        "Cricket",
+        "Football",
+        "Basketball",
+    ]

--- a/tests/app/questionnaire/test_value_source_resolver.py
+++ b/tests/app/questionnaire/test_value_source_resolver.py
@@ -71,7 +71,7 @@ def get_value_source_resolver(
 ):
     if not schema:
         schema = get_mock_schema()
-        schema.answer_should_have_list_item_id = Mock(return_value=bool(list_item_id))
+        schema.should_answer_have_list_item_id = Mock(return_value=bool(list_item_id))
 
     if not use_default_answer:
         schema.get_default_answer = Mock(return_value=None)
@@ -124,7 +124,7 @@ def test_answer_source_with_list_item_id_no_list_item_selector():
 
 def test_list_item_id_ignored_if_answer_not_in_list_collector_or_repeat():
     schema = get_mock_schema()
-    schema.answer_should_have_list_item_id = Mock(return_value=False)
+    schema.should_answer_have_list_item_id = Mock(return_value=False)
 
     value_source_resolver = get_value_source_resolver(
         schema=schema,
@@ -189,9 +189,9 @@ def test_answer_source_with_routing_path_block_ids(is_answer_on_path, is_inside_
 
     if is_inside_repeat:
         location.list_item_id = answer.list_item_id = "item-1"
-        schema.answer_should_have_list_item_id = Mock(return_value=True)
+        schema.should_answer_have_list_item_id = Mock(return_value=True)
     else:
-        schema.answer_should_have_list_item_id = Mock(return_value=True)
+        schema.should_answer_have_list_item_id = Mock(return_value=True)
 
     value_source_resolver = get_value_source_resolver(
         schema=schema,

--- a/tests/app/questionnaire/test_value_source_resolver.py
+++ b/tests/app/questionnaire/test_value_source_resolver.py
@@ -71,7 +71,7 @@ def get_value_source_resolver(
 ):
     if not schema:
         schema = get_mock_schema()
-        schema.should_answer_have_list_item_id = Mock(return_value=bool(list_item_id))
+        schema.is_repeating_answer = Mock(return_value=bool(list_item_id))
 
     if not use_default_answer:
         schema.get_default_answer = Mock(return_value=None)
@@ -124,7 +124,7 @@ def test_answer_source_with_list_item_id_no_list_item_selector():
 
 def test_list_item_id_ignored_if_answer_not_in_list_collector_or_repeat():
     schema = get_mock_schema()
-    schema.should_answer_have_list_item_id = Mock(return_value=False)
+    schema.is_repeating_answer = Mock(return_value=False)
 
     value_source_resolver = get_value_source_resolver(
         schema=schema,
@@ -196,7 +196,7 @@ def test_answer_source_with_routing_path_block_ids(is_answer_on_path, is_inside_
 
     if is_inside_repeat:
         location.list_item_id = answer.list_item_id = "item-1"
-        schema.should_answer_have_list_item_id = Mock(return_value=True)
+        schema.is_repeating_answer = Mock(return_value=True)
     else:
         location.list_item_id = answer.list_item_id = None
 

--- a/tests/app/questionnaire/test_value_source_resolver.py
+++ b/tests/app/questionnaire/test_value_source_resolver.py
@@ -9,35 +9,6 @@ from app.questionnaire import Location, QuestionnaireSchema
 from app.questionnaire.relationship_location import RelationshipLocation
 from app.questionnaire.value_source_resolver import ValueSourceResolver
 
-answer_source = {"source": "answers", "identifier": "some-answer"}
-answer_source_dict_answer_selector = {
-    **answer_source,
-    "selector": "years",
-}
-answer_source_list_item_selector_location = {
-    **answer_source,
-    "list_item_selector": {"source": "location", "id": "list_item_id"},
-}
-answer_source_list_item_selector_list_first_item = {
-    **answer_source,
-    "list_item_selector": {"source": "list", "id": "some-list", "id_selector": "first"},
-}
-
-metadata_source = {"source": "metadata", "identifier": "some-metadata"}
-
-list_source = {"source": "list", "identifier": "some-list"}
-list_source_id_selector_first = {**list_source, "id_selector": "first"}
-list_source_id_selector_primary_person = {
-    **list_source,
-    "id_selector": "primary_person",
-}
-list_source_id_selector_same_name_items = {
-    **list_source,
-    "id_selector": "same_name_items",
-}
-
-location_source = {"source": "location", "identifier": "list_item_id"}
-
 
 def get_list_items(num: int):
     return [f"item-{i}" for i in range(1, num + 1)]
@@ -93,7 +64,12 @@ def test_answer_source():
         answer_store=AnswerStore([{"answer_id": "some-answer", "value": "Yes"}]),
     )
 
-    assert value_source_resolver.resolve(answer_source) == "Yes"
+    assert (
+        value_source_resolver.resolve(
+            {"source": "answers", "identifier": "some-answer"}
+        )
+        == "Yes"
+    )
 
 
 def test_answer_source_with_dict_answer_selector():
@@ -108,7 +84,16 @@ def test_answer_source_with_dict_answer_selector():
         ),
     )
 
-    assert value_source_resolver.resolve(answer_source_dict_answer_selector) == 1
+    assert (
+        value_source_resolver.resolve(
+            {
+                "source": "answers",
+                "identifier": "some-answer",
+                "selector": "years",
+            }
+        )
+        == 1
+    )
 
 
 def test_answer_source_with_list_item_id_no_list_item_selector():
@@ -119,7 +104,12 @@ def test_answer_source_with_list_item_id_no_list_item_selector():
         list_item_id="item-1",
     )
 
-    assert value_source_resolver.resolve(answer_source) == "Yes"
+    assert (
+        value_source_resolver.resolve(
+            {"source": "answers", "identifier": "some-answer"}
+        )
+        == "Yes"
+    )
 
 
 def test_list_item_id_ignored_if_answer_not_in_list_collector_or_repeat():
@@ -132,7 +122,12 @@ def test_list_item_id_ignored_if_answer_not_in_list_collector_or_repeat():
         list_item_id="item-1",
     )
 
-    assert value_source_resolver.resolve(answer_source) == "Yes"
+    assert (
+        value_source_resolver.resolve(
+            {"source": "answers", "identifier": "some-answer"}
+        )
+        == "Yes"
+    )
 
 
 def test_answer_source_with_list_item_selector_location():
@@ -152,7 +147,13 @@ def test_answer_source_with_list_item_selector_location():
     )
 
     assert (
-        value_source_resolver.resolve(answer_source_list_item_selector_location)
+        value_source_resolver.resolve(
+            {
+                "source": "answers",
+                "identifier": "some-answer",
+                "list_item_selector": {"source": "location", "id": "list_item_id"},
+            }
+        )
         == "Yes"
     )
 
@@ -172,7 +173,17 @@ def test_answer_source_with_list_item_selector_list_first_item():
     )
 
     assert (
-        value_source_resolver.resolve(answer_source_list_item_selector_list_first_item)
+        value_source_resolver.resolve(
+            {
+                "source": "answers",
+                "identifier": "some-answer",
+                "list_item_selector": {
+                    "source": "list",
+                    "id": "some-list",
+                    "id_selector": "first",
+                },
+            }
+        )
         == "Yes"
     )
 
@@ -234,7 +245,12 @@ def test_answer_source_default_answer(use_default_answer):
     )
 
     expected_result = "Yes" if use_default_answer else None
-    assert value_source_resolver.resolve(answer_source) == expected_result
+    assert (
+        value_source_resolver.resolve(
+            {"source": "answers", "identifier": "some-answer"}
+        )
+        == expected_result
+    )
 
 
 @pytest.mark.parametrize(
@@ -261,7 +277,10 @@ def test_list_source(list_count):
         ),
     )
 
-    assert value_source_resolver.resolve(list_source) == list_count
+    assert (
+        value_source_resolver.resolve({"source": "list", "identifier": "some-list"})
+        == list_count
+    )
 
 
 def test_list_source_with_id_selector_first():
@@ -269,7 +288,12 @@ def test_list_source_with_id_selector_first():
         list_store=ListStore([{"name": "some-list", "items": get_list_items(3)}]),
     )
 
-    assert value_source_resolver.resolve(list_source_id_selector_first) == "item-1"
+    assert (
+        value_source_resolver.resolve(
+            {"source": "list", "identifier": "some-list", "id_selector": "first"}
+        )
+        == "item-1"
+    )
 
 
 def test_list_source_with_id_selector_same_name_items():
@@ -285,9 +309,16 @@ def test_list_source_with_id_selector_same_name_items():
         ),
     )
 
-    assert value_source_resolver.resolve(
-        list_source_id_selector_same_name_items
-    ) == get_list_items(3)
+    assert (
+        value_source_resolver.resolve(
+            {
+                "source": "list",
+                "identifier": "some-list",
+                "id_selector": "same_name_items",
+            }
+        )
+        == get_list_items(3)
+    )
 
 
 @pytest.mark.parametrize(
@@ -308,14 +339,25 @@ def test_list_source_id_selector_primary_person(primary_person_list_item_id):
     )
 
     assert (
-        value_source_resolver.resolve(list_source_id_selector_primary_person)
+        value_source_resolver.resolve(
+            {
+                "source": "list",
+                "identifier": "some-list",
+                "id_selector": "primary_person",
+            }
+        )
         == primary_person_list_item_id
     )
 
 
 def test_location_source():
     value_source_resolver = get_value_source_resolver(list_item_id="item-1")
-    assert value_source_resolver.resolve(location_source) == "item-1"
+    assert (
+        value_source_resolver.resolve(
+            {"source": "location", "identifier": "list_item_id"}
+        )
+        == "item-1"
+    )
 
 
 def test_list_of_sources():

--- a/tests/app/questionnaire/test_value_source_resolver.py
+++ b/tests/app/questionnaire/test_value_source_resolver.py
@@ -8,7 +8,7 @@ from app.data_models.answer import Answer
 from app.questionnaire import Location, QuestionnaireSchema
 from app.questionnaire.relationship_location import RelationshipLocation
 from app.questionnaire.value_source_resolver import ValueSourceResolver
-from tests.app.libs.test_utils import ESCAPED_CONTENT, HTML_CONTENT
+from tests.app.data_model.test_answer import ESCAPED_CONTENT, HTML_CONTENT
 
 
 def get_list_items(num: int):
@@ -396,7 +396,7 @@ def test_location_source():
     "answer_value, escaped_value",
     [
         (HTML_CONTENT, ESCAPED_CONTENT),
-        ([HTML_CONTENT, 1, HTML_CONTENT], [ESCAPED_CONTENT, 1, ESCAPED_CONTENT]),
+        ([HTML_CONTENT, "some value"], [ESCAPED_CONTENT, "some value"]),
         (1, 1),
         (None, None),
     ],
@@ -418,4 +418,24 @@ def test_answer_value_can_be_escaped(answer_value, escaped_value):
             {"source": "answers", "identifier": "some-answer"}
         )
         == escaped_value
+    )
+
+
+def test_answer_value_with_selector_can_be_escaped():
+    value_source_resolver = get_value_source_resolver(
+        answer_store=AnswerStore(
+            [
+                {
+                    "answer_id": "some-answer",
+                    "value": {"key_1": HTML_CONTENT, "key_2": 1},
+                }
+            ]
+        ),
+        escape_answer_value=True,
+    )
+    assert (
+        value_source_resolver.resolve(
+            {"source": "answers", "identifier": "some-answer", "selector": "key_1"}
+        )
+        == ESCAPED_CONTENT
     )

--- a/tests/app/questionnaire/test_value_source_resolver.py
+++ b/tests/app/questionnaire/test_value_source_resolver.py
@@ -392,60 +392,6 @@ def test_location_source():
     )
 
 
-def test_list_of_sources():
-    value_source_resolver = get_value_source_resolver(
-        answer_store=AnswerStore(
-            [
-                {
-                    "answer_id": "first-name",
-                    "list_item_id": "item-1",
-                    "value": "John",
-                },
-                {
-                    "answer_id": "second-name",
-                    "list_item_id": "item-1",
-                    "value": "Doe",
-                },
-            ]
-        ),
-        list_item_id="item-1",
-    )
-    list_of_sources = [
-        {"source": "answers", "identifier": "first-name"},
-        {"source": "answers", "identifier": "second-name"},
-    ]
-    assert value_source_resolver.resolve(list_of_sources) == ["John", "Doe"]
-
-
-def test_list_of_sources_with_list_values_are_flattened():
-    value_source_resolver = get_value_source_resolver(
-        answer_store=AnswerStore(
-            [
-                {
-                    "answer_id": "primary-hobby",
-                    "list_item_id": "item-1",
-                    "value": "Cricket",
-                },
-                {
-                    "answer_id": "other-hobbies",
-                    "list_item_id": "item-1",
-                    "value": ["Football", "Basketball"],
-                },
-            ]
-        ),
-        list_item_id="item-1",
-    )
-    list_of_sources = [
-        {"source": "answers", "identifier": "primary-hobby"},
-        {"source": "answers", "identifier": "other-hobbies"},
-    ]
-    assert value_source_resolver.resolve(list_of_sources) == [
-        "Cricket",
-        "Football",
-        "Basketball",
-    ]
-
-
 @pytest.mark.parametrize(
     "answer_value, escaped_value",
     [


### PR DESCRIPTION
### What is the context of this PR?

Added a new `ValueSourceResolver` interface since we now need the ability to resolve value sources both in placeholders and the new when rules. Placeholders have been refactored to use this new interface. Field handlers define its own way of resolving value sources which should be removed and replaced with `ValueSourceResolver` as a future piece of work. Field handlers were not refactored in this PR to keep these changes to a minimum and because they require additional work to add support for list stores etc.

For placeholders, values are escaped and for routing we perform operation on unescaped values, therefore I have left it up to the caller to escape the values instead of making it the responsibility of `ValueSourceResolver` as it give the freedom to the caller to escape as they please.

### How to review 
Ensure the changes make sense and placeholders work as expected.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
