### PR TITLE
Use question title as legend

### DIFF
--- a/app/jinja_filters.py
+++ b/app/jinja_filters.py
@@ -198,8 +198,7 @@ def should_wrap_with_fieldset(question):
         question["type"] == "MutuallyExclusive"
         or len(answers) > 1
         or (
-            len(answers) == 1
-            and answers[0]["type"]
+            answers[0]["type"]
             in ["Radio", "Date", "MonthYearDate", "Duration", "Address", "Relationship"]
             and "label" not in answers[0]
         )

--- a/app/jinja_filters.py
+++ b/app/jinja_filters.py
@@ -188,10 +188,21 @@ def setAttributes(dictionary, attributes):
 
 @blueprint.app_template_filter()
 def should_wrap_with_fieldset(question):
-    answers = question["answers"]
+    # Logic for when to wrap with a fieldset comes from
+    # https://ons-design-system.netlify.app/patterns/question/
+    if question["type"] == "DateRange":
+        return False
 
-    if len(answers) > 1 and not any(
-        answer["type"] in {"Date", "MonthYearDate", "Duration"} for answer in answers
+    answers = question["answers"]
+    if (
+        question["type"] == "MutuallyExclusive"
+        or len(answers) > 1
+        or (
+            len(answers) == 1
+            and answers[0]["type"]
+            in ["Radio", "Date", "MonthYearDate", "Duration", "Address", "Relationship"]
+            and "label" not in answers[0]
+        )
     ):
         return True
 

--- a/app/jinja_filters.py
+++ b/app/jinja_filters.py
@@ -194,7 +194,7 @@ def should_wrap_with_fieldset(question):
         return False
 
     answers = question["answers"]
-    if (
+    return (
         question["type"] == "MutuallyExclusive"
         or len(answers) > 1
         or (
@@ -203,10 +203,7 @@ def should_wrap_with_fieldset(question):
             in ["Radio", "Date", "MonthYearDate", "Duration", "Address", "Relationship"]
             and "label" not in answers[0]
         )
-    ):
-        return True
-
-    return False
+    )
 
 
 @blueprint.app_context_processor

--- a/app/translations/messages.pot
+++ b/app/translations/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2021-07-29 12:39+0100\n"
+"POT-Creation-Date: 2021-08-05 08:48+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -67,7 +67,7 @@ msgstr ""
 msgid "Enter a date"
 msgstr ""
 
-#: app/forms/error_messages.py:23 templates/partials/answers/address.html:57
+#: app/forms/error_messages.py:23 templates/partials/answers/address.html:56
 msgid "Enter an address"
 msgstr ""
 
@@ -521,7 +521,7 @@ msgstr ""
 msgid "Give feedback about this service"
 msgstr ""
 
-#: app/views/handlers/feedback.py:128 app/views/handlers/feedback.py:172
+#: app/views/handlers/feedback.py:133 app/views/handlers/feedback.py:172
 msgid "Select what your feedback is about"
 msgstr ""
 
@@ -759,7 +759,7 @@ msgid ""
 "census, enter your email address"
 msgstr ""
 
-#: templates/confirm-email.html:13 templates/partials/answers/address.html:56
+#: templates/confirm-email.html:13 templates/partials/answers/address.html:55
 #: templates/question.html:10
 #, python-format
 msgid "There is a problem with your answer"
@@ -825,7 +825,7 @@ msgid_plural "There are %(num)s problems with your feedback"
 msgstr[0] ""
 msgstr[1] ""
 
-#: templates/feedback.html:41
+#: templates/feedback.html:39
 msgid "Send feedback"
 msgstr ""
 
@@ -833,7 +833,7 @@ msgstr ""
 msgid "If you can’t answer someone else’s questions"
 msgstr ""
 
-#: templates/interstitial.html:23 templates/partials/question.html:27
+#: templates/interstitial.html:23 templates/partials/question.html:25
 msgid "If you can’t answer questions for this person"
 msgstr ""
 
@@ -1181,120 +1181,120 @@ msgid ""
 " of the section</a>"
 msgstr ""
 
-#: templates/partials/question.html:62
+#: templates/partials/question.html:60
 msgid "Selecting this will clear your answer"
 msgstr ""
 
-#: templates/partials/question.html:63
+#: templates/partials/question.html:61
 msgid "cleared"
 msgstr ""
 
-#: templates/partials/question.html:66
+#: templates/partials/question.html:64
 msgid "Selecting this will deselect any selected options"
 msgstr ""
 
-#: templates/partials/question.html:67 templates/partials/question.html:75
+#: templates/partials/question.html:65 templates/partials/question.html:73
 msgid "deselected"
 msgstr ""
 
-#: templates/partials/question.html:71
+#: templates/partials/question.html:69
 msgid "Or"
 msgstr ""
 
-#: templates/partials/answers/address.html:10
+#: templates/partials/answers/address.html:9
 msgid "Address line 1"
 msgstr ""
 
-#: templates/partials/answers/address.html:15
+#: templates/partials/answers/address.html:14
 msgid "Address line 2"
 msgstr ""
 
-#: templates/partials/answers/address.html:19
+#: templates/partials/answers/address.html:18
 msgid "Town or city"
 msgstr ""
 
-#: templates/partials/answers/address.html:23
+#: templates/partials/answers/address.html:22
 msgid "Postcode"
 msgstr ""
 
-#: templates/partials/answers/address.html:34
+#: templates/partials/answers/address.html:33
 msgid "Enter address or postcode and select from results"
 msgstr ""
 
-#: templates/partials/answers/address.html:36
+#: templates/partials/answers/address.html:35
 msgid "Search for an address"
 msgstr ""
 
-#: templates/partials/answers/address.html:37
+#: templates/partials/answers/address.html:36
 msgid "Manually enter address"
 msgstr ""
 
-#: templates/partials/answers/address.html:42
+#: templates/partials/answers/address.html:41
 msgid ""
 "Use up and down keys to navigate suggestions once you’ve typed more than "
 "two characters. Use the enter key to select a suggestion. Touch device "
 "users, explore by touch or with swipe gestures."
 msgstr ""
 
-#: templates/partials/answers/address.html:43
+#: templates/partials/answers/address.html:42
 msgid "You have selected"
 msgstr ""
 
-#: templates/partials/answers/address.html:44
+#: templates/partials/answers/address.html:43
 msgid "Enter 3 or more characters for suggestions."
 msgstr ""
 
-#: templates/partials/answers/address.html:45
+#: templates/partials/answers/address.html:44
 msgid "There is one suggestion available."
 msgstr ""
 
-#: templates/partials/answers/address.html:46
+#: templates/partials/answers/address.html:45
 msgid "There are {n} suggestions available."
 msgstr ""
 
-#: templates/partials/answers/address.html:47
+#: templates/partials/answers/address.html:46
 msgid ""
 "Results have been limited to 10 suggestions. Type more characters to "
 "improve your search"
 msgstr ""
 
-#: templates/partials/answers/address.html:48
+#: templates/partials/answers/address.html:47
 msgid "There are {n} for {x}"
 msgstr ""
 
-#: templates/partials/answers/address.html:49
+#: templates/partials/answers/address.html:48
 msgid "{n} addresses"
 msgstr ""
 
-#: templates/partials/answers/address.html:50
+#: templates/partials/answers/address.html:49
 msgid "Enter more of the address to improve results"
 msgstr ""
 
-#: templates/partials/answers/address.html:51
+#: templates/partials/answers/address.html:50
 msgid "Select an address"
 msgstr ""
 
-#: templates/partials/answers/address.html:52
+#: templates/partials/answers/address.html:51
 msgid "No results found. Try entering a different part of the address"
 msgstr ""
 
-#: templates/partials/answers/address.html:53
+#: templates/partials/answers/address.html:52
 msgid "{n} results found. Enter more of the address to improve results"
 msgstr ""
 
-#: templates/partials/answers/address.html:54
+#: templates/partials/answers/address.html:53
 msgid "Enter more of the address to get results"
 msgstr ""
 
-#: templates/partials/answers/address.html:58
+#: templates/partials/answers/address.html:57
 msgid "Select or manually enter an address"
 msgstr ""
 
-#: templates/partials/answers/address.html:59
+#: templates/partials/answers/address.html:58
 msgid "Sorry, there was a problem loading addresses"
 msgstr ""
 
-#: templates/partials/answers/address.html:60
+#: templates/partials/answers/address.html:59
 msgid "Enter address manually"
 msgstr ""
 
@@ -1302,60 +1302,60 @@ msgstr ""
 msgid "Select all that apply"
 msgstr ""
 
-#: templates/partials/answers/date.html:30
+#: templates/partials/answers/date.html:23
 msgid "Day"
 msgstr ""
 
-#: templates/partials/answers/date.html:45
+#: templates/partials/answers/date.html:38
 msgid "Month"
 msgstr ""
 
-#: templates/partials/answers/date.html:60
+#: templates/partials/answers/date.html:53
 msgid "Year"
 msgstr ""
 
-#: templates/partials/answers/radio.html:14
+#: templates/partials/answers/radio.html:15
 msgid "Clear selection"
 msgstr ""
 
 #: templates/partials/answers/textarea.html:16
-#: templates/partials/answers/textfield.html:46
+#: templates/partials/answers/textfield.html:45
 msgid "You have {x} character remaining"
 msgstr ""
 
 #: templates/partials/answers/textarea.html:17
-#: templates/partials/answers/textfield.html:47
+#: templates/partials/answers/textfield.html:46
 msgid "You have {x} characters remaining"
 msgstr ""
 
-#: templates/partials/answers/textfield.html:26
+#: templates/partials/answers/textfield.html:25
 msgid ""
 "Use up and down keys to navigate suggestions once you've typed more than "
 "two characters. Use the enter key to select a suggestion. Touch device "
 "users, explore by touch or with swipe gestures."
 msgstr ""
 
-#: templates/partials/answers/textfield.html:27
+#: templates/partials/answers/textfield.html:26
 msgid "Continue entering to improve suggestions"
 msgstr ""
 
-#: templates/partials/answers/textfield.html:28
+#: templates/partials/answers/textfield.html:27
 msgid "Suggestions"
 msgstr ""
 
-#: templates/partials/answers/textfield.html:29
+#: templates/partials/answers/textfield.html:28
 msgid "No results found"
 msgstr ""
 
-#: templates/partials/answers/textfield.html:30
+#: templates/partials/answers/textfield.html:29
 msgid "Continue entering to get suggestions"
 msgstr ""
 
-#: templates/partials/answers/textfield.html:44
+#: templates/partials/answers/textfield.html:43
 msgid "{x} character too many"
 msgstr ""
 
-#: templates/partials/answers/textfield.html:45
+#: templates/partials/answers/textfield.html:44
 msgid "{x} characters too many"
 msgstr ""
 

--- a/app/views/handlers/feedback.py
+++ b/app/views/handlers/feedback.py
@@ -125,12 +125,12 @@ class Feedback:
             "type": "General",
             "id": "feedback",
             "title": lazy_gettext("Give feedback about this service"),
-            "label": lazy_gettext("Select what your feedback is about"),
             "answers": [
                 {
                     "type": "Radio",
                     "id": "feedback-type",
                     "mandatory": True,
+                    "label": lazy_gettext("Select what your feedback is about"),
                     "options": [
                         {
                             "label": lazy_gettext("The census questions"),

--- a/templates/feedback.html
+++ b/templates/feedback.html
@@ -30,9 +30,7 @@
   {% endif %}
 
   <h1 class="question__title u-fs-xxl" data-qa="feedback-title">{{ content.question.title }}</h1>
-  <legend class="fieldset__legend">{{ content.question.label}}</legend>
   {%- for answer in question.answers -%}
-    {% set question_title = answer.title %}
     {% include 'partials/answer.html' %}
   {%- endfor -%}
 

--- a/templates/partials/answers/address.html
+++ b/templates/partials/answers/address.html
@@ -4,8 +4,7 @@
 
 {% set config = {
     "id": answer.id,
-    "legend": question.title,
-    "legendClasses": "u-vh",
+    "dontWrap": true,
     "line1": {
         "label": _("Address line 1"),
         "value": address_form.line1._value() | e,

--- a/templates/partials/answers/currency.html
+++ b/templates/partials/answers/currency.html
@@ -19,8 +19,7 @@
   "attributes": {
     "data-qa": "input-text"
   },
-  "legend": question_title,
-  "legendClasses": "u-vh",
+  "dontWrap": true if mutuallyExclusive else false,
   "mutuallyExclusive": mutuallyExclusive,
   "classes": get_width_class_for_number(answer),
   "error": error

--- a/templates/partials/answers/date.html
+++ b/templates/partials/answers/date.html
@@ -4,18 +4,11 @@
 {%- set month_field = form.fields[answer['id']]['month'] -%}
 {%- set year_field = form.fields[answer['id']]['year'] -%}
 
-{% if answer.label %}
-  {% set legend = answer.label %}
-{% else %}
-  {% set legend = question_title %}
-  {% set legendClasses = "u-vh" %}
-{% endif %}
-
 {%- set config = {
   "id": answer.id,
+  "legend": answer.label,
+  "dontWrap": not answer.label,
   "description": answer.description,
-  "legend": legend,
-  "legendClasses": legendClasses,
   "attributes": {
     "data-qa": "widget-date"
   },

--- a/templates/partials/answers/duration.html
+++ b/templates/partials/answers/duration.html
@@ -1,10 +1,8 @@
 {% from "components/duration/_macro.njk" import onsDuration %}
 
 {% set config = {
-  "legend": question_title,
   "id": answer.id,
-  "legendClasses": "u-vh",
-  "label": answer.label,
+  "dontWrap": not answer.label,
   "mutuallyExclusive": mutuallyExclusive,
   "error": error
 } %}
@@ -28,6 +26,12 @@
     "value": months.data if months.data is not none else '',
     "label": _(months.label.text)
   }) %}
+{% endif %}
+
+{% if years and months %}
+  {%- set config = config | setAttribute("legend", answer.label) -%}
+{% else %}
+  {%- set config = config | setAttribute("label", answer.label) -%}
 {% endif %}
 
 {{ onsDuration(config) }}

--- a/templates/partials/answers/mobilenumber.html
+++ b/templates/partials/answers/mobilenumber.html
@@ -17,8 +17,6 @@
   "attributes": {
     "data-qa": "input-text"
   },
-  "legend": question_title,
-  "legendClasses": "u-vh",
   "error": error
 } %}
 

--- a/templates/partials/answers/number.html
+++ b/templates/partials/answers/number.html
@@ -15,8 +15,7 @@
   "attributes": {
     "data-qa": "input-text"
   },
-  "legend": question_title,
-  "legendClasses": "u-vh",
+  "dontWrap": true if mutuallyExclusive else false,
   "mutuallyExclusive": mutuallyExclusive,
   "classes": get_width_class_for_number(answer),
   "error": error

--- a/templates/partials/answers/percentage.html
+++ b/templates/partials/answers/percentage.html
@@ -19,8 +19,7 @@
   "suffix": {
     "title": "%"
   },
-  "legend": question_title,
-  "legendClasses": "u-vh",
+  "dontWrap": true if mutuallyExclusive else false,
   "mutuallyExclusive": mutuallyExclusive,
   "classes": get_width_class_for_number(answer),
   "error": error

--- a/templates/partials/answers/radio.html
+++ b/templates/partials/answers/radio.html
@@ -1,10 +1,11 @@
 {% from "components/radios/_macro.njk" import onsRadios %}
 
+
 {% set config = {
   "id": answer.id,
   "name": answer.id,
-  "legend": question_title,
-  "legendClasses": "u-vh",
+  "legend": answer.label,
+  "dontWrap": not answer.label,
   "radios": map_radio_config(form, answer),
   "error": error
 } %}

--- a/templates/partials/answers/relationship.html
+++ b/templates/partials/answers/relationship.html
@@ -3,8 +3,7 @@
 {{ onsRelationships({
   "id": answer.id,
   "name": answer.id,
-  "legend": question["title"],
-  "legendClasses": "u-vh",
+  "dontWrap": true,
   "playback": answer["playback"],
   "radios": map_relationships_config(form, answer),
   "error": error

--- a/templates/partials/answers/textarea.html
+++ b/templates/partials/answers/textarea.html
@@ -17,8 +17,7 @@
     "charCountPlural": _("You have {x} characters remaining")
   },
   "rows": answer.rows,
-  "legend": question_title,
-  "legendClasses": "u-vh",
+  "dontWrap": true if mutuallyExclusive else false,
   "mutuallyExclusive": mutuallyExclusive,
   "error": error
 }) }}

--- a/templates/partials/answers/textfield.html
+++ b/templates/partials/answers/textfield.html
@@ -15,8 +15,7 @@
   "attributes": {
     "data-qa": "input-text"
   },
-  "legend": question_title,
-  "legendClasses": "u-vh",
+  "dontWrap": true if mutuallyExclusive else false,
   "mutuallyExclusive": mutuallyExclusive,
   "error": error
 } %}

--- a/templates/partials/answers/unit.html
+++ b/templates/partials/answers/unit.html
@@ -21,8 +21,7 @@
   "attributes": {
     "data-qa": "input-text"
   },
-  "legend": question_title,
-  "legendClasses": "u-vh",
+  "dontWrap": true if mutuallyExclusive else false,
   "mutuallyExclusive": mutuallyExclusive,
   "classes": get_width_class_for_number(answer),
   "error": error

--- a/templates/partials/question.html
+++ b/templates/partials/question.html
@@ -14,8 +14,6 @@
 {% set question_instruction = format_paragraphs(question.instruction) %}
 {% set question_error = form.question_errors[question.id] %}
 
-{% set should_wrap_with_fieldset = should_wrap_with_fieldset(question) %}
-
 {%- set question_definition -%}
   {%- if question.definitions -%}
     {%- include 'partials/question-definition.html' -%}
@@ -82,17 +80,7 @@
         {% include 'partials/answer.html' %}
       {%- endfor -%}
     {%- endset -%}
-
-    {%- if should_wrap_with_fieldset -%}
-      {%- call onsFieldset({
-        "legend": question_title,
-        "legendClasses": "u-vh"
-      }) -%}
-        {{ answers }}
-      {%- endcall -%}
-    {%- else -%}
-      {{ answers }}
-    {%- endif -%}
+    {{ answers }}
   {%- endif -%}
 {% endset %}
 
@@ -100,7 +88,8 @@
   "id": question.id,
   "title": title,
   "description": question_description,
-  "instruction": question_instruction
+  "instruction": question_instruction,
+  "legendIsQuestionTitle": should_wrap_with_fieldset(question)
 }) %}
   {%- if content.list -%}
     {% set list = content.list %}

--- a/tests/app/test_jinja_filters.py
+++ b/tests/app/test_jinja_filters.py
@@ -21,6 +21,7 @@ from app.jinja_filters import (
     get_width_class_for_number,
     map_list_collector_config,
     map_summary_item_config,
+    should_wrap_with_fieldset,
     strip_tags,
 )
 from tests.app.app_context_test_case import AppContextTestCase
@@ -205,6 +206,48 @@ class TestJinjaFilters(AppContextTestCase):  # pylint: disable=too-many-public-m
     def test_get_width_class_for_number_large_number(self):
         answer = {"maximum": {"value": 123456789012345678901}}
         self.assertIsNone(get_width_class_for_number(answer))
+
+    def test_should_wrap_with_fieldset_daterange(self):
+        question = {"type": "DateRange"}
+        self.assertFalse(should_wrap_with_fieldset(question))
+
+    def test_should_wrap_with_fieldset_mutually_exclusive(self):
+        question = {"type": "MutuallyExclusive", "answers": []}
+        self.assertTrue(should_wrap_with_fieldset(question))
+
+    def test_should_wrap_with_fieldset_multiple_answers(self):
+        question = {
+            "type": "General",
+            "answers": [{"type": "TextField"}, {"type": "TextField"}],
+        }
+        self.assertTrue(should_wrap_with_fieldset(question))
+
+    def test_should_wrap_with_fieldset_single_answer(self):
+        for answer_type in [
+            "Radio",
+            "Date",
+            "MonthYearDate",
+            "Duration",
+            "Address",
+            "Relationship",
+        ]:
+            question = {"type": "General", "answers": [{"type": answer_type}]}
+            self.assertTrue(should_wrap_with_fieldset(question))
+
+    def test_should_wrap_with_fieldset_single_answer_with_label(self):
+        for answer_type in [
+            "Radio",
+            "Date",
+            "MonthYearDate",
+            "Duration",
+            "Address",
+            "Relationship",
+        ]:
+            question = {
+                "type": "General",
+                "answers": [{"type": answer_type, "label": "Label"}],
+            }
+            self.assertFalse(should_wrap_with_fieldset(question))
 
 
 @pytest.fixture

--- a/tests/functional/base_pages/feedback.page.js
+++ b/tests/functional/base_pages/feedback.page.js
@@ -9,6 +9,18 @@ class FeedbackPage extends FeedbackBasePage {
     return "#feedback-type";
   }
 
+  feedbackTypeCensusQuestions() {
+    return "#feedback-type-0";
+  }
+
+  feedbackTypePageDesignAndStructure() {
+    return "#feedback-type-1";
+  }
+
+  feedbackTypeGeneralFeedback() {
+    return "#feedback-type-2";
+  }
+
   feedbackText() {
     return "#feedback-text";
   }

--- a/tests/functional/spec/dates.spec.js
+++ b/tests/functional/spec/dates.spec.js
@@ -10,12 +10,11 @@ describe("Date checks", () => {
     browser.openQuestionnaire("test_dates.json");
   });
 
-  it("Given an answer label is provided for a date question when the question page is loaded then the label should be displayed ", () => {
+  it("Given an answer label is provided for a date question then the label should be displayed ", () => {
     expect($(DateRangePage.legend()).getText()).to.contain("Period from");
-    expect($(DateMonthYearPage.legend()).getAttribute("class")).not.to.contain("u-vh");
   });
 
-  it("Given an answer label is not provided for a date question when the question page is loaded then the question title should be used as a label but not displayed ", () => {
+  it("Given an answer label is not provided for a date question then the question title should be used within the legend ", () => {
     $(DateRangePage.dateRangeFromday()).setValue(1);
     $(DateRangePage.dateRangeFrommonth()).setValue(1);
     $(DateRangePage.dateRangeFromyear()).setValue(1901);
@@ -27,7 +26,6 @@ describe("Date checks", () => {
     $(DateRangePage.submit()).click();
 
     expect($(DateMonthYearPage.legend()).getText()).to.contain("Date with month and year");
-    expect($(DateMonthYearPage.legend()).getAttribute("class")).to.contain("u-vh");
   });
 
   it("Given the test_dates survey is selected when dates are entered then the summary screen shows the dates entered formatted", () => {

--- a/tests/functional/spec/feedback.spec.js
+++ b/tests/functional/spec/feedback.spec.js
@@ -33,8 +33,8 @@ describe("Feedback", () => {
 
     it("When I enter valid feedback, Then I can submit the feedback page and get confirmation that the feedback has been sent", () => {
       browser.url(FeedbackPage.url());
-      $(FeedbackPage.feedbackType()).click();
-      $(FeedbackPage.feedbackText()).setValue("The census questions");
+      $(FeedbackPage.feedbackTypeGeneralFeedback()).click();
+      $(FeedbackPage.feedbackText()).setValue("Well done!");
       $(FeedbackPage.submit()).click();
       expect(browser.getUrl()).to.contain(FeedbackSentPage.pageName);
       expect($(FeedbackSentPage.feedbackThankYouText()).getText()).to.contain("Thank you for your feedback");
@@ -42,8 +42,8 @@ describe("Feedback", () => {
 
     it("When I click the done button on the feedback sent page, Then I am taken to the thank you page", () => {
       browser.url(FeedbackPage.url());
-      $(FeedbackPage.feedbackType()).click();
-      $(FeedbackPage.feedbackText()).setValue("The census questions");
+      $(FeedbackPage.feedbackTypeGeneralFeedback()).click();
+      $(FeedbackPage.feedbackText()).setValue("Well done!");
       $(FeedbackPage.submit()).click();
       $(FeedbackSentPage.doneButton()).click();
       expect(browser.getUrl()).to.contain("thank-you");


### PR DESCRIPTION
### What is the context of this PR?
The design system components now have a `legendIsQuestionTitle` that removes the need for duplicating the question title (visually hidden) into the answer legend. The rules for when this apply are documented at https://ons-design-system.netlify.app/patterns/question/.

This pull request implements the logic for everything except `Checkbox` answers. `Checkbox` answers don't allow for defining the `legend` at the schema level - we use the `label` schema property to populate the `checkboxesLabel` in the design system macro. This is being looked at by the design system team, and will likely require a new schema property to allow both a label and some kind of instruction (e.g. "Select all that apply").

### How to review 
- Review the changes and use the appropriate test schemas to test
- The question title should not appear twice (the second visually hidden) in the HTML for:
  - `Radio`, `Date`, `MonthYearDate`, `Duration`, `Address` or `Relationship` answers 
  - mutually exclusive questions
  - questions with more than one answer

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
