### PR TITLE
Define answer labels when using multiple answers

### DIFF
--- a/scripts/run_validator.sh
+++ b/scripts/run_validator.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-tag=latest
+tag=validate-answer-label-when-multiple
 docker pull onsdigital/eq-questionnaire-validator:$tag
 docker run -d -p 5001:5000 "onsdigital/eq-questionnaire-validator:$tag"

--- a/test_schemas/en/test_custom_question_summary.json
+++ b/test_schemas/en/test_custom_question_summary.json
@@ -132,6 +132,7 @@
                                     {
                                         "id": "single-checkbox-answer",
                                         "mandatory": false,
+                                        "label": "Confirmation",
                                         "options": [
                                             {
                                                 "label": "This age is an estimate",


### PR DESCRIPTION
### What is the context of this PR?
Ensure schemas that uses multiple answers define an answer label. The `MutuallyExclusive` question type are allowed to not define a label.

### How to review 
Ensure schemas are passing based on changed from https://github.com/ONSdigital/eq-questionnaire-validator/pull/104

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
