### PR TITLE
Update submitted_at to timestamp

### DIFF
--- a/app/data_models/app_models.py
+++ b/app/data_models/app_models.py
@@ -57,7 +57,7 @@ class QuestionnaireStateSchema(Schema, DateTimeSchemaMixin):
     user_id = fields.Str()
     state_data = fields.Str()
     version = fields.Integer()
-    submitted_at = fields.DateTime(allow_none=True)
+    submitted_at = Timestamp(allow_none=True)
 
     @post_load
     def make_model(self, data, **kwargs):

--- a/app/views/handlers/submission.py
+++ b/app/views/handlers/submission.py
@@ -22,7 +22,7 @@ class SubmissionHandler:
 
     @cached_property
     def submitted_at(self):
-        return datetime.now(timezone.utc)
+        return datetime.now(timezone.utc).replace(microsecond=0)
 
     def submit_questionnaire(self):
         payload = self.get_payload()

--- a/tests/app/storage/test_encrypted_questionnaire_storage.py
+++ b/tests/app/storage/test_encrypted_questionnaire_storage.py
@@ -42,7 +42,7 @@ class TestEncryptedQuestionnaireStorage(AppContextTestCase):
         )
 
     def test_store_and_get_with_submitted_at(self):
-        now = datetime.now(timezone.utc)
+        now = datetime.now(timezone.utc).replace(microsecond=0)
         encrypted = EncryptedQuestionnaireStorage(
             user_id="1", user_ik="2", pepper="pepper"
         )


### PR DESCRIPTION
### What is the context of this PR?
After issues with purging questionnaire state using datetime this PR changes submitted_at to a timestamp. As our current timestamp doesn't use milliseconds and submitted_at is also included in the payload it was decided to remove  the milliseconds on submission.py

### How to review 
Check the change works, locally or on GCP if you like (I did do both)

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
