### PR TITLE
Use schema defined post submission guidance on thank you page

### DIFF
--- a/app/views/contexts/thank_you_context.py
+++ b/app/views/contexts/thank_you_context.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Mapping
+from typing import Mapping, Optional
 
 from flask import url_for
 from flask_babel import lazy_gettext
@@ -12,7 +12,10 @@ from app.views.contexts.submission_metadata_context import (
 
 
 def build_thank_you_context(
-    session_data: SessionData, submitted_at: datetime, survey_type: str
+    session_data: SessionData,
+    submitted_at: datetime,
+    survey_type: str,
+    guidance_content: Optional[dict] = None,
 ) -> Mapping:
 
     if survey_type == "social":
@@ -32,6 +35,7 @@ def build_thank_you_context(
         "hide_sign_out_button": True,
         "submission_text": submission_text,
         "metadata": metadata,
+        "guidance": guidance_content,
     }
 
 

--- a/app/views/handlers/thank_you.py
+++ b/app/views/handlers/thank_you.py
@@ -52,8 +52,14 @@ class ThankYou:
 
     def get_context(self):
         if not self._is_census_theme:
+            guidance_content = self._schema.json.get("post_submission", {}).get(
+                "guidance"
+            )
             return build_thank_you_context(
-                self._session_store.session_data, self._submitted_at, get_survey_type()
+                self._session_store.session_data,
+                self._submitted_at,
+                get_survey_type(),
+                guidance_content,
             )
 
         confirmation_email_form = (

--- a/scripts/run_validator.sh
+++ b/scripts/run_validator.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-tag=add-post-submission-guidance-property
+tag=latest
 docker pull onsdigital/eq-questionnaire-validator:$tag
 docker run -d -p 5001:5000 "onsdigital/eq-questionnaire-validator:$tag"

--- a/scripts/run_validator.sh
+++ b/scripts/run_validator.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-tag=latest
+tag=add-post-submission-guidance-property
 docker pull onsdigital/eq-questionnaire-validator:$tag
 docker run -d -p 5001:5000 "onsdigital/eq-questionnaire-validator:$tag"

--- a/templates/thank-you.html
+++ b/templates/thank-you.html
@@ -22,8 +22,14 @@
       {{ onsMetadata(content.metadata)}}
   {% endcall %}
 
-  <p class="u-mb-s">{{ _("Your answers will be processed in the next few weeks.") }}
+  {% if content.guidance %}
+    {% set contents = content.guidance.contents %}
+    {% include 'partials/contents.html' %}
+  {% else %}
+    <p class="u-mb-s">{{ _("Your answers will be processed in the next few weeks.") }}
     {{ _("We may contact you to query your answers via phone or secure message.") }}</p>
-  <p class="u-mb-s">{{ _("For more information on how we use this data.") }}<br>
+    <p class="u-mb-s">{{ _("For more information on how we use this data.") }}<br>
     <a href="https://www.ons.gov.uk/surveys">https://www.ons.gov.uk/surveys</a></p>
+  {% endif %}
+
 {% endblock %}

--- a/test_schemas/en/test_thank_you.json
+++ b/test_schemas/en/test_thank_you.json
@@ -1,0 +1,82 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "language": "en",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.3",
+    "survey_id": "001",
+    "title": "Test Thank You",
+    "theme": "default",
+    "description": "A questionnaire to test post submission params",
+    "metadata": [
+        {
+            "name": "user_id",
+            "type": "string"
+        },
+        {
+            "name": "period_id",
+            "type": "string"
+        },
+        {
+            "name": "ru_name",
+            "type": "string"
+        }
+    ],
+    "post_submission": {
+        "guidance": {
+            "contents": [
+                {
+                    "description": "This survey was important."
+                },
+                {
+                    "description": "<a href=''>Important link</a>"
+                }
+            ]
+        }
+    },
+    "questionnaire_flow": {
+        "type": "Linear",
+        "options": {
+            "summary": {
+                "collapsible": false
+            }
+        }
+    },
+    "sections": [
+        {
+            "id": "section",
+            "groups": [
+                {
+                    "blocks": [
+                        {
+                            "id": "did-you-know",
+                            "question": {
+                                "answers": [
+                                    {
+                                        "id": "answer",
+                                        "mandatory": false,
+                                        "options": [
+                                            {
+                                                "label": "Yes",
+                                                "value": "Yes"
+                                            },
+                                            {
+                                                "label": "No",
+                                                "value": "No"
+                                            }
+                                        ],
+                                        "type": "Radio"
+                                    }
+                                ],
+                                "id": "question",
+                                "title": "Did you know this schema is testing post submission params?",
+                                "type": "General"
+                            },
+                            "type": "Question"
+                        }
+                    ],
+                    "id": "group"
+                }
+            ]
+        }
+    ]
+}

--- a/tests/app/views/contexts/test_thank_you_context.py
+++ b/tests/app/views/contexts/test_thank_you_context.py
@@ -65,3 +65,13 @@ def test_default_survey_context_with_trad_as(fake_session_data, app: Flask):
             == "Your answers have been submitted for <span>ESSENTIAL ENTERPRISE LTD</span> (123)."
         )
         assert len(context["metadata"]["itemsList"]) == 2
+
+
+def test_custom_guidance(fake_session_data, app: Flask):
+    with app.app_context():
+        custom_guidance = {"contents": [{"description": "Custom guidance"}]}
+        context = build_thank_you_context(
+            fake_session_data, SUBMITTED_AT, SURVEY_TYPE_DEFAULT, custom_guidance
+        )
+
+        assert context["guidance"] == custom_guidance

--- a/tests/integration/routes/test_thank_you.py
+++ b/tests/integration/routes/test_thank_you.py
@@ -74,3 +74,20 @@ class TestThankYou(IntegrationTestCase):
 
         for output in logs.output:
             self.assertNotIn("questionnaire request", output)
+
+    def test_default_guidance(self):
+        self.launchSurvey("test_textfield")
+        self.post({"name-answer": "Adam"})
+        self.post()
+
+        self.assertInUrl("thank-you")
+        self.assertInBody("Your answers will be processed in the next few weeks.")
+
+    def test_custom_guidance(self):
+        self.launchSurvey("test_thank_you")
+        self.post({"answer": "Yes"})
+        self.post()
+
+        self.assertInUrl("thank-you")
+        self.assertInBody("This survey was important.")
+        self.assertInBody('<a href="">Important link</a>')


### PR DESCRIPTION
### What is the context of this PR?
Uses the new `post_submission.guidance` schema property to override thank you page guidance.

### How to review 
- Use the new `test_thank_you` schema to verify the new functionality
- Use another default theme survey to verify the existing runner default guidance still works

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
