### PR TITLE
Fix cdn path for design system assets

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -47,7 +47,7 @@ def utcoffset_or_fail(date_value, key):
 
 DATASTORE_USE_GRPC = parse_mode(os.getenv("DATASTORE_USE_GRPC", "True"))
 CDN_URL = os.getenv("CDN_URL", "https://cdn.eq.gcp.onsdigital.uk")
-CDN_ASSETS_PATH = os.getenv("CDN_ASSETS_PATH", "/sdc/design-system")
+CDN_ASSETS_PATH = os.getenv("CDN_ASSETS_PATH", "/design-system")
 EQ_MINIMIZE_ASSETS = parse_mode(os.getenv("EQ_MINIMIZE_ASSETS", "True"))
 # max request payload size in bytes
 MAX_CONTENT_LENGTH = int(os.getenv("EQ_MAX_HTTP_POST_CONTENT_LENGTH", "65536"))


### PR DESCRIPTION
### What is the context of this PR?
This fixes incorrect cdn assets path when environmental variable from `.development.env` file is not used and settings.py fallback option is picked instead.

### How to review 
Check if assets are pulled from cdn when not using environmental variable (eg. using local runner instance).

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
