### PR TITLE
Add print button to the view submitted response page

### DIFF
--- a/templates/view-submitted-response.html
+++ b/templates/view-submitted-response.html
@@ -34,14 +34,14 @@
         "type": 'button',
         "text": 'Print answers',
         "buttonStyle": "print",
+        "classes": "btn--small",
         "attributes": {
           "data-qa": "btn-print"
         }
       })
     }}
-    <br><br>
     {% block summary %}
-      <div class="u-mb-m">
+      <div class="u-mt-l">
         {% include 'partials/summary/summary.html' %}
       </div>
     {% endblock summary %}

--- a/templates/view-submitted-response.html
+++ b/templates/view-submitted-response.html
@@ -41,7 +41,7 @@
       })
     }}
     {% block summary %}
-      <div class="u-mt-l">
+      <div class="u-mt-l u-mb-l">
         {% include 'partials/summary/summary.html' %}
       </div>
     {% endblock summary %}

--- a/templates/view-submitted-response.html
+++ b/templates/view-submitted-response.html
@@ -29,6 +29,17 @@
   </h1>
   {{ onsMetadata(content.metadata)}}
   {% if not content.view_submitted_response.expired %}
+    {{
+      onsButton({
+        "type": 'button',
+        "text": 'Print answers',
+        "buttonStyle": "print",
+        "attributes": {
+          "data-qa": "btn-print"
+        }
+      })
+    }}
+    <br><br>
     {% block summary %}
       <div class="u-mb-m">
         {% include 'partials/summary/summary.html' %}

--- a/tests/functional/base_pages/view_submitted_response_base.page.js
+++ b/tests/functional/base_pages/view_submitted_response_base.page.js
@@ -12,6 +12,10 @@ class ViewSubmittedResponseBasePage extends BasePage {
   metadataValue(number = 1) {
     return `.metadata > dd:nth-of-type(${number})`;
   }
+
+  printButton() {
+    return '[data-qa="btn-print"]';
+  }
 }
 
 export default ViewSubmittedResponseBasePage;

--- a/tests/functional/spec/features/view_submitted_response/view_submitted_response.js
+++ b/tests/functional/spec/features/view_submitted_response/view_submitted_response.js
@@ -15,7 +15,7 @@ describe("View Submitted Response", () => {
     $(AddressBlockPage.submit()).click();
     $(SubmitPage.submit()).click();
     browser.url("/submitted/view-response");
-    expect($(ViewSubmittedResponsePage.printButton()).getText()).to.equal("Print answers");
+    expect($(ViewSubmittedResponsePage.printButton()).isDisplayed()).to.be.true;
     expect($(ViewSubmittedResponsePage.heading()).getText()).to.equal("Answers submitted for Apple.");
     expect($(ViewSubmittedResponsePage.metadataTerm(1)).getText()).to.equal("Submitted on:");
     expect($(ViewSubmittedResponsePage.metadataTerm(2)).getText()).to.equal("Submission reference:");

--- a/tests/functional/spec/features/view_submitted_response/view_submitted_response.js
+++ b/tests/functional/spec/features/view_submitted_response/view_submitted_response.js
@@ -15,6 +15,7 @@ describe("View Submitted Response", () => {
     $(AddressBlockPage.submit()).click();
     $(SubmitPage.submit()).click();
     browser.url("/submitted/view-response");
+    expect($(ViewSubmittedResponsePage.printButton()).getText()).to.equal("Print answers");
     expect($(ViewSubmittedResponsePage.heading()).getText()).to.equal("Answers submitted for Apple.");
     expect($(ViewSubmittedResponsePage.metadataTerm(1)).getText()).to.equal("Submitted on:");
     expect($(ViewSubmittedResponsePage.metadataTerm(2)).getText()).to.equal("Submission reference:");


### PR DESCRIPTION
### What is the context of this PR?

Adds a `Print answers` button to the `view-submitted-response` page.

### How to review 

Use the `test_view_submitted_response` schema to test this change

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
