### PR TITLE
Add Type hinting to placeholders and remove default stores

### DIFF
--- a/app/questionnaire/placeholder_parser.py
+++ b/app/questionnaire/placeholder_parser.py
@@ -1,5 +1,4 @@
-from decimal import Decimal
-from typing import Any, Mapping, Optional, Sequence, Union
+from typing import Any, Mapping, Optional, Sequence
 
 from werkzeug.datastructures import ImmutableDict
 
@@ -30,11 +29,11 @@ class PlaceholderParser:
         location: Location = None,
     ):
 
-        self._schema = schema
         self._answer_store = answer_store
-        self._metadata = metadata
-        self._list_item_id = list_item_id
         self._list_store = list_store
+        self._metadata = metadata
+        self._schema = schema
+        self._list_item_id = list_item_id
         self._location = location
         self._transformer = PlaceholderTransforms(language)
         self._placeholder_map: dict[str, Any] = {}
@@ -98,7 +97,7 @@ class PlaceholderParser:
     def _resolve_value_source_list(
         self, value_source_list: list[dict]
     ) -> Optional[ValueSourceTypes]:
-        values: list[Union[None, str, int, Decimal]] = []
+        values: list[ValueSourceTypes] = []
         for value_source in value_source_list:
             value = self._value_source_resolver.resolve(value_source)
             if isinstance(value, list):

--- a/app/questionnaire/placeholder_parser.py
+++ b/app/questionnaire/placeholder_parser.py
@@ -1,4 +1,4 @@
-from typing import Any, Mapping, Optional, Sequence
+from typing import Any, Mapping, Optional, Sequence, Union
 
 from werkzeug.datastructures import ImmutableDict
 
@@ -7,6 +7,7 @@ from app.data_models.list_store import ListStore
 from app.questionnaire import Location, QuestionnaireSchema
 from app.questionnaire.placeholder_transforms import PlaceholderTransforms
 from app.questionnaire.value_source_resolver import (
+    ValueSourceEscapedTypes,
     ValueSourceResolver,
     ValueSourceTypes,
 )
@@ -36,7 +37,9 @@ class PlaceholderParser:
         self._list_item_id = list_item_id
         self._location = location
         self._transformer = PlaceholderTransforms(language)
-        self._placeholder_map: dict[str, str] = {}
+        self._placeholder_map: dict[
+            str, Union[ValueSourceEscapedTypes, ValueSourceTypes, None]
+        ] = {}
 
         self._value_source_resolver = ValueSourceResolver(
             answer_store=self._answer_store,
@@ -57,7 +60,9 @@ class PlaceholderParser:
                 ] = self._parse_placeholder(placeholder)
         return self._placeholder_map
 
-    def _parse_placeholder(self, placeholder: Mapping) -> Any:
+    def _parse_placeholder(
+        self, placeholder: Mapping
+    ) -> Union[ValueSourceEscapedTypes, ValueSourceTypes, None]:
         try:
             return self._parse_transforms(placeholder["transforms"])
         except KeyError:

--- a/app/questionnaire/placeholder_parser.py
+++ b/app/questionnaire/placeholder_parser.py
@@ -67,7 +67,7 @@ class PlaceholderParser:
 
     def _parse_placeholder(
         self, placeholder: Mapping
-    ) -> Union[ValueSourceEscapedTypes, ValueSourceTypes]:
+    ) -> Union[ValueSourceEscapedTypes, ValueSourceTypes, TransformedValueTypes]:
         try:
             return self._parse_transforms(placeholder["transforms"])
         except KeyError:

--- a/app/questionnaire/placeholder_parser.py
+++ b/app/questionnaire/placeholder_parser.py
@@ -52,7 +52,9 @@ class PlaceholderParser:
             escape_answer_values=True,
         )
 
-    def __call__(self, placeholder_list: Sequence[Mapping]) -> Mapping:
+    def __call__(
+        self, placeholder_list: Sequence[Mapping]
+    ) -> dict[str, Union[ValueSourceEscapedTypes, ValueSourceTypes, None]]:
         placeholder_list = QuestionnaireSchema.get_mutable_deepcopy(placeholder_list)
         for placeholder in placeholder_list:
             if placeholder["placeholder"] not in self._placeholder_map:

--- a/app/questionnaire/placeholder_parser.py
+++ b/app/questionnaire/placeholder_parser.py
@@ -1,5 +1,5 @@
 from decimal import Decimal
-from typing import Any, Mapping, Sequence, Union
+from typing import Any, Mapping, Optional, Sequence, Union
 
 from werkzeug.datastructures import ImmutableDict
 
@@ -12,6 +12,8 @@ from app.questionnaire.value_source_resolver import (
     ValueSourceResolver,
     ValueSourceTypes,
 )
+
+TransformedValueTypes = Union[None, str, int, Decimal, bool]
 
 
 class PlaceholderParser:
@@ -27,7 +29,7 @@ class PlaceholderParser:
         list_store: ListStore,
         metadata: ImmutableDict,
         schema: QuestionnaireSchema,
-        list_item_id: Union[str, None] = None,
+        list_item_id: Optional[str] = None,
         location: Location = None,
     ):
 
@@ -54,7 +56,7 @@ class PlaceholderParser:
 
     def __call__(
         self, placeholder_list: Sequence[Mapping]
-    ) -> dict[str, Union[ValueSourceEscapedTypes, ValueSourceTypes, None]]:
+    ) -> dict[str, Union[ValueSourceEscapedTypes, ValueSourceTypes]]:
         placeholder_list = QuestionnaireSchema.get_mutable_deepcopy(placeholder_list)
         for placeholder in placeholder_list:
             if placeholder["placeholder"] not in self._placeholder_map:
@@ -65,7 +67,7 @@ class PlaceholderParser:
 
     def _parse_placeholder(
         self, placeholder: Mapping
-    ) -> Union[ValueSourceEscapedTypes, ValueSourceTypes, None]:
+    ) -> Union[ValueSourceEscapedTypes, ValueSourceTypes]:
         try:
             return self._parse_transforms(placeholder["transforms"])
         except KeyError:
@@ -73,15 +75,12 @@ class PlaceholderParser:
 
     def _parse_transforms(
         self, transform_list: Sequence[Mapping]
-    ) -> Union[ValueSourceTypes, None]:
+    ) -> Optional[ValueSourceTypes]:
         transformed_value: Union[
             list[ValueSourceTypes],
             ValueSourceEscapedTypes,
             ValueSourceTypes,
-            None,
-            str,
-            int,
-            Decimal,
+            TransformedValueTypes,
         ] = None
 
         for transform in transform_list:

--- a/app/questionnaire/placeholder_parser.py
+++ b/app/questionnaire/placeholder_parser.py
@@ -1,5 +1,5 @@
 from decimal import Decimal
-from typing import Any, Mapping, Optional, Sequence, Union
+from typing import Any, Mapping, MutableMapping, Optional, Sequence, Union
 
 from werkzeug.datastructures import ImmutableDict
 
@@ -40,7 +40,7 @@ class PlaceholderParser:
         self._list_item_id = list_item_id
         self._location = location
         self._transformer = PlaceholderTransforms(language)
-        self._placeholder_map: dict[
+        self._placeholder_map: MutableMapping[
             str, Union[ValueSourceEscapedTypes, ValueSourceTypes, None]
         ] = {}
 
@@ -56,7 +56,7 @@ class PlaceholderParser:
 
     def __call__(
         self, placeholder_list: Sequence[Mapping]
-    ) -> dict[str, Union[ValueSourceEscapedTypes, ValueSourceTypes]]:
+    ) -> MutableMapping[str, Union[ValueSourceEscapedTypes, ValueSourceTypes]]:
         placeholder_list = QuestionnaireSchema.get_mutable_deepcopy(placeholder_list)
         for placeholder in placeholder_list:
             if placeholder["placeholder"] not in self._placeholder_map:
@@ -84,7 +84,7 @@ class PlaceholderParser:
         ] = None
 
         for transform in transform_list:
-            transform_args: dict[str, Any] = {}
+            transform_args: MutableMapping[str, Any] = {}
 
             for arg_key, arg_value in transform["arguments"].items():
                 if isinstance(arg_value, list):

--- a/app/questionnaire/placeholder_parser.py
+++ b/app/questionnaire/placeholder_parser.py
@@ -36,7 +36,7 @@ class PlaceholderParser:
         self._list_item_id = list_item_id
         self._location = location
         self._transformer = PlaceholderTransforms(language)
-        self._placeholder_map: dict[str, Any] = {}
+        self._placeholder_map: dict[str, str] = {}
 
         self._value_source_resolver = ValueSourceResolver(
             answer_store=self._answer_store,

--- a/app/questionnaire/placeholder_parser.py
+++ b/app/questionnaire/placeholder_parser.py
@@ -1,4 +1,5 @@
-from typing import Any, Mapping, Optional, Sequence, Union
+from decimal import Decimal
+from typing import Any, Mapping, Sequence, Union
 
 from werkzeug.datastructures import ImmutableDict
 
@@ -26,7 +27,7 @@ class PlaceholderParser:
         list_store: ListStore,
         metadata: ImmutableDict,
         schema: QuestionnaireSchema,
-        list_item_id: Optional[str] = None,
+        list_item_id: Union[str, None] = None,
         location: Location = None,
     ):
 
@@ -70,8 +71,16 @@ class PlaceholderParser:
 
     def _parse_transforms(
         self, transform_list: Sequence[Mapping]
-    ) -> Optional[ValueSourceTypes]:
-        transformed_value = None
+    ) -> Union[ValueSourceTypes, None]:
+        transformed_value: Union[
+            list[ValueSourceTypes],
+            ValueSourceEscapedTypes,
+            ValueSourceTypes,
+            None,
+            str,
+            int,
+            Decimal,
+        ] = None
 
         for transform in transform_list:
             transform_args: dict[str, Any] = {}
@@ -101,7 +110,7 @@ class PlaceholderParser:
 
     def _resolve_value_source_list(
         self, value_source_list: list[dict]
-    ) -> Optional[ValueSourceTypes]:
+    ) -> list[ValueSourceTypes]:
         values: list[ValueSourceTypes] = []
         for value_source in value_source_list:
             value = self._value_source_resolver.resolve(value_source)

--- a/app/questionnaire/placeholder_renderer.py
+++ b/app/questionnaire/placeholder_renderer.py
@@ -1,4 +1,4 @@
-from typing import Any, Union
+from typing import Any, Mapping, Optional
 
 from jsonpointer import resolve_pointer, set_pointer
 from werkzeug.datastructures import ImmutableDict
@@ -38,7 +38,7 @@ class PlaceholderRenderer:
         self,
         dict_to_render: dict[str, Any],
         pointer_to_render: str,
-        list_item_id: Union[str, None],
+        list_item_id: Optional[str],
     ) -> str:
         pointer_data = resolve_pointer(dict_to_render, pointer_to_render)
 
@@ -46,7 +46,7 @@ class PlaceholderRenderer:
 
     def get_plural_count(
         self, schema_partial: dict[str, str]
-    ) -> Union[AnswerValueTypes, None]:
+    ) -> Optional[AnswerValueTypes]:
         source = schema_partial["source"]
         source_id = schema_partial["identifier"]
 
@@ -62,7 +62,7 @@ class PlaceholderRenderer:
     def render_placeholder(
         self,
         placeholder_data: dict[str, Any],
-        list_item_id: Union[str, None],
+        list_item_id: Optional[str],
     ) -> str:
         placeholder_parser = PlaceholderParser(
             language=self._language,
@@ -77,11 +77,11 @@ class PlaceholderRenderer:
         placeholder_data = QuestionnaireSchema.get_mutable_deepcopy(placeholder_data)
 
         if "text_plural" in placeholder_data:
-            plural_schema: dict[str, dict] = placeholder_data["text_plural"]
+            plural_schema: Mapping[str, dict] = placeholder_data["text_plural"]
             count = self.get_plural_count(plural_schema["count"])
 
             plural_form_key = get_plural_form_key(count, self._language)
-            plural_forms: dict[str, str] = plural_schema["forms"]
+            plural_forms: Mapping[str, str] = plural_schema["forms"]
             placeholder_data["text"] = plural_forms[plural_form_key]
 
         if "text" not in placeholder_data and "placeholders" not in placeholder_data:
@@ -95,7 +95,7 @@ class PlaceholderRenderer:
         return formatted_placeholder_data
 
     def render(
-        self, dict_to_render: dict[str, Any], list_item_id: Union[str, None]
+        self, dict_to_render: dict[str, Any], list_item_id: Optional[str]
     ) -> dict[str, Any]:
         """
         Transform the current schema json to a fully rendered dictionary

--- a/app/questionnaire/placeholder_renderer.py
+++ b/app/questionnaire/placeholder_renderer.py
@@ -39,13 +39,13 @@ class PlaceholderRenderer:
         dict_to_render: dict[str, Any],
         pointer_to_render: str,
         list_item_id: Optional[str],
-    ) -> dict:
+    ) -> str:
         pointer_data = resolve_pointer(dict_to_render, pointer_to_render)
 
         return self.render_placeholder(pointer_data, list_item_id)
 
     def get_plural_count(
-        self, schema_partial: dict[str, Any]
+        self, schema_partial: dict[str, str]
     ) -> Optional[AnswerValueTypes]:
         source = schema_partial["source"]
         source_id = schema_partial["identifier"]
@@ -60,8 +60,10 @@ class PlaceholderRenderer:
         return metadata_source_id
 
     def render_placeholder(
-        self, placeholder_data: dict[str, Any], list_item_id: Optional[str]
-    ) -> dict[str, Any]:
+        self,
+        placeholder_data: dict[str, Any],
+        list_item_id: Optional[str],
+    ) -> str:
         placeholder_parser = PlaceholderParser(
             language=self._language,
             answer_store=self._answer_store,
@@ -75,19 +77,21 @@ class PlaceholderRenderer:
         placeholder_data = QuestionnaireSchema.get_mutable_deepcopy(placeholder_data)
 
         if "text_plural" in placeholder_data:
-            plural_schema = placeholder_data["text_plural"]
+            plural_schema: dict[str, dict] = placeholder_data["text_plural"]
             count = self.get_plural_count(plural_schema["count"])
 
             plural_form_key = get_plural_form_key(count, self._language)
-            placeholder_data["text"] = plural_schema["forms"][plural_form_key]
+            plural_forms: dict[str, str] = plural_schema["forms"]
+            placeholder_data["text"] = plural_forms[plural_form_key]
 
         if "text" not in placeholder_data and "placeholders" not in placeholder_data:
             raise ValueError("No placeholder found to render")
 
         transformed_values = placeholder_parser(placeholder_data["placeholders"])
-        formatted_placeholder_data: dict[str, Any] = placeholder_data["text"].format(
+        formatted_placeholder_data: str = placeholder_data["text"].format(
             **transformed_values
         )
+
         return formatted_placeholder_data
 
     def render(

--- a/app/questionnaire/placeholder_renderer.py
+++ b/app/questionnaire/placeholder_renderer.py
@@ -1,4 +1,4 @@
-from typing import Any, Mapping, Optional
+from typing import Any, Mapping, MutableMapping, Optional
 
 from jsonpointer import resolve_pointer, set_pointer
 from werkzeug.datastructures import ImmutableDict
@@ -36,7 +36,7 @@ class PlaceholderRenderer:
 
     def render_pointer(
         self,
-        dict_to_render: dict[str, Any],
+        dict_to_render: Mapping[str, Any],
         pointer_to_render: str,
         list_item_id: Optional[str],
     ) -> str:
@@ -45,7 +45,7 @@ class PlaceholderRenderer:
         return self.render_placeholder(pointer_data, list_item_id)
 
     def get_plural_count(
-        self, schema_partial: dict[str, str]
+        self, schema_partial: Mapping[str, str]
     ) -> Optional[AnswerValueTypes]:
         source = schema_partial["source"]
         source_id = schema_partial["identifier"]
@@ -61,7 +61,7 @@ class PlaceholderRenderer:
 
     def render_placeholder(
         self,
-        placeholder_data: dict[str, Any],
+        placeholder_data: MutableMapping[str, Any],
         list_item_id: Optional[str],
     ) -> str:
         placeholder_parser = PlaceholderParser(
@@ -95,8 +95,8 @@ class PlaceholderRenderer:
         return formatted_placeholder_data
 
     def render(
-        self, dict_to_render: dict[str, Any], list_item_id: Optional[str]
-    ) -> dict[str, Any]:
+        self, dict_to_render: Mapping[str, Any], list_item_id: Optional[str]
+    ) -> Mapping[str, Any]:
         """
         Transform the current schema json to a fully rendered dictionary
         """

--- a/app/questionnaire/placeholder_renderer.py
+++ b/app/questionnaire/placeholder_renderer.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any, Union
 
 from jsonpointer import resolve_pointer, set_pointer
 from werkzeug.datastructures import ImmutableDict
@@ -38,7 +38,7 @@ class PlaceholderRenderer:
         self,
         dict_to_render: dict[str, Any],
         pointer_to_render: str,
-        list_item_id: Optional[str],
+        list_item_id: Union[str, None],
     ) -> str:
         pointer_data = resolve_pointer(dict_to_render, pointer_to_render)
 
@@ -46,7 +46,7 @@ class PlaceholderRenderer:
 
     def get_plural_count(
         self, schema_partial: dict[str, str]
-    ) -> Optional[AnswerValueTypes]:
+    ) -> Union[AnswerValueTypes, None]:
         source = schema_partial["source"]
         source_id = schema_partial["identifier"]
 
@@ -62,7 +62,7 @@ class PlaceholderRenderer:
     def render_placeholder(
         self,
         placeholder_data: dict[str, Any],
-        list_item_id: Optional[str],
+        list_item_id: Union[str, None],
     ) -> str:
         placeholder_parser = PlaceholderParser(
             language=self._language,
@@ -95,7 +95,7 @@ class PlaceholderRenderer:
         return formatted_placeholder_data
 
     def render(
-        self, dict_to_render: dict[str, Any], list_item_id: Optional[str]
+        self, dict_to_render: dict[str, Any], list_item_id: Union[str, None]
     ) -> dict[str, Any]:
         """
         Transform the current schema json to a fully rendered dictionary

--- a/app/questionnaire/placeholder_transforms.py
+++ b/app/questionnaire/placeholder_transforms.py
@@ -205,7 +205,7 @@ class PlaceholderTransforms:
                 19: "eg",
             }.get(number_to_format, "fed")
 
-    def first_non_empty_item(self, items: list[str]) -> str:
+    def first_non_empty_item(self, items: Sequence[str]) -> str:
         """
         :param items: anything that is iterable
         :return: first non empty value
@@ -220,11 +220,11 @@ class PlaceholderTransforms:
         return ""
 
     @staticmethod
-    def contains(list_to_check: list[str], value: str) -> bool:
+    def contains(list_to_check: Sequence[str], value: str) -> bool:
         return value in list_to_check
 
     @staticmethod
-    def list_has_items(list_to_check: list[str]) -> bool:
+    def list_has_items(list_to_check: Sequence[str]) -> bool:
         return len(list_to_check) > 0
 
     @staticmethod

--- a/app/questionnaire/placeholder_transforms.py
+++ b/app/questionnaire/placeholder_transforms.py
@@ -14,24 +14,29 @@ class PlaceholderTransforms:
     A class to group the transforms that can be used within placeholders
     """
 
-    def __init__(self, language):
+    def __init__(self, language: str):
         self.language = language
         self.locale = DEFAULT_LOCALE if language in ["en", "eo"] else language
 
     input_date_format = "%Y-%m-%d"
     input_date_format_month_year_only = "%Y-%m"
 
-    def format_currency(self, number=None, currency="GBP"):
-        return format_currency(number, currency, locale=self.locale)
+    def format_currency(self, number: int = None, currency: str = "GBP") -> str:
+        formatted_currency: str = format_currency(number, currency, locale=self.locale)
+        return formatted_currency
 
-    def format_date(self, date_to_format, date_format):
-        date_to_format = datetime.strptime(
+    def format_date(self, date_to_format: str, date_format: str) -> str:
+        date_to_format_strptime: datetime = datetime.strptime(
             date_to_format, self.input_date_format
         ).replace(tzinfo=timezone.utc)
-        return format_datetime(date_to_format, date_format, locale=self.locale)
+
+        formatted_datetime: str = format_datetime(
+            date_to_format_strptime, date_format, locale=self.locale
+        )
+        return formatted_datetime
 
     @staticmethod
-    def format_list(list_to_format):
+    def format_list(list_to_format: list[str]) -> str:
         formatted_list = "<ul>"
         for item in list_to_format:
             formatted_list += f"<li>{item}</li>"
@@ -40,7 +45,8 @@ class PlaceholderTransforms:
         return formatted_list
 
     @staticmethod
-    def remove_empty_from_list(list_to_filter):
+    def remove_empty_from_list(list_to_filter: list[str]) -> list[str]:
+
         """
         :param list_to_filter: anything that is iterable
         :return: a list with no empty values
@@ -58,7 +64,7 @@ class PlaceholderTransforms:
         """
         return [item for item in list_to_filter if item or item is False or item == 0]
 
-    def concatenate_list(self, list_to_concatenate, delimiter):
+    def concatenate_list(self, list_to_concatenate: list[str], delimiter: str) -> str:
         filtered_list = self.remove_empty_from_list(list_to_concatenate)
         return delimiter.join(filtered_list)
 
@@ -83,7 +89,7 @@ class PlaceholderTransforms:
 
         return self._create_hyperlink(href, email_address)
 
-    def format_possessive(self, string_to_format):
+    def format_possessive(self, string_to_format: str) -> str:
         if string_to_format and self.language == "en":
             lowered_string = string_to_format.lower()
 
@@ -97,14 +103,15 @@ class PlaceholderTransforms:
 
         return string_to_format
 
-    def format_number(self, number):
+    def format_number(self, number: int) -> str:
         if number or number == 0:
-            return format_decimal(number, locale=self.locale)
+            formatted_decimal: str = format_decimal(number, locale=self.locale)
+            return formatted_decimal
 
         return ""
 
     @staticmethod
-    def calculate_date_difference(first_date, second_date):
+    def calculate_date_difference(first_date: str, second_date: str) -> str:
 
         time = relativedelta(
             PlaceholderTransforms.parse_date(second_date),
@@ -112,24 +119,24 @@ class PlaceholderTransforms:
         )
 
         if time.years:
-            year_string = ngettext(
+            year_string: str = ngettext(
                 "{number_of_years} year", "{number_of_years} years", time.years
             )
             return year_string.format(number_of_years=time.years)
 
         if time.months:
-            month_string = ngettext(
+            month_string: str = ngettext(
                 "{number_of_months} month", "{number_of_months} months", time.months
             )
             return month_string.format(number_of_months=time.months)
 
-        day_string = ngettext(
+        day_string: str = ngettext(
             "{number_of_days} day", "{number_of_days} days", time.days
         )
         return day_string.format(number_of_days=time.days)
 
     @staticmethod
-    def parse_date(date):
+    def parse_date(date: str) -> datetime:
         """
         :param date: string representing a date
         :return: datetime of that date
@@ -150,10 +157,10 @@ class PlaceholderTransforms:
             ).replace(tzinfo=timezone.utc)
 
     @staticmethod
-    def add(lhs, rhs):
+    def add(lhs: int, rhs: int) -> int:
         return lhs + rhs
 
-    def format_ordinal(self, number_to_format, determiner=None):
+    def format_ordinal(self, number_to_format: int, determiner: str = None) -> str:
 
         indicator = self.get_ordinal_indicator(number_to_format)
 
@@ -167,7 +174,7 @@ class PlaceholderTransforms:
 
         return f"{number_to_format}{indicator}"
 
-    def get_ordinal_indicator(self, number_to_format):
+    def get_ordinal_indicator(self, number_to_format: int) -> str:
         if self.language in ["en", "eo"]:
             if 11 <= number_to_format % 100 <= 13:
                 return "th"
@@ -194,7 +201,7 @@ class PlaceholderTransforms:
                 19: "eg",
             }.get(number_to_format, "fed")
 
-    def first_non_empty_item(self, items):
+    def first_non_empty_item(self, items: list[str]) -> str:
         """
         :param items: anything that is iterable
         :return: first non empty value
@@ -209,15 +216,20 @@ class PlaceholderTransforms:
         return ""
 
     @staticmethod
-    def contains(list_to_check, value):
+    def contains(list_to_check: list[str], value: str) -> bool:
         return value in list_to_check
 
     @staticmethod
-    def list_has_items(list_to_check):
+    def list_has_items(list_to_check: list[str]) -> bool:
         return len(list_to_check) > 0
 
     @staticmethod
-    def format_name(first_name, middle_names, last_name, include_middle_names=False):
+    def format_name(
+        first_name: str,
+        middle_names: str,
+        last_name: str,
+        include_middle_names: bool = False,
+    ) -> str:
         return (
             f"{first_name} {middle_names} {last_name}"
             if include_middle_names and middle_names

--- a/app/questionnaire/placeholder_transforms.py
+++ b/app/questionnaire/placeholder_transforms.py
@@ -66,7 +66,9 @@ class PlaceholderTransforms:
         """
         return [item for item in list_to_filter if item or item is False or item == 0]
 
-    def concatenate_list(self, list_to_concatenate: list[str], delimiter: str) -> str:
+    def concatenate_list(
+        self, list_to_concatenate: Sequence[str], delimiter: str
+    ) -> str:
         filtered_list = self.remove_empty_from_list(list_to_concatenate)
         return delimiter.join(filtered_list)
 

--- a/app/questionnaire/placeholder_transforms.py
+++ b/app/questionnaire/placeholder_transforms.py
@@ -1,4 +1,6 @@
 from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Sequence, Union
 from urllib.parse import quote
 
 from babel.dates import format_datetime
@@ -26,17 +28,17 @@ class PlaceholderTransforms:
         return formatted_currency
 
     def format_date(self, date_to_format: str, date_format: str) -> str:
-        date_to_format_strptime: datetime = datetime.strptime(
+        date_as_datetime = datetime.strptime(
             date_to_format, self.input_date_format
         ).replace(tzinfo=timezone.utc)
 
         formatted_datetime: str = format_datetime(
-            date_to_format_strptime, date_format, locale=self.locale
+            date_as_datetime, date_format, locale=self.locale
         )
         return formatted_datetime
 
     @staticmethod
-    def format_list(list_to_format: list[str]) -> str:
+    def format_list(list_to_format: Sequence[str]) -> str:
         formatted_list = "<ul>"
         for item in list_to_format:
             formatted_list += f"<li>{item}</li>"
@@ -45,7 +47,7 @@ class PlaceholderTransforms:
         return formatted_list
 
     @staticmethod
-    def remove_empty_from_list(list_to_filter: list[str]) -> list[str]:
+    def remove_empty_from_list(list_to_filter: Sequence[str]) -> list[str]:
 
         """
         :param list_to_filter: anything that is iterable
@@ -103,7 +105,7 @@ class PlaceholderTransforms:
 
         return string_to_format
 
-    def format_number(self, number: int) -> str:
+    def format_number(self, number: Union[int, Decimal, str]) -> str:
         if number or number == 0:
             formatted_decimal: str = format_decimal(number, locale=self.locale)
             return formatted_decimal
@@ -157,7 +159,7 @@ class PlaceholderTransforms:
             ).replace(tzinfo=timezone.utc)
 
     @staticmethod
-    def add(lhs: int, rhs: int) -> int:
+    def add(lhs: Union[int, Decimal], rhs: Union[int, Decimal]) -> Union[int, Decimal]:
         return lhs + rhs
 
     def format_ordinal(self, number_to_format: int, determiner: str = None) -> str:

--- a/app/views/contexts/context.py
+++ b/app/views/contexts/context.py
@@ -1,5 +1,6 @@
 from abc import ABC
-from typing import Mapping
+
+from werkzeug.datastructures import ImmutableDict
 
 from app.data_models.answer_store import AnswerStore
 from app.data_models.list_store import ListStore
@@ -17,7 +18,7 @@ class Context(ABC):
         answer_store: AnswerStore,
         list_store: ListStore,
         progress_store: ProgressStore,
-        metadata: Mapping,
+        metadata: ImmutableDict,
     ):
         self._language = language
         self._schema = schema
@@ -36,8 +37,8 @@ class Context(ABC):
 
         self._placeholder_renderer = PlaceholderRenderer(
             language=self._language,
-            schema=self._schema,
             answer_store=self._answer_store,
-            metadata=self._metadata,
             list_store=self._list_store,
+            metadata=self._metadata,
+            schema=self._schema,
         )

--- a/app/views/contexts/section_summary_context.py
+++ b/app/views/contexts/section_summary_context.py
@@ -2,6 +2,7 @@ from functools import cached_property
 from typing import Mapping, Optional
 
 from flask import url_for
+from werkzeug.datastructures import ImmutableDict
 
 from app.data_models import AnswerStore, ListStore, ProgressStore
 from app.questionnaire import QuestionnaireSchema
@@ -22,7 +23,7 @@ class SectionSummaryContext(Context):
         answer_store: AnswerStore,
         list_store: ListStore,
         progress_store: ProgressStore,
-        metadata: Mapping,
+        metadata: ImmutableDict,
         routing_path: RoutingPath,
         current_location: Location,
     ):

--- a/app/views/contexts/summary/group.py
+++ b/app/views/contexts/summary/group.py
@@ -30,10 +30,10 @@ class Group:
         )
         self.placeholder_renderer = PlaceholderRenderer(
             language=language,
-            schema=schema,
             answer_store=answer_store,
-            metadata=metadata,
             list_store=list_store,
+            metadata=metadata,
+            schema=schema,
         )
 
     @staticmethod

--- a/app/views/handlers/block.py
+++ b/app/views/handlers/block.py
@@ -62,11 +62,11 @@ class BlockHandler:
     def placeholder_renderer(self):
         return PlaceholderRenderer(
             self._language,
-            schema=self._schema,
             answer_store=self._questionnaire_store.answer_store,
-            metadata=self._questionnaire_store.metadata,
-            location=self._current_location,
             list_store=self._questionnaire_store.list_store,
+            metadata=self._questionnaire_store.metadata,
+            schema=self._schema,
+            location=self._current_location,
         )
 
     @cached_property

--- a/app/views/handlers/individual_response.py
+++ b/app/views/handlers/individual_response.py
@@ -161,11 +161,11 @@ class IndividualResponseHandler:
     def placeholder_renderer(self):
         return PlaceholderRenderer(
             language=self._language,
-            schema=self._schema,
             answer_store=self._questionnaire_store.answer_store,
-            metadata=self._questionnaire_store.metadata,
-            location=None,
             list_store=self._questionnaire_store.list_store,
+            metadata=self._questionnaire_store.metadata,
+            schema=self._schema,
+            location=None,
         )
 
     @cached_property

--- a/mypy.ini
+++ b/mypy.ini
@@ -10,6 +10,18 @@ warn_no_return = False
 disallow_untyped_defs = True
 warn_return_any = True
 
+[mypy-app.questionnaire.placeholder_parser]
+disallow_untyped_defs = True
+warn_return_any = True
+
+[mypy-app.questionnaire.placeholder_renderer]
+disallow_untyped_defs = True
+warn_return_any = True
+
+[mypy-app.questionnaire.placeholder_transforms]
+disallow_untyped_defs = True
+warn_return_any = True
+
 [mypy-app.questionnaire.questionnaire_schema]
 disallow_untyped_defs = True
 warn_return_any = True

--- a/tests/app/forms/test_questionnaire_form.py
+++ b/tests/app/forms/test_questionnaire_form.py
@@ -1369,7 +1369,11 @@ class TestQuestionnaireForm(
             )
 
             renderer = PlaceholderRenderer(
-                language="en", schema=schema, answer_store=answer_store
+                language="en",
+                answer_store=answer_store,
+                list_store=ListStore(),
+                metadata={},
+                schema=schema,
             )
             rendered_schema = renderer.render(question_schema, None)
 

--- a/tests/app/questionnaire/conftest.py
+++ b/tests/app/questionnaire/conftest.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock
 import pytest
 
 from app.data_models.answer_store import AnswerStore
+from app.data_models.list_store import ListStore
 from app.questionnaire import QuestionnaireSchema
 from app.questionnaire.location import Location
 from app.questionnaire.placeholder_parser import PlaceholderParser
@@ -30,17 +31,24 @@ def location():
 
 
 @pytest.fixture
-def parser(answer_store, location):
+def parser(answer_store, location, mock_schema):
     return PlaceholderParser(
-        language="en", answer_store=answer_store, location=location
+        language="en",
+        answer_store=answer_store,
+        list_store=ListStore(),
+        metadata={},
+        schema=mock_schema,
+        location=location,
     )
 
 
 @pytest.fixture
-def parser_with_list_item_id(answer_store, location):
+def parser_with_list_item_id(answer_store, list_store, location):
     return PlaceholderParser(
         language="en",
         answer_store=answer_store,
+        list_store=list_store,
+        metadata={},
         location=location,
         list_item_id="test-list-item-id",
     )

--- a/tests/app/questionnaire/test_placeholder_parser.py
+++ b/tests/app/questionnaire/test_placeholder_parser.py
@@ -23,7 +23,13 @@ def test_metadata_placeholder():
     ]
 
     period_str = "Aug 2018"
-    parser = PlaceholderParser(language="en", metadata={"period_str": period_str})
+    parser = PlaceholderParser(
+        language="en",
+        answer_store=AnswerStore(),
+        list_store=ListStore(),
+        metadata={"period_str": period_str},
+        schema=QuestionnaireSchema({}),
+    )
 
     placeholders = parser(placeholder_list)
     assert period_str == placeholders["period"]
@@ -54,7 +60,11 @@ def test_previous_answer_transform_placeholder():
     )
 
     parser = PlaceholderParser(
-        language="en", schema=QuestionnaireSchema({}), answer_store=answer_store
+        language="en",
+        answer_store=answer_store,
+        list_store=ListStore(),
+        metadata={},
+        schema=QuestionnaireSchema({}),
     )
     placeholders = parser(placeholder_list)
 
@@ -81,7 +91,11 @@ def test_metadata_transform_placeholder():
     ]
 
     parser = PlaceholderParser(
-        language="en", metadata={"ref_p_start_date": "2019-02-11"}
+        language="en",
+        answer_store=AnswerStore(),
+        list_store=ListStore(),
+        metadata={"ref_p_start_date": "2019-02-11"},
+        schema=QuestionnaireSchema({}),
     )
     placeholders = parser(placeholder_list)
 
@@ -115,6 +129,9 @@ def test_multiple_answer_transform_placeholder():
                 {"answer_id": "last-name", "value": "Bloggs"},
             ]
         ),
+        list_store=ListStore(),
+        metadata={},
+        schema=QuestionnaireSchema({}),
     )
 
     placeholders = parser(placeholder_list)
@@ -142,7 +159,10 @@ def test_first_non_empty_item_transform_placeholder():
 
     parser = PlaceholderParser(
         language="en",
+        answer_store=AnswerStore(),
+        list_store=ListStore(),
         metadata={"ru_name": "ru_name"},
+        schema=QuestionnaireSchema({}),
     )
 
     placeholders = parser(placeholder_list)
@@ -173,6 +193,9 @@ def test_format_list_answer_transform_placeholder():
         answer_store=AnswerStore(
             [{"answer_id": "checkbox-answer", "value": ["Ham", "Cheese"]}]
         ),
+        list_store=ListStore(),
+        metadata={},
+        schema=QuestionnaireSchema({}),
     )
 
     placeholders = parser(placeholder_list)
@@ -208,6 +231,9 @@ def test_placeholder_parser_escapes_answers():
                 }
             ]
         ),
+        list_store=ListStore(),
+        metadata={},
+        schema=QuestionnaireSchema({}),
     )
 
     placeholders = parser(placeholder_list)
@@ -245,7 +271,11 @@ def test_multiple_metadata_transform_placeholder():
     ]
 
     parser = PlaceholderParser(
-        language="en", metadata={"ref_p_start_date": "2019-02-11"}
+        language="en",
+        answer_store=AnswerStore(),
+        list_store=ListStore(),
+        metadata={"ref_p_start_date": "2019-02-11"},
+        schema=QuestionnaireSchema({}),
     )
 
     placeholders = parser(placeholder_list)
@@ -274,7 +304,10 @@ def test_multiple_metadata_list_transform_placeholder():
 
     parser = PlaceholderParser(
         language="en",
+        answer_store=AnswerStore(),
+        list_store=ListStore(),
         metadata={"ref_p_start_date": "2019-02-11", "ref_p_end_date": "2019-10-11"},
+        schema=QuestionnaireSchema({}),
     )
     placeholders = parser(placeholder_list)
 
@@ -306,6 +339,9 @@ def test_checkbox_transform_placeholder():
                 {"answer_id": "checkbox-answer", "value": ["Ham", "Cheese"]},
             ]
         ),
+        list_store=ListStore(),
+        metadata={},
+        schema=QuestionnaireSchema({}),
     )
 
     placeholders = parser(placeholder_list)
@@ -340,7 +376,9 @@ def test_mixed_transform_placeholder():
         answer_store=AnswerStore(
             [{"answer_id": "date-of-birth-answer", "value": "1999-01-01"}]
         ),
+        list_store=ListStore(),
         metadata={"second-date": "2019-02-02"},
+        schema=QuestionnaireSchema({}),
     )
     placeholders = parser(placeholder_list)
 
@@ -371,6 +409,9 @@ def test_mixed_transform_placeholder_value():
         answer_store=AnswerStore(
             [{"answer_id": "date-of-birth-answer", "value": "1999-01-01"}]
         ),
+        list_store=ListStore(),
+        metadata={},
+        schema=QuestionnaireSchema({}),
     )
     placeholders = parser(placeholder_list)
 
@@ -389,7 +430,13 @@ def test_list_source_count():
     list_store.add_list_item("people")
     list_store.add_list_item("people")
 
-    parser = PlaceholderParser(language="en", list_store=list_store)
+    parser = PlaceholderParser(
+        language="en",
+        answer_store=AnswerStore(),
+        list_store=list_store,
+        metadata={},
+        schema=QuestionnaireSchema({}),
+    )
     placeholders = parser(placeholder_list)
 
     assert placeholders["number_of_people"] == 2
@@ -414,7 +461,13 @@ def test_list_source_count_in_transform():
     list_store = ListStore()
     list_store.add_list_item("people")
 
-    parser = PlaceholderParser(language="en", list_store=list_store)
+    parser = PlaceholderParser(
+        language="en",
+        answer_store=AnswerStore(),
+        list_store=list_store,
+        metadata={},
+        schema=QuestionnaireSchema({}),
+    )
     placeholders = parser(placeholder_list)
 
     assert placeholders["number_of_people"] == 2
@@ -451,6 +504,9 @@ def test_chain_transform_placeholder():
                 {"answer_id": "last-name", "value": "Bloggs"},
             ]
         ),
+        list_store=ListStore(),
+        metadata={},
+        schema=QuestionnaireSchema({}),
     )
 
     placeholders = parser(placeholder_list)
@@ -486,7 +542,11 @@ def test_placeholder_resolves_answer_value_based_on_first_item_in_list():
     )
 
     parser = PlaceholderParser(
-        language="en", list_store=list_store, answer_store=answer_store
+        language="en",
+        answer_store=answer_store,
+        list_store=list_store,
+        metadata={},
+        schema=QuestionnaireSchema({}),
     )
 
     placeholders = parser(placeholder_list)
@@ -508,7 +568,11 @@ def test_placeholder_resolves_list_item_value_based_on_first_item_in_list():
     list_store = ListStore([{"items": ["item-1", "item-2"], "name": "people"}])
 
     parser = PlaceholderParser(
-        language="en", list_store=list_store, answer_store=AnswerStore()
+        language="en",
+        answer_store=AnswerStore(),
+        list_store=list_store,
+        metadata={},
+        schema=QuestionnaireSchema({}),
     )
 
     placeholders = parser(placeholder_list)
@@ -539,7 +603,10 @@ def test_placeholder_resolves_same_name_items():
 
     parser = PlaceholderParser(
         language="en",
+        answer_store=AnswerStore(),
         list_store=list_store,
+        metadata={},
+        schema=QuestionnaireSchema({}),
         list_item_id="abc123",
     )
 
@@ -636,9 +703,10 @@ def test_placeholder_resolves_name_is_duplicate_chain(mock_schema):
 
     parser = PlaceholderParser(
         language="en",
-        schema=mock_schema,
-        list_store=list_store,
         answer_store=answer_store,
+        list_store=list_store,
+        metadata={},
+        schema=mock_schema,
         list_item_id="abc123",
     )
 
@@ -648,9 +716,10 @@ def test_placeholder_resolves_name_is_duplicate_chain(mock_schema):
 
     parser = PlaceholderParser(
         language="en",
-        schema=mock_schema,
-        list_store=list_store,
         answer_store=answer_store,
+        list_store=list_store,
+        metadata={},
+        schema=mock_schema,
         list_item_id="cde456",
     )
 
@@ -743,9 +812,10 @@ def test_placeholder_resolves_list_has_items_chain(mock_schema):
 
     parser = PlaceholderParser(
         language="en",
-        schema=mock_schema,
-        list_store=list_store,
         answer_store=answer_store,
+        list_store=list_store,
+        metadata={},
+        schema=mock_schema,
         list_item_id="abc123",
     )
 
@@ -755,9 +825,10 @@ def test_placeholder_resolves_list_has_items_chain(mock_schema):
 
     parser = PlaceholderParser(
         language="en",
-        schema=mock_schema,
-        list_store=list_store,
         answer_store=answer_store,
+        list_store=list_store,
+        metadata={},
+        schema=mock_schema,
         list_item_id="cde456",
     )
 

--- a/tests/app/questionnaire/test_placeholder_renderer.py
+++ b/tests/app/questionnaire/test_placeholder_renderer.py
@@ -120,6 +120,8 @@ class TestPlaceholderRenderer(AppContextTestCase):
                     {"answer_id": "date-of-birth-answer", "value": "1991-01-01"},
                 ]
             ),
+            list_store=ListStore(),
+            metadata={},
         )
 
         rendered = renderer.render_pointer(
@@ -154,6 +156,8 @@ class TestPlaceholderRenderer(AppContextTestCase):
                     {"answer_id": "date-of-birth-answer", "value": "1986-01-01"},
                 ]
             ),
+            list_store=ListStore(),
+            metadata={},
         )
 
         rendered_schema = renderer.render(json_to_render, list_item_id=None)
@@ -187,6 +191,8 @@ class TestPlaceholderRenderer(AppContextTestCase):
                     {"answer_id": "date-of-birth-answer", "value": "1986-01-01"},
                 ]
             ),
+            list_store=ListStore(),
+            metadata={},
         )
 
         rendered_schema = renderer.render(json_to_render, list_item_id=None)
@@ -195,13 +201,25 @@ class TestPlaceholderRenderer(AppContextTestCase):
         assert rendered_label == "Alfred Aho age is 33 years. Is this correct?"
 
     def test_errors_on_invalid_pointer(self):
-        renderer = PlaceholderRenderer(language="en", schema=Mock())
+        renderer = PlaceholderRenderer(
+            language="en",
+            answer_store=AnswerStore(),
+            list_store=ListStore(),
+            metadata={},
+            schema=Mock(),
+        )
 
         with self.assertRaises(ValueError):
             renderer.render_pointer(self.question_json, "/title", list_item_id=None)
 
     def test_errors_on_invalid_json(self):
-        renderer = PlaceholderRenderer(language="en", schema=Mock())
+        renderer = PlaceholderRenderer(
+            language="en",
+            answer_store=AnswerStore(),
+            list_store=ListStore(),
+            metadata={},
+            schema=Mock(),
+        )
 
         with self.assertRaises(ValueError):
             dict_to_render = {"invalid": {"no": "placeholders", "in": "this"}}
@@ -211,7 +229,11 @@ class TestPlaceholderRenderer(AppContextTestCase):
 def test_renders_text_plural_from_answers():
     answer_store = AnswerStore([{"answer_id": "number-of-people", "value": 1}])
     renderer = PlaceholderRenderer(
-        language="en", answer_store=answer_store, schema=Mock()
+        language="en",
+        answer_store=answer_store,
+        list_store=ListStore(),
+        metadata={},
+        schema=Mock(),
     )
 
     rendered_text = renderer.render_placeholder(
@@ -237,7 +259,13 @@ def test_renders_text_plural_from_answers():
 
 
 def test_renders_text_plural_from_list():
-    renderer = PlaceholderRenderer(language="en", list_store=ListStore(), schema=Mock())
+    renderer = PlaceholderRenderer(
+        language="en",
+        answer_store=AnswerStore(),
+        list_store=ListStore(),
+        metadata={},
+        schema=Mock(),
+    )
 
     rendered_text = renderer.render_placeholder(
         {
@@ -263,7 +291,13 @@ def test_renders_text_plural_from_list():
 
 def test_renders_text_plural_from_metadata():
     metadata = {"some_value": 100}
-    renderer = PlaceholderRenderer(language="en", metadata=metadata, schema=Mock())
+    renderer = PlaceholderRenderer(
+        language="en",
+        answer_store=AnswerStore(),
+        list_store=ListStore(),
+        metadata=metadata,
+        schema=Mock(),
+    )
 
     rendered_text = renderer.render_placeholder(
         {

--- a/tests/app/questionnaire/test_placeholder_renderer.py
+++ b/tests/app/questionnaire/test_placeholder_renderer.py
@@ -6,7 +6,6 @@ from app.questionnaire.placeholder_renderer import (
     PlaceholderRenderer,
     find_pointers_containing,
 )
-from app.questionnaire.questionnaire_schema import QuestionnaireSchema
 from tests.app.app_context_test_case import AppContextTestCase
 
 
@@ -110,20 +109,14 @@ class TestPlaceholderRenderer(AppContextTestCase):
             "transforms"
         ][0] = mock_transform
 
-        renderer = PlaceholderRenderer(
-            language="en",
-            schema=QuestionnaireSchema({}),
-            answer_store=AnswerStore(
-                [
-                    {"answer_id": "first-name", "value": "Hal"},
-                    {"answer_id": "last-name", "value": "Abelson"},
-                    {"answer_id": "date-of-birth-answer", "value": "1991-01-01"},
-                ]
-            ),
-            list_store=ListStore(),
-            metadata={},
+        answer_store = AnswerStore(
+            [
+                {"answer_id": "first-name", "value": "Hal"},
+                {"answer_id": "last-name", "value": "Abelson"},
+                {"answer_id": "date-of-birth-answer", "value": "1991-01-01"},
+            ]
         )
-
+        renderer = get_placeholder_render(answer_store=answer_store)
         rendered = renderer.render_pointer(
             self.question_json, "/answers/0/options/0/label", list_item_id=None
         )
@@ -146,20 +139,15 @@ class TestPlaceholderRenderer(AppContextTestCase):
             "transforms"
         ][0] = mock_transform
 
-        renderer = PlaceholderRenderer(
-            language="en",
-            schema=QuestionnaireSchema({}),
-            answer_store=AnswerStore(
-                [
-                    {"answer_id": "first-name", "value": "Alfred"},
-                    {"answer_id": "last-name", "value": "Aho"},
-                    {"answer_id": "date-of-birth-answer", "value": "1986-01-01"},
-                ]
-            ),
-            list_store=ListStore(),
-            metadata={},
+        answer_store = AnswerStore(
+            [
+                {"answer_id": "first-name", "value": "Alfred"},
+                {"answer_id": "last-name", "value": "Aho"},
+                {"answer_id": "date-of-birth-answer", "value": "1986-01-01"},
+            ]
         )
 
+        renderer = get_placeholder_render(answer_store=answer_store)
         rendered_schema = renderer.render(json_to_render, list_item_id=None)
         rendered_label = rendered_schema["answers"][0]["options"][0]["label"]
 
@@ -181,45 +169,27 @@ class TestPlaceholderRenderer(AppContextTestCase):
             "transforms"
         ][0] = mock_transform
 
-        renderer = PlaceholderRenderer(
-            language="cy",
-            schema=QuestionnaireSchema({}),
-            answer_store=AnswerStore(
-                [
-                    {"answer_id": "first-name", "value": "Alfred"},
-                    {"answer_id": "last-name", "value": "Aho"},
-                    {"answer_id": "date-of-birth-answer", "value": "1986-01-01"},
-                ]
-            ),
-            list_store=ListStore(),
-            metadata={},
+        answer_store = AnswerStore(
+            [
+                {"answer_id": "first-name", "value": "Alfred"},
+                {"answer_id": "last-name", "value": "Aho"},
+                {"answer_id": "date-of-birth-answer", "value": "1986-01-01"},
+            ]
         )
-
+        renderer = get_placeholder_render(language="cy", answer_store=answer_store)
         rendered_schema = renderer.render(json_to_render, list_item_id=None)
         rendered_label = rendered_schema["answers"][0]["options"][0]["label"]
 
         assert rendered_label == "Alfred Aho age is 33 years. Is this correct?"
 
     def test_errors_on_invalid_pointer(self):
-        renderer = PlaceholderRenderer(
-            language="en",
-            answer_store=AnswerStore(),
-            list_store=ListStore(),
-            metadata={},
-            schema=Mock(),
-        )
+        renderer = get_placeholder_render()
 
         with self.assertRaises(ValueError):
             renderer.render_pointer(self.question_json, "/title", list_item_id=None)
 
     def test_errors_on_invalid_json(self):
-        renderer = PlaceholderRenderer(
-            language="en",
-            answer_store=AnswerStore(),
-            list_store=ListStore(),
-            metadata={},
-            schema=Mock(),
-        )
+        renderer = get_placeholder_render()
         renderer._answer_store = AnswerStore()
         with self.assertRaises(ValueError):
             dict_to_render = {"invalid": {"no": "placeholders", "in": "this"}}
@@ -228,14 +198,7 @@ class TestPlaceholderRenderer(AppContextTestCase):
 
 def test_renders_text_plural_from_answers():
     answer_store = AnswerStore([{"answer_id": "number-of-people", "value": 1}])
-    renderer = PlaceholderRenderer(
-        language="en",
-        answer_store=answer_store,
-        list_store=ListStore(),
-        metadata={},
-        schema=Mock(),
-    )
-
+    renderer = get_placeholder_render(answer_store=answer_store)
     rendered_text = renderer.render_placeholder(
         {
             "text_plural": {
@@ -259,13 +222,7 @@ def test_renders_text_plural_from_answers():
 
 
 def test_renders_text_plural_from_list():
-    renderer = PlaceholderRenderer(
-        language="en",
-        answer_store=AnswerStore(),
-        list_store=ListStore(),
-        metadata={},
-        schema=Mock(),
-    )
+    renderer = get_placeholder_render()
 
     rendered_text = renderer.render_placeholder(
         {
@@ -291,13 +248,7 @@ def test_renders_text_plural_from_list():
 
 def test_renders_text_plural_from_metadata():
     metadata = {"some_value": 100}
-    renderer = PlaceholderRenderer(
-        language="en",
-        answer_store=AnswerStore(),
-        list_store=ListStore(),
-        metadata=metadata,
-        schema=Mock(),
-    )
+    renderer = get_placeholder_render(metadata=metadata)
 
     rendered_text = renderer.render_placeholder(
         {
@@ -319,3 +270,16 @@ def test_renders_text_plural_from_metadata():
     )
 
     assert rendered_text == "Yes, 100 people live here"
+
+
+def get_placeholder_render(
+    language="en", answer_store=AnswerStore(), list_store=ListStore(), metadata={}
+):
+    renderer = PlaceholderRenderer(
+        language=language,
+        answer_store=answer_store,
+        list_store=list_store,
+        metadata=metadata,
+        schema=Mock(),
+    )
+    return renderer

--- a/tests/app/questionnaire/test_placeholder_renderer.py
+++ b/tests/app/questionnaire/test_placeholder_renderer.py
@@ -220,7 +220,7 @@ class TestPlaceholderRenderer(AppContextTestCase):
             metadata={},
             schema=Mock(),
         )
-
+        renderer._answer_store = AnswerStore()
         with self.assertRaises(ValueError):
             dict_to_render = {"invalid": {"no": "placeholders", "in": "this"}}
             renderer.render_pointer(dict_to_render, "/invalid", list_item_id=None)

--- a/tests/app/questionnaire/test_placeholder_transforms.py
+++ b/tests/app/questionnaire/test_placeholder_transforms.py
@@ -1,4 +1,5 @@
 import unittest
+from decimal import Decimal
 
 from app.questionnaire.placeholder_transforms import PlaceholderTransforms
 
@@ -118,8 +119,11 @@ class TestPlaceholderParser(unittest.TestCase):
             == "Milk, Eggs, Flour, Water"
         )
 
-    def test_add(self):
-        assert self.transforms.add(1, 2) == 3
+    def test_add_int(self):
+        assert self.transforms.add(int(1), int(2)) == int(3)
+
+    def test_add_decimal(self):
+        assert self.transforms.add(Decimal("1.11"), Decimal("2.22")) == Decimal("3.33")
 
     def test_format_ordinal_with_determiner(self):
         assert self.transforms.format_ordinal(1, "a_or_an") == "a 1st"


### PR DESCRIPTION
### What is the context of this PR?
Typing has been added to placeholders. The defaults have also been removed, so the stores are now always passed +schema

### How to review 
Confirm that typing is correct (in places it could be allowing too many) and make sure every works as before with placeholders

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
