### PR TITLE
Add type hints for forms modules `address_form.py`, `email_form.py`, `questionnaire_form.py`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ venv
 
 # VS Code
 .vscode
+*.code-workspace
 
 .DS_Store
 

--- a/app/data_models/__init__.py
+++ b/app/data_models/__init__.py
@@ -1,3 +1,4 @@
+from .answer import Answer, AnswerValueTypes
 from .fulfilment_request import FulfilmentRequest
 from .progress_store import CompletionStatus
 from .questionnaire_store import (
@@ -10,7 +11,9 @@ from .session_data import SessionData
 from .session_store import SessionStore
 
 __all__ = [
+    "Answer",
     "AnswerStore",
+    "AnswerValueTypes",
     "CompletionStatus",
     "FulfilmentRequest",
     "ListStore",

--- a/app/forms/address_form.py
+++ b/app/forms/address_form.py
@@ -1,12 +1,20 @@
+from __future__ import annotations
+
 import logging
 from functools import cached_property
+from typing import Any
 
 from wtforms import Form, HiddenField, StringField
+from wtforms.validators import InputRequired
 
 logger = logging.getLogger(__name__)
 
+AddressValidatorTypes = list[InputRequired]
 
-def get_address_form(validators):
+
+def get_address_form(
+    validators: AddressValidatorTypes,
+) -> Form:
     class AddressForm(Form):
         line1 = StringField(validators=validators)
         line2 = StringField()
@@ -15,7 +23,8 @@ def get_address_form(validators):
         uprn = HiddenField()
 
         @cached_property
-        def data(self):
-            return super().data
+        def data(self) -> dict[str, Any]:
+            data_: dict[str, Any] = super().data
+            return data_
 
     return AddressForm

--- a/app/forms/email_form.py
+++ b/app/forms/email_form.py
@@ -3,7 +3,7 @@ from wtforms import StringField
 from wtforms.validators import Email, InputRequired
 
 from app.forms import error_messages
-from app.forms.questionnaire_form import map_subfield_errors
+from app.forms.questionnaire_form import ErrorList, map_subfield_errors
 from app.forms.validators import EmailTLDCheck
 
 
@@ -17,7 +17,7 @@ class EmailForm(FlaskForm):
         filters=[lambda x: x.strip() if x else None],
     )
 
-    def map_errors(self):
+    def map_errors(self) -> ErrorList:
         return (
             map_subfield_errors(self.errors, self.email.id)
             if self.email.id in self.errors

--- a/app/forms/field_handlers/address_handler.py
+++ b/app/forms/field_handlers/address_handler.py
@@ -3,11 +3,9 @@ from functools import cached_property
 from wtforms import FormField
 from wtforms.validators import InputRequired
 
-from app.forms.address_form import get_address_form
+from app.forms.address_form import AddressValidatorTypes, get_address_form
 from app.forms.field_handlers.field_handler import FieldHandler
 from app.forms.validators import format_message_with_title
-
-AddressValidatorTypes = list[InputRequired]
 
 
 class AddressHandler(FieldHandler):

--- a/app/forms/field_handlers/date_handlers.py
+++ b/app/forms/field_handlers/date_handlers.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timezone
 from functools import cached_property
-from typing import Optional, Union
+from typing import Any, Optional, Union
 
 from dateutil.relativedelta import relativedelta
 
@@ -75,7 +75,7 @@ class DateHandler(FieldHandler):
 
         :return: date value
         """
-        value = self.get_schema_value(self.answer_schema[key])
+        value: Any = self.get_schema_value(self.answer_schema[key])
 
         if value == "now":
             value = datetime.now(timezone.utc).strftime("%Y-%m-%d")
@@ -107,8 +107,6 @@ class DateHandler(FieldHandler):
         """
         Gets attributes within a minimum or maximum of a date field and validates that the entered date
         is valid.
-
-        :return: attributes
         """
         date_value = None
 

--- a/app/forms/field_handlers/duration_handler.py
+++ b/app/forms/field_handlers/duration_handler.py
@@ -9,7 +9,7 @@ class DurationHandler(FieldHandler):
 
     def get_field(self) -> FormField:
         return FormField(
-            get_duration_form(self.answer_schema, self.error_messages),
+            get_duration_form(self.answer_schema, dict(self.error_messages)),
             label=self.label,
             description=self.guidance,
         )

--- a/app/forms/field_handlers/field_handler.py
+++ b/app/forms/field_handlers/field_handler.py
@@ -1,6 +1,6 @@
 from abc import ABC
 from functools import cached_property
-from typing import Mapping, Optional, Union
+from typing import Any, Mapping, Optional, Union
 
 from wtforms import Field, validators
 from wtforms.validators import Optional as OptionalValidator
@@ -18,9 +18,9 @@ class FieldHandler(ABC):
 
     def __init__(
         self,
-        answer_schema: dict,
+        answer_schema: Mapping[str, Any],
         value_source_resolver: ValueSourceResolver,
-        error_messages: dict[str, str],
+        error_messages: Mapping[str, str],
         disable_validation: bool = False,
         question_title: str = None,
     ):

--- a/app/forms/field_handlers/number_handler.py
+++ b/app/forms/field_handlers/number_handler.py
@@ -87,7 +87,7 @@ class NumberHandler(FieldHandler):
     def _get_number_field_validators(
         self,
     ) -> list[Union[NumberCheck, NumberRange, DecimalPlaces]]:
-        answer_errors = self.error_messages.copy()
+        answer_errors = dict(self.error_messages)
 
         for error_key in self.validation_messages.keys():
             answer_errors[error_key] = self.get_validation_message(error_key)

--- a/app/forms/questionnaire_form.py
+++ b/app/forms/questionnaire_form.py
@@ -1,31 +1,46 @@
+from __future__ import annotations
+
 import itertools
 import logging
+from collections.abc import Callable
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
+from typing import Any, Mapping, Optional, Sequence, Union
 
 from dateutil.relativedelta import relativedelta
 from flask_wtf import FlaskForm
 from werkzeug.datastructures import ImmutableMultiDict, MultiDict
 from wtforms import validators
 
+from app.data_models import AnswerStore, AnswerValueTypes, ListStore
 from app.forms import error_messages
-from app.forms.field_handlers import DateHandler, get_field_handler
+from app.forms.field_handlers import DateHandler, FieldHandler, get_field_handler
 from app.forms.validators import DateRangeCheck, MutuallyExclusiveCheck, SumCheck
+from app.questionnaire import Location, QuestionnaireSchema, QuestionSchema
+from app.questionnaire.relationship_location import RelationshipLocation
 from app.questionnaire.value_source_resolver import ValueSourceResolver
 
 logger = logging.getLogger(__name__)
+
+Calculation = Mapping[str, Any]
+QuestionnaireExtraValidators = Mapping[str, Sequence[Callable]]
+Period = Mapping[str, int]
+PeriodLimits = Mapping[str, Any]
+Error = Union[Mapping, Sequence]
+Errors = Mapping[str, Error]
+ErrorList = Sequence[tuple[str, str]]
 
 
 class QuestionnaireForm(FlaskForm):
     def __init__(
         self,
-        schema,
-        question_schema,
-        answer_store,
-        list_store,
-        metadata,
-        location,
-        **kwargs,
+        schema: QuestionnaireSchema,
+        question_schema: QuestionSchema,
+        answer_store: AnswerStore,
+        list_store: ListStore,
+        metadata: dict[str, Any],
+        location: Union[None, Location, RelationshipLocation],
+        **kwargs: Union[MultiDict[str, Any], Mapping[str, Any], None],
     ):
         self.schema = schema
         self.question = question_schema
@@ -33,18 +48,20 @@ class QuestionnaireForm(FlaskForm):
         self.list_store = list_store
         self.metadata = metadata
         self.location = location
-        self.question_errors = {}
-        self.options_with_detail_answer = {}
+        self.question_errors: dict[str, str] = {}
+        self.options_with_detail_answer: dict = {}
         self.question_title = self.question.get("title", "")
 
         super().__init__(**kwargs)
 
-    def validate(self, extra_validators=None):
+    def validate(
+        self, extra_validators: Optional[QuestionnaireExtraValidators] = None
+    ) -> bool:
         """
         Validate this form as usual and check for any form-level validation errors based on question type
         :return: boolean
         """
-        super(QuestionnaireForm, self).validate(extra_validators)
+        super(QuestionnaireForm, self).validate(extra_validators=extra_validators)
         valid_fields = FlaskForm.validate(self)
         valid_date_range_form = True
         valid_calculated_form = True
@@ -71,7 +88,7 @@ class QuestionnaireForm(FlaskForm):
             and valid_mutually_exclusive_form
         )
 
-    def validate_date_range_question(self, question):
+    def validate_date_range_question(self, question: QuestionSchema) -> bool:
         date_from = question["answers"][0]
         date_to = question["answers"][1]
         if self._has_min_and_max_single_dates(date_from, date_to):
@@ -109,25 +126,25 @@ class QuestionnaireForm(FlaskForm):
 
         return True
 
-    def validate_calculated_question(self, question):
+    def validate_calculated_question(self, question: QuestionSchema) -> bool:
         for calculation in question["calculations"]:
-            target_total, currency = self._get_target_total_and_currency(
-                calculation, question
-            )
-            if self.answers_all_valid(
-                calculation["answers_to_calculate"]
-            ) and self._validate_calculated_question(
-                calculation, question, target_total, currency
-            ):
-                # Remove any previous question errors if it passes this OR before returning True
-                if question["id"] in self.question_errors:
-                    self.question_errors.pop(question["id"])
-                return True
+            result = self._get_target_total_and_currency(calculation, question)
+            if result:
+                target_total, currency = result
+                if self.answers_all_valid(
+                    calculation["answers_to_calculate"]
+                ) and self._validate_calculated_question(
+                    calculation, question, target_total, currency
+                ):
+                    # Remove any previous question errors if it passes this OR before returning True
+                    if question["id"] in self.question_errors:
+                        self.question_errors.pop(question["id"])
+                    return True
 
         return False
 
-    def validate_mutually_exclusive_question(self, question):
-        is_mandatory = question.get("mandatory")
+    def validate_mutually_exclusive_question(self, question: QuestionSchema) -> bool:
+        is_mandatory: bool = question["mandatory"]
         messages = (
             question["validation"].get("messages") if "validation" in question else None
         )
@@ -149,23 +166,39 @@ class QuestionnaireForm(FlaskForm):
             return False
         return True
 
-    def _get_target_total_and_currency(self, calculation, question):
+    def _get_target_total_and_currency(
+        self,
+        calculation: Calculation,
+        question: QuestionSchema,
+    ) -> Optional[tuple[Union[Calculation, AnswerValueTypes], Optional[str]]]:
+
+        calculation_value: Union[Calculation, AnswerValueTypes]
+        currency: Optional[str]
+
         if "value" in calculation:
-            return calculation["value"], question.get("currency")
+            calculation_value = calculation["value"]
+            currency = question.get("currency")
+            return calculation_value, currency
 
         target_answer = self.schema.get_answers_by_answer_id(calculation["answer_id"])[
             0
         ]
-        return (
-            self.answer_store.get_answer(calculation["answer_id"]).value,
-            target_answer.get("currency"),
-        )
+        calculation_value = self.answer_store.get_answer(
+            calculation["answer_id"]
+        ).value  # type: ignore # expect not None
+        currency = target_answer.get("currency")
+
+        return calculation_value, currency
 
     def validate_date_range_with_period_limits_and_single_date_limits(
-        self, question_id, period_limits, period_range
-    ):
+        self,
+        question_id: Union[str, Sequence[Mapping]],
+        period_limits: PeriodLimits,
+        period_range: timedelta,
+    ) -> None:
         # Get period_limits from question
-        period_min = self._get_period_limits(period_limits)[0]
+        period_limits_item: tuple = self._get_period_limits(period_limits)
+        period_min: Mapping[str, int] = period_limits_item[0]
         min_offset = self._get_offset_value(period_min)
 
         # Exception to be raised if range available is smaller than minimum range allowed
@@ -176,7 +209,9 @@ class QuestionnaireForm(FlaskForm):
             raise Exception(exception)
 
     @staticmethod
-    def validate_date_range_with_single_date_limits(question_id, period_range):
+    def validate_date_range_with_single_date_limits(
+        question_id: str, period_range: timedelta
+    ) -> None:
         # Exception to be raised if range from answers are smaller than
         # minimum or larger than maximum period_limits
         exception = "The schema has invalid date answer limits for {}".format(
@@ -187,8 +222,13 @@ class QuestionnaireForm(FlaskForm):
             raise Exception(exception)
 
     def _validate_date_range_question(
-        self, question_id, period_from_id, period_to_id, messages, period_limits
-    ):
+        self,
+        question_id: str,
+        period_from_id: str,
+        period_to_id: str,
+        messages: Mapping[str, str],
+        period_limits: Optional[PeriodLimits],
+    ) -> bool:
         period_from = getattr(self, period_from_id)
         period_to = getattr(self, period_to_id)
         period_min, period_max = self._get_period_limits(period_limits)
@@ -207,8 +247,12 @@ class QuestionnaireForm(FlaskForm):
         return True
 
     def _validate_calculated_question(
-        self, calculation, question, target_total, currency
-    ):
+        self,
+        calculation: Calculation,
+        question: QuestionSchema,
+        target_total: Any,
+        currency: Optional[str],
+    ) -> bool:
         messages = None
         if "validation" in question:
             messages = question["validation"].get("messages")
@@ -234,7 +278,11 @@ class QuestionnaireForm(FlaskForm):
 
         return True
 
-    def _get_period_range_for_single_date(self, date_from, date_to):
+    def _get_period_range_for_single_date(
+        self,
+        date_from: Mapping[str, dict],
+        date_to: Mapping[str, dict],
+    ) -> timedelta:
 
         list_item_id = self.location.list_item_id if self.location else None
         value_source_resolver = ValueSourceResolver(
@@ -248,15 +296,17 @@ class QuestionnaireForm(FlaskForm):
         )
 
         handler = DateHandler(date_from, value_source_resolver, error_messages)
-        from_min_period_date = handler.get_date_value("minimum")
-        from_max_period_date = handler.get_date_value("maximum")
 
+        min_period_date = handler.get_date_value("minimum") or handler.get_date_value(
+            "maximum"
+        )
         handler.answer_schema = date_to
-        to_min_period_date = handler.get_date_value("minimum")
-        to_max_period_date = handler.get_date_value("maximum")
+        max_period_date = handler.get_date_value("maximum") or handler.get_date_value(
+            "minimum"
+        )
 
-        min_period_date = from_min_period_date or from_max_period_date
-        max_period_date = to_max_period_date or to_min_period_date
+        if not min_period_date or not max_period_date:
+            raise ValueError("Period range must have a start and end date")
 
         # Work out the largest possible range, for date range question
         period_range = max_period_date - min_period_date
@@ -264,17 +314,20 @@ class QuestionnaireForm(FlaskForm):
         return period_range
 
     @staticmethod
-    def is_date_form_populated(date_from, date_to):
+    def is_date_form_populated(date_from: Sequence, date_to: Sequence) -> bool:
         return all(field.data for field in itertools.chain(date_from, date_to))
 
     @staticmethod
-    def _has_min_and_max_single_dates(date_from, date_to):
+    def _has_min_and_max_single_dates(
+        date_from: Mapping[str, Mapping],
+        date_to: Mapping[str, Mapping],
+    ) -> bool:
         return ("minimum" in date_from or "maximum" in date_from) and (
             "minimum" in date_to or "maximum" in date_to
         )
 
     @staticmethod
-    def _get_offset_value(period_object):
+    def _get_offset_value(period_object: Mapping[str, int]) -> timedelta:
         now = datetime.now(tz=timezone.utc)
         delta = relativedelta(
             years=period_object.get("years", 0),
@@ -285,7 +338,9 @@ class QuestionnaireForm(FlaskForm):
         return now + delta - now
 
     @staticmethod
-    def _get_period_limits(limits):
+    def _get_period_limits(
+        limits: Optional[PeriodLimits],
+    ) -> tuple[Optional[dict[str, Any]], Optional[dict[str, Any]]]:
         minimum, maximum = None, None
         if limits:
             if "minimum" in limits:
@@ -295,26 +350,31 @@ class QuestionnaireForm(FlaskForm):
         return minimum, maximum
 
     @staticmethod
-    def _get_calculation_type(calculation_type):
+    def _get_calculation_type(calculation_type: str) -> Callable:
         if calculation_type == "sum":
             return sum
 
         raise Exception("Invalid calculation_type: {}".format(calculation_type))
 
-    def _get_formatted_calculation_values(self, answers_list):
+    def _get_formatted_calculation_values(
+        self, answers_list: Sequence[str]
+    ) -> list[str]:
         return [
             self.get_data(answer_id).replace(" ", "").replace(",", "")
             for answer_id in answers_list
         ]
 
     @staticmethod
-    def _get_calculation_total(calculation_type, values):
-        return calculation_type(Decimal(value or 0) for value in values)
+    def _get_calculation_total(
+        calculation_type: Callable, values: Sequence[Union[float, int, Decimal, str]]
+    ) -> Decimal:
+        result: Decimal = calculation_type(Decimal(value or 0) for value in values)
+        return result
 
-    def answers_all_valid(self, answer_id_list):
+    def answers_all_valid(self, answer_id_list: Sequence[str]) -> bool:
         return not set(answer_id_list) & set(self.errors)
 
-    def map_errors(self):
+    def map_errors(self) -> list[tuple[str, str]]:
         ordered_errors = []
 
         if self.question["id"] in self.question_errors:
@@ -333,24 +393,38 @@ class QuestionnaireForm(FlaskForm):
 
         return ordered_errors
 
-    def answer_errors(self, input_id):
+    def answer_errors(self, input_id: str) -> list[str]:
         error_id = _get_error_id(input_id)
         return [error[1] for error in self.map_errors() if error_id == error[0]]
 
-    def get_data(self, answer_id):
+    def get_data(self, answer_id: str) -> str:
         attr = getattr(self, answer_id)
-        return attr.raw_data[0] if attr.raw_data else ""
+        if attr.raw_data:
+            result: str = attr.raw_data[0]
+        else:
+            result = ""
+        return result
 
 
-def _option_value_in_data(answer, option, data):
+def _option_value_in_data(
+    answer: Mapping[str, str],
+    option: Mapping[str, Any],
+    data: Union[MultiDict[str, Any], Mapping[str, Any]],
+) -> bool:
     data_to_inspect = data.to_dict(flat=False) if isinstance(data, MultiDict) else data
 
-    return option["value"] in dict(data_to_inspect).get(answer["id"], [])
+    return option["value"] in data_to_inspect.get(answer["id"], [])
 
 
 def get_answer_fields(
-    question, data, schema, answer_store, list_store, metadata, location
-):
+    question: QuestionSchema,
+    data: Union[None, MultiDict[str, Any], Mapping[str, Any]],
+    schema: QuestionnaireSchema,
+    answer_store: AnswerStore,
+    list_store: ListStore,
+    metadata: dict[str, Any],
+    location: Union[Location, RelationshipLocation, None],
+) -> dict[str, FieldHandler]:
     list_item_id = location.list_item_id if location else None
     value_source_resolver = ValueSourceResolver(
         answer_store=answer_store,
@@ -367,7 +441,11 @@ def get_answer_fields(
     for answer in question.get("answers", []):
         for option in answer.get("options", []):
             if "detail_answer" in option:
-                disable_validation = not _option_value_in_data(answer, option, data)
+                if data:
+                    disable_validation = not _option_value_in_data(answer, option, data)
+                else:
+                    disable_validation = True
+
                 detail_answer = option["detail_answer"]
 
                 answer_fields[option["detail_answer"]["id"]] = get_field_handler(
@@ -387,23 +465,28 @@ def get_answer_fields(
     return answer_fields
 
 
-def map_subfield_errors(errors, answer_id):
+def map_subfield_errors(errors: Mapping[str, Any], answer_id: str) -> ErrorList:
     subfield_errors = []
 
     if isinstance(errors[answer_id], dict):
-        for error_list in errors[answer_id].values():
+        errors_dict = errors[answer_id]
+        for error_list in errors_dict.values():
             for error in error_list:
                 error_id = _get_error_id(answer_id)
                 subfield_errors.append((error_id, error))
     else:
-        for error in errors[answer_id]:
+        errors_list = errors[answer_id]
+        for error in errors_list:
             error_id = _get_error_id(answer_id)
             subfield_errors.append((error_id, error))
 
     return subfield_errors
 
 
-def map_detail_answer_errors(errors, answer_json):
+def map_detail_answer_errors(
+    errors: Errors,
+    answer_json: Mapping[str, Any],
+) -> ErrorList:
     detail_answer_errors = []
 
     for option in answer_json["options"]:
@@ -415,11 +498,13 @@ def map_detail_answer_errors(errors, answer_json):
     return detail_answer_errors
 
 
-def _get_error_id(id):
+def _get_error_id(id: str) -> str:
     return f"{id}-error"
 
 
-def _clear_detail_answer_field(form_data, question_schema):
+def _clear_detail_answer_field(
+    form_data: MultiDict, question_schema: QuestionSchema
+) -> MultiDict[str, Any]:
     """
     Clears the detail answer field if the parent option is not selected
     """
@@ -435,23 +520,25 @@ def _clear_detail_answer_field(form_data, question_schema):
 
 
 def generate_form(
-    schema,
-    question_schema,
-    answer_store,
-    list_store,
-    metadata,
-    location=None,
-    data=None,
-    form_data=None,
-):
+    schema: QuestionnaireSchema,
+    question_schema: QuestionSchema,
+    answer_store: AnswerStore,
+    list_store: ListStore,
+    metadata: dict[str, Any],
+    location: Union[None, Location, RelationshipLocation] = None,
+    data: Optional[dict[str, Any]] = None,
+    form_data: Optional[MultiDict[str, Any]] = None,
+) -> QuestionnaireForm:
     class DynamicForm(QuestionnaireForm):
         pass
 
     if form_data:
         form_data = _clear_detail_answer_field(form_data, question_schema)
+
+    input_data = form_data if form_data is not None else data
     answer_fields = get_answer_fields(
         question_schema,
-        form_data if form_data is not None else data,
+        input_data,
         schema,
         answer_store,
         list_store,

--- a/app/forms/validators.py
+++ b/app/forms/validators.py
@@ -400,10 +400,10 @@ class SumCheck:
 
     def __call__(
         self,
-        form: "QuestionnaireForm",
+        form: QuestionnaireForm,
         conditions: List[str],
-        total: int,
-        target_total: int,
+        total: Decimal,
+        target_total: Union[Decimal, int],
     ) -> None:
         if len(conditions) > 1:
             try:
@@ -427,7 +427,9 @@ class SumCheck:
             )
 
     @staticmethod
-    def _is_valid(condition: str, total: int, target_total: int) -> tuple[bool, str]:
+    def _is_valid(
+        condition: str, total: Decimal, target_total: Union[Decimal, int]
+    ) -> tuple[bool, str]:
         if condition == "equals":
             return total == target_total, "TOTAL_SUM_NOT_EQUALS"
         if condition == "less than":

--- a/app/questionnaire/__init__.py
+++ b/app/questionnaire/__init__.py
@@ -1,4 +1,4 @@
 from .location import Location
-from .questionnaire_schema import QuestionnaireSchema
+from .questionnaire_schema import QuestionnaireSchema, QuestionSchema
 
-__all__ = ["QuestionnaireSchema", "Location"]
+__all__ = ["QuestionnaireSchema", "Location", "QuestionSchema"]

--- a/app/questionnaire/questionnaire_schema.py
+++ b/app/questionnaire/questionnaire_schema.py
@@ -21,6 +21,8 @@ LIST_COLLECTOR_CHILDREN = [
 
 RELATIONSHIP_CHILDREN = ["UnrelatedQuestion"]
 
+QuestionSchema = Mapping[str, Any]
+
 
 class QuestionnaireSchema:  # pylint: disable=too-many-public-methods
     def __init__(
@@ -379,11 +381,12 @@ class QuestionnaireSchema:  # pylint: disable=too-many-public-methods
             or self.is_answer_in_repeating_section(answer_id)
         )
 
-    def get_answers_by_answer_id(self, answer_id: str) -> Optional[list[ImmutableDict]]:
+    def get_answers_by_answer_id(self, answer_id: str) -> list[ImmutableDict]:
         """Return answers matching answer id, including all matching answers inside
         variants
         """
-        return self._answers_by_id.get(answer_id)
+        answers: list[ImmutableDict] = self._answers_by_id.get(answer_id, [])
+        return answers
 
     def get_default_answer(self, answer_id: str) -> Optional[Answer]:
         if answer_schemas := self.get_answers_by_answer_id(answer_id):

--- a/app/views/handlers/confirm_email.py
+++ b/app/views/handlers/confirm_email.py
@@ -17,7 +17,7 @@ from app.data_models import (
 )
 from app.forms.questionnaire_form import generate_form
 from app.helpers import url_safe_serializer
-from app.questionnaire import QuestionnaireSchema
+from app.questionnaire import QuestionnaireSchema, QuestionSchema
 from app.settings import (
     EQ_SUBMISSION_CONFIRMATION_CLOUD_FUNCTION_NAME,
     EQ_SUBMISSION_CONFIRMATION_QUEUE,
@@ -80,7 +80,7 @@ class ConfirmEmail:
         )
 
     @cached_property
-    def question_schema(self):
+    def question_schema(self) -> QuestionSchema:
         return {
             "type": "General",
             "id": "confirm-email",

--- a/app/views/handlers/question.py
+++ b/app/views/handlers/question.py
@@ -1,4 +1,5 @@
 from functools import cached_property
+from typing import Any
 
 from flask import url_for
 from flask_babel import gettext
@@ -98,7 +99,7 @@ class Question(BlockHandler):
             self._current_location, self._routing_path, self._return_to
         )
 
-    def _get_answers_for_question(self, question_json):
+    def _get_answers_for_question(self, question_json) -> dict[str, Any]:
         answer_ids = self._schema.get_answer_ids_for_question(question_json)
         answers = self._questionnaire_store.answer_store.get_answers_by_answer_id(
             answer_ids=answer_ids, list_item_id=self._current_location.list_item_id

--- a/mypy.ini
+++ b/mypy.ini
@@ -66,6 +66,18 @@ warn_return_any = True
 disallow_untyped_defs = True
 warn_return_any = True
 
+[mypy-app.forms.questionnaire_form]
+disallow_untyped_defs = True
+warn_return_any = True
+
+[mypy-app.forms.email_form]
+disallow_untyped_defs = True
+warn_return_any = True
+
+[mypy-app.forms.address_form]
+disallow_untyped_defs = True
+warn_return_any = True
+
 [mypy-app.forms.validators]
 disallow_untyped_defs = True
 warn_return_any = True

--- a/tests/app/forms/test_questionnaire_form.py
+++ b/tests/app/forms/test_questionnaire_form.py
@@ -646,6 +646,37 @@ class TestQuestionnaireForm(
                 schema.error_messages["DATE_PERIOD_TOO_LARGE"] % {"max": "3 years"},
             )
 
+    def test_date_raises_ValueError_when_any_date_range_parts_are_falsy(self):
+        with self.app_request_context():
+            schema = load_schema_from_name("test_date_validation_combined")
+
+            question_schema = schema.get_block("date-range-block")["question"]
+
+            form_data = MultiDict(
+                {
+                    "date-range-from-day": "01",
+                    "date-range-from-month": "1",
+                    "date-range-from-year": "2017",
+                    "date-range-to-day": "14",
+                    "date-range-to-month": "3",
+                    "date-range-to-year": "2017",
+                }
+            )
+
+            metadata = {"ref_p_start_date": "2017-01-21"}
+
+            form = generate_form(
+                schema,
+                question_schema,
+                AnswerStore(),
+                ListStore(),
+                metadata,
+                form_data=form_data,
+            )
+
+            with self.assertRaises(ValueError):
+                form.validate()
+
     def test_bespoke_message_for_date_validation_range(self):
         with self.app_request_context():
             schema = load_schema_from_name("test_date_validation_range")


### PR DESCRIPTION
### What is the context of this PR?
Adds type hints to `apps/forms/address_form.py`, `apps/forms/email_form.py`, `apps/forms/questionnaire_form.py` to ease development and identify issues with incompatible types earlier. 

Companion PR, adding type hints to the other modules in `forms`: https://github.com/ONSdigital/eq-questionnaire-runner/pull/668

### How to review 
Run unit tests (most importantly mypy) to show no breakage and that types used are all correct. Reviewers to check the more complicated types like nested dicts/lists if they happen to know the code already.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
