### PR TITLE
Add new routing and or and not operators

### DIFF
--- a/test_schemas/en/test_new_routing_and.json
+++ b/test_schemas/en/test_new_routing_and.json
@@ -6,7 +6,7 @@
     "survey_id": "001",
     "title": "Test Routing And",
     "theme": "default",
-    "description": "A test survey for routing based on the and operator",
+    "description": "A test survey for routing based on the AND operator",
     "metadata": [
         {
             "name": "user_id",

--- a/test_schemas/en/test_new_routing_and.json
+++ b/test_schemas/en/test_new_routing_and.json
@@ -1,0 +1,175 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "language": "en",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.3",
+    "survey_id": "001",
+    "title": "Test Routing And",
+    "theme": "default",
+    "description": "A test survey for routing based on the and operator",
+    "metadata": [
+        {
+            "name": "user_id",
+            "type": "string"
+        },
+        {
+            "name": "period_id",
+            "type": "string"
+        },
+        {
+            "name": "ru_name",
+            "type": "string"
+        }
+    ],
+    "questionnaire_flow": {
+        "type": "Linear",
+        "options": {
+            "summary": {
+                "collapsible": false
+            }
+        }
+    },
+    "sections": [
+        {
+            "id": "default-section",
+            "groups": [
+                {
+                    "blocks": [
+                        {
+                            "type": "Question",
+                            "id": "number-question-1",
+                            "question": {
+                                "answers": [
+                                    {
+                                        "id": "answer-1",
+                                        "mandatory": true,
+                                        "type": "Number",
+                                        "label": "Enter 123"
+                                    }
+                                ],
+                                "id": "question",
+                                "title": "Enter the number 123",
+                                "type": "General"
+                            }
+                        },
+                        {
+                            "type": "Question",
+                            "id": "number-question-2",
+                            "question": {
+                                "answers": [
+                                    {
+                                        "id": "answer-2",
+                                        "mandatory": true,
+                                        "type": "Number",
+                                        "label": "Enter 321"
+                                    }
+                                ],
+                                "id": "question",
+                                "title": "Enter the number 321",
+                                "type": "General"
+                            },
+                            "routing_rules": [
+                                {
+                                    "block": "correct-answer",
+                                    "when": {
+                                        "and": [
+                                            {
+                                                "==": [
+                                                    {
+                                                        "source": "answers",
+                                                        "identifier": "answer-1"
+                                                    },
+                                                    123
+                                                ]
+                                            },
+                                            {
+                                                "==": [
+                                                    {
+                                                        "source": "answers",
+                                                        "identifier": "answer-2"
+                                                    },
+                                                    321
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "block": "incorrect-answer"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "Interstitial",
+                            "id": "incorrect-answer",
+                            "content": {
+                                "title": "You did not enter the correct answers",
+                                "contents": [
+                                    {
+                                        "description": {
+                                            "text": "You were asked to enter <em>123</em> and <em>321</em> but you actually entered <em>{answer-1}</em> and <em>{answer-2}</em>.",
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "answer-1",
+                                                    "value": {
+                                                        "source": "answers",
+                                                        "identifier": "answer-1"
+                                                    }
+                                                },
+                                                {
+                                                    "placeholder": "answer-2",
+                                                    "value": {
+                                                        "source": "answers",
+                                                        "identifier": "answer-2"
+                                                    }
+                                                }
+
+                                            ]
+                                        }
+                                    }
+                                ]
+                            },
+                            "routing_rules": [
+                                {
+                                    "section": "End"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "Interstitial",
+                            "id": "correct-answer",
+                            "content": {
+                                "title": "Correct",
+                                "contents": [
+                                    {
+                                        "description": {
+                                            "text": "You were asked to enter <em>123</em> and <em>321</em> and you entered <em>{answer-1}</em> and <em>{answer-2}</em>.",
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "answer-1",
+                                                    "value": {
+                                                        "source": "answers",
+                                                        "identifier": "answer-1"
+                                                    }
+                                                },
+                                                {
+                                                    "placeholder": "answer-2",
+                                                    "value": {
+                                                        "source": "answers",
+                                                        "identifier": "answer-2"
+                                                    }
+                                                }
+
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "id": "group"
+                }
+            ]
+        }
+    ]
+}

--- a/test_schemas/en/test_new_routing_and.json
+++ b/test_schemas/en/test_new_routing_and.json
@@ -47,7 +47,7 @@
                                         "label": "Enter 123"
                                     }
                                 ],
-                                "id": "question",
+                                "id": "question-1",
                                 "title": "Enter the number 123",
                                 "type": "General"
                             }
@@ -64,7 +64,7 @@
                                         "label": "Enter 321"
                                     }
                                 ],
-                                "id": "question",
+                                "id": "question-2",
                                 "title": "Enter the number 321",
                                 "type": "General"
                             },

--- a/test_schemas/en/test_new_routing_and.json
+++ b/test_schemas/en/test_new_routing_and.json
@@ -39,6 +39,13 @@
                             "type": "Question",
                             "id": "number-question-1",
                             "question": {
+                                "guidance": {
+                                    "contents": [
+                                        {
+                                            "description": "Enter 123 here AND 321 on the next question to route to the “correct” page otherwise you will be routed to the “incorrect” page"
+                                        }
+                                    ]
+                                },
                                 "answers": [
                                     {
                                         "id": "answer-1",

--- a/test_schemas/en/test_new_routing_and.json
+++ b/test_schemas/en/test_new_routing_and.json
@@ -123,7 +123,6 @@
                                                         "identifier": "answer-2"
                                                     }
                                                 }
-
                                             ]
                                         }
                                     }
@@ -159,7 +158,6 @@
                                                         "identifier": "answer-2"
                                                     }
                                                 }
-
                                             ]
                                         }
                                     }

--- a/test_schemas/en/test_new_routing_not.json
+++ b/test_schemas/en/test_new_routing_not.json
@@ -71,7 +71,7 @@
                             },
                             "routing_rules": [
                                 {
-                                    "block": "country-interstitial-india",
+                                    "block": "country-interstitial-not-india",
                                     "when": {
                                         "not": [
                                             {
@@ -87,18 +87,30 @@
                                     }
                                 },
                                 {
-                                    "section": "End"
+                                    "block": "country-interstitial-india"
                                 }
                             ]
                         },
                         {
-                            "id": "country-interstitial-india",
+                            "id": "country-interstitial-not-india",
                             "type": "Interstitial",
                             "content": {
                                 "title": "Condition: Does not contain India",
                                 "contents": [
                                     {
                                         "description": "You did not chose India."
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "id": "country-interstitial-india",
+                            "type": "Interstitial",
+                            "content": {
+                                "title": "Condition: Contained India",
+                                "contents": [
+                                    {
+                                        "description": "You chose India."
                                     }
                                 ]
                             }

--- a/test_schemas/en/test_new_routing_not.json
+++ b/test_schemas/en/test_new_routing_not.json
@@ -6,7 +6,7 @@
     "survey_id": "001",
     "title": "Test Routing Not",
     "theme": "default",
-    "description": "A test survey for routing based on the not operator",
+    "description": "A test survey for routing based on the NOT operator",
     "metadata": [
         {
             "name": "user_id",
@@ -37,61 +37,48 @@
                     "blocks": [
                         {
                             "type": "Question",
-                            "id": "number-question-1",
+                            "id": "country-checkbox",
                             "question": {
+                                "id": "country-checkbox-question",
+                                "title": "Have you visited any of the following countries?",
+                                "type": "General",
                                 "answers": [
                                     {
-                                        "id": "answer-1",
-                                        "mandatory": true,
-                                        "type": "Number",
-                                        "label": "Do not enter 123"
+                                        "id": "country-checkbox-answer",
+                                        "mandatory": false,
+                                        "type": "Checkbox",
+                                        "options": [
+                                            {
+                                                "label": "India",
+                                                "value": "India"
+                                            },
+                                            {
+                                                "label": "Azerbaijan",
+                                                "value": "Azerbaijan"
+                                            },
+                                            {
+                                                "label": "Liechtenstein",
+                                                "value": "Liechtenstein"
+                                            },
+                                            {
+                                                "label": "Malta",
+                                                "value": "Malta"
+                                            }
+                                        ]
                                     }
-                                ],
-                                "id": "question-1",
-                                "title": "Do not enter the number 123",
-                                "type": "General"
-                            }
-                        },
-                        {
-                            "type": "Question",
-                            "id": "number-question-2",
-                            "question": {
-                                "answers": [
-                                    {
-                                        "id": "answer-2",
-                                        "mandatory": true,
-                                        "type": "Number",
-                                        "label": "Do not enter 321"
-                                    }
-                                ],
-                                "id": "question-2",
-                                "title": "Do not enter the number 321",
-                                "type": "General"
+                                ]
                             },
                             "routing_rules": [
                                 {
-                                    "block": "correct-answer",
+                                    "block": "country-interstitial-india",
                                     "when": {
                                         "not": [
                                             {
-                                                "and": [
+                                                "in": [
+                                                    "India",
                                                     {
-                                                        "==": [
-                                                            {
-                                                                "source": "answers",
-                                                                "identifier": "answer-1"
-                                                            },
-                                                            123
-                                                        ]
-                                                    },
-                                                    {
-                                                        "==": [
-                                                            {
-                                                                "source": "answers",
-                                                                "identifier": "answer-2"
-                                                            },
-                                                            321
-                                                        ]
+                                                        "source": "answers",
+                                                        "identifier": "country-checkbox-answer"
                                                     }
                                                 ]
                                             }
@@ -99,77 +86,24 @@
                                     }
                                 },
                                 {
-                                    "block": "incorrect-answer"
-                                }
-                            ]
-                        },
-                        {
-                            "type": "Interstitial",
-                            "id": "incorrect-answer",
-                            "content": {
-                                "title": "You entered the incorrect numbers",
-                                "contents": [
-                                    {
-                                        "description": {
-                                            "text": "You were asked not to enter <em>123</em> and <em>321</em> but you entered <em>{answer-1}</em> and <em>{answer-2}</em>.",
-                                            "placeholders": [
-                                                {
-                                                    "placeholder": "answer-1",
-                                                    "value": {
-                                                        "source": "answers",
-                                                        "identifier": "answer-1"
-                                                    }
-                                                },
-                                                {
-                                                    "placeholder": "answer-2",
-                                                    "value": {
-                                                        "source": "answers",
-                                                        "identifier": "answer-2"
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            },
-                            "routing_rules": [
-                                {
                                     "section": "End"
                                 }
                             ]
                         },
                         {
+                            "id": "country-interstitial-india",
                             "type": "Interstitial",
-                            "id": "correct-answer",
                             "content": {
-                                "title": "Correct",
+                                "title": "Condition: Does not contain India",
                                 "contents": [
                                     {
-                                        "description": {
-                                            "text": "You were asked not to enter <em>123</em> and <em>321</em> and you entered <em>{answer-1}</em> and <em>{answer-2}</em>.",
-                                            "placeholders": [
-                                                {
-                                                    "placeholder": "answer-1",
-                                                    "value": {
-                                                        "source": "answers",
-                                                        "identifier": "answer-1"
-                                                    }
-                                                },
-                                                {
-                                                    "placeholder": "answer-2",
-                                                    "value": {
-                                                        "source": "answers",
-                                                        "identifier": "answer-2"
-                                                    }
-                                                }
-                                            ]
-                                        }
+                                        "description": "You did not chose India."
                                     }
                                 ]
                             }
                         }
                     ],
-                    "id": "group"
+                    "id": "checkboxes"
                 }
             ]
         }

--- a/test_schemas/en/test_new_routing_not.json
+++ b/test_schemas/en/test_new_routing_not.json
@@ -47,7 +47,7 @@
                                         "label": "Do not enter 123"
                                     }
                                 ],
-                                "id": "question",
+                                "id": "question-1",
                                 "title": "Do not enter the number 123",
                                 "type": "General"
                             }
@@ -64,7 +64,7 @@
                                         "label": "Do not enter 321"
                                     }
                                 ],
-                                "id": "question",
+                                "id": "question-2",
                                 "title": "Do not enter the number 321",
                                 "type": "General"
                             },

--- a/test_schemas/en/test_new_routing_not.json
+++ b/test_schemas/en/test_new_routing_not.json
@@ -127,7 +127,6 @@
                                                         "identifier": "answer-2"
                                                     }
                                                 }
-
                                             ]
                                         }
                                     }
@@ -163,7 +162,6 @@
                                                         "identifier": "answer-2"
                                                     }
                                                 }
-
                                             ]
                                         }
                                     }

--- a/test_schemas/en/test_new_routing_not.json
+++ b/test_schemas/en/test_new_routing_not.json
@@ -47,6 +47,7 @@
                                         "id": "country-checkbox-answer",
                                         "mandatory": false,
                                         "type": "Checkbox",
+                                        "instruction": "Do not select India",
                                         "options": [
                                             {
                                                 "label": "India",

--- a/test_schemas/en/test_new_routing_not.json
+++ b/test_schemas/en/test_new_routing_not.json
@@ -1,0 +1,179 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "language": "en",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.3",
+    "survey_id": "001",
+    "title": "Test Routing Not",
+    "theme": "default",
+    "description": "A test survey for routing based on the not operator",
+    "metadata": [
+        {
+            "name": "user_id",
+            "type": "string"
+        },
+        {
+            "name": "period_id",
+            "type": "string"
+        },
+        {
+            "name": "ru_name",
+            "type": "string"
+        }
+    ],
+    "questionnaire_flow": {
+        "type": "Linear",
+        "options": {
+            "summary": {
+                "collapsible": false
+            }
+        }
+    },
+    "sections": [
+        {
+            "id": "default-section",
+            "groups": [
+                {
+                    "blocks": [
+                        {
+                            "type": "Question",
+                            "id": "number-question-1",
+                            "question": {
+                                "answers": [
+                                    {
+                                        "id": "answer-1",
+                                        "mandatory": true,
+                                        "type": "Number",
+                                        "label": "Do not enter 123"
+                                    }
+                                ],
+                                "id": "question",
+                                "title": "Do not enter the number 123",
+                                "type": "General"
+                            }
+                        },
+                        {
+                            "type": "Question",
+                            "id": "number-question-2",
+                            "question": {
+                                "answers": [
+                                    {
+                                        "id": "answer-2",
+                                        "mandatory": true,
+                                        "type": "Number",
+                                        "label": "Do not enter 321"
+                                    }
+                                ],
+                                "id": "question",
+                                "title": "Do not enter the number 321",
+                                "type": "General"
+                            },
+                            "routing_rules": [
+                                {
+                                    "block": "correct-answer",
+                                    "when": {
+                                        "not": [
+                                            {
+                                                "and": [
+                                                    {
+                                                        "==": [
+                                                            {
+                                                                "source": "answers",
+                                                                "identifier": "answer-1"
+                                                            },
+                                                            123
+                                                        ]
+                                                    },
+                                                    {
+                                                        "==": [
+                                                            {
+                                                                "source": "answers",
+                                                                "identifier": "answer-2"
+                                                            },
+                                                            321
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "block": "incorrect-answer"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "Interstitial",
+                            "id": "incorrect-answer",
+                            "content": {
+                                "title": "You entered the incorrect numbers",
+                                "contents": [
+                                    {
+                                        "description": {
+                                            "text": "You were asked not to enter <em>123</em> and <em>321</em> but you entered <em>{answer-1}</em> and <em>{answer-2}</em>.",
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "answer-1",
+                                                    "value": {
+                                                        "source": "answers",
+                                                        "identifier": "answer-1"
+                                                    }
+                                                },
+                                                {
+                                                    "placeholder": "answer-2",
+                                                    "value": {
+                                                        "source": "answers",
+                                                        "identifier": "answer-2"
+                                                    }
+                                                }
+
+                                            ]
+                                        }
+                                    }
+                                ]
+                            },
+                            "routing_rules": [
+                                {
+                                    "section": "End"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "Interstitial",
+                            "id": "correct-answer",
+                            "content": {
+                                "title": "Correct",
+                                "contents": [
+                                    {
+                                        "description": {
+                                            "text": "You were asked not to enter <em>123</em> and <em>321</em> and you entered <em>{answer-1}</em> and <em>{answer-2}</em>.",
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "answer-1",
+                                                    "value": {
+                                                        "source": "answers",
+                                                        "identifier": "answer-1"
+                                                    }
+                                                },
+                                                {
+                                                    "placeholder": "answer-2",
+                                                    "value": {
+                                                        "source": "answers",
+                                                        "identifier": "answer-2"
+                                                    }
+                                                }
+
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "id": "group"
+                }
+            ]
+        }
+    ]
+}

--- a/test_schemas/en/test_new_routing_or.json
+++ b/test_schemas/en/test_new_routing_or.json
@@ -47,7 +47,7 @@
                                         "label": "Enter 123"
                                     }
                                 ],
-                                "id": "question",
+                                "id": "question-1",
                                 "title": "Enter the number 123",
                                 "type": "General"
                             }
@@ -64,7 +64,7 @@
                                         "label": "Enter 321"
                                     }
                                 ],
-                                "id": "question",
+                                "id": "question-2",
                                 "title": "Enter the number 321",
                                 "type": "General"
                             },

--- a/test_schemas/en/test_new_routing_or.json
+++ b/test_schemas/en/test_new_routing_or.json
@@ -1,0 +1,175 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "language": "en",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.3",
+    "survey_id": "001",
+    "title": "Test Routing Or",
+    "theme": "default",
+    "description": "A test survey for routing based on the or operator",
+    "metadata": [
+        {
+            "name": "user_id",
+            "type": "string"
+        },
+        {
+            "name": "period_id",
+            "type": "string"
+        },
+        {
+            "name": "ru_name",
+            "type": "string"
+        }
+    ],
+    "questionnaire_flow": {
+        "type": "Linear",
+        "options": {
+            "summary": {
+                "collapsible": false
+            }
+        }
+    },
+    "sections": [
+        {
+            "id": "default-section",
+            "groups": [
+                {
+                    "blocks": [
+                        {
+                            "type": "Question",
+                            "id": "number-question-1",
+                            "question": {
+                                "answers": [
+                                    {
+                                        "id": "answer-1",
+                                        "mandatory": true,
+                                        "type": "Number",
+                                        "label": "Enter 123"
+                                    }
+                                ],
+                                "id": "question",
+                                "title": "Enter the number 123",
+                                "type": "General"
+                            }
+                        },
+                        {
+                            "type": "Question",
+                            "id": "number-question-2",
+                            "question": {
+                                "answers": [
+                                    {
+                                        "id": "answer-2",
+                                        "mandatory": true,
+                                        "type": "Number",
+                                        "label": "Enter 321"
+                                    }
+                                ],
+                                "id": "question",
+                                "title": "Enter the number 321",
+                                "type": "General"
+                            },
+                            "routing_rules": [
+                                {
+                                    "block": "correct-answer",
+                                    "when": {
+                                        "or": [
+                                            {
+                                                "==": [
+                                                    {
+                                                        "source": "answers",
+                                                        "identifier": "answer-1"
+                                                    },
+                                                    123
+                                                ]
+                                            },
+                                            {
+                                                "==": [
+                                                    {
+                                                        "source": "answers",
+                                                        "identifier": "answer-2"
+                                                    },
+                                                    321
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "block": "incorrect-answer"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "Interstitial",
+                            "id": "incorrect-answer",
+                            "content": {
+                                "title": "You did not enter a correct answer",
+                                "contents": [
+                                    {
+                                        "description": {
+                                            "text": "You were asked to enter <em>123</em> or <em>321</em> but you actually entered <em>{answer-1}</em> and <em>{answer-2}</em>.",
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "answer-1",
+                                                    "value": {
+                                                        "source": "answers",
+                                                        "identifier": "answer-1"
+                                                    }
+                                                },
+                                                {
+                                                    "placeholder": "answer-2",
+                                                    "value": {
+                                                        "source": "answers",
+                                                        "identifier": "answer-2"
+                                                    }
+                                                }
+
+                                            ]
+                                        }
+                                    }
+                                ]
+                            },
+                            "routing_rules": [
+                                {
+                                    "section": "End"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "Interstitial",
+                            "id": "correct-answer",
+                            "content": {
+                                "title": "Correct",
+                                "contents": [
+                                    {
+                                        "description": {
+                                            "text": "You were asked to enter <em>123</em> or <em>321</em> and you entered <em>{answer-1}</em> and <em>{answer-2}</em>.",
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "answer-1",
+                                                    "value": {
+                                                        "source": "answers",
+                                                        "identifier": "answer-1"
+                                                    }
+                                                },
+                                                {
+                                                    "placeholder": "answer-2",
+                                                    "value": {
+                                                        "source": "answers",
+                                                        "identifier": "answer-2"
+                                                    }
+                                                }
+
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "id": "group"
+                }
+            ]
+        }
+    ]
+}

--- a/test_schemas/en/test_new_routing_or.json
+++ b/test_schemas/en/test_new_routing_or.json
@@ -6,7 +6,7 @@
     "survey_id": "001",
     "title": "Test Routing Or",
     "theme": "default",
-    "description": "A test survey for routing based on the or operator",
+    "description": "A test survey for routing based on the OR operator",
     "metadata": [
         {
             "name": "user_id",

--- a/test_schemas/en/test_new_routing_or.json
+++ b/test_schemas/en/test_new_routing_or.json
@@ -123,7 +123,6 @@
                                                         "identifier": "answer-2"
                                                     }
                                                 }
-
                                             ]
                                         }
                                     }
@@ -159,7 +158,6 @@
                                                         "identifier": "answer-2"
                                                     }
                                                 }
-
                                             ]
                                         }
                                     }

--- a/test_schemas/en/test_new_routing_or.json
+++ b/test_schemas/en/test_new_routing_or.json
@@ -39,6 +39,13 @@
                             "type": "Question",
                             "id": "number-question-1",
                             "question": {
+                                "guidance": {
+                                    "contents": [
+                                        {
+                                            "description": "Enter 123 here OR 321 on the next question to route to the “correct” page otherwise you will be routed to the “incorrect” page"
+                                        }
+                                    ]
+                                },
                                 "answers": [
                                     {
                                         "id": "answer-1",
@@ -56,13 +63,6 @@
                             "type": "Question",
                             "id": "number-question-2",
                             "question": {
-                                "guidance": {
-                                    "contents": [
-                                        {
-                                            "description": "Enter 123 here OR 321 on the next question to route to the “correct” page otherwise you will be routed to the “incorrect” page"
-                                        }
-                                    ]
-                                },
                                 "answers": [
                                     {
                                         "id": "answer-2",

--- a/test_schemas/en/test_new_routing_or.json
+++ b/test_schemas/en/test_new_routing_or.json
@@ -56,6 +56,13 @@
                             "type": "Question",
                             "id": "number-question-2",
                             "question": {
+                                "guidance": {
+                                    "contents": [
+                                        {
+                                            "description": "Enter 123 here OR 321 on the next question to route to the “correct” page otherwise you will be routed to the “incorrect” page"
+                                        }
+                                    ]
+                                },
                                 "answers": [
                                     {
                                         "id": "answer-2",

--- a/tests/functional/spec/features/routing/and.spec.js
+++ b/tests/functional/spec/features/routing/and.spec.js
@@ -10,7 +10,7 @@ describe("Feature: Routing - And Operator", () => {
         browser.openQuestionnaire("test_new_routing_and.json");
       });
 
-      it("When I enter both answers correctly, Then I should be routed to the correct page", () => {
+      it("When I enter 123 and 321, Then I should be routed to the correct page", () => {
         $(FirstNumberQuestionPage.answer1()).setValue(123);
         $(FirstNumberQuestionPage.submit()).click();
         $(SecondNumberQuestionPage.answer2()).setValue(321);
@@ -18,7 +18,7 @@ describe("Feature: Routing - And Operator", () => {
         expect(browser.getUrl()).to.contain(CorrectAnswerPage.pageName);
       });
 
-      it("When I enter one of the answers incorrectly, Then I should be routed to the incorrect page", () => {
+      it("When I enter 555 and 321, Then I should be routed to the incorrect page", () => {
         $(FirstNumberQuestionPage.answer1()).setValue(555);
         $(FirstNumberQuestionPage.submit()).click();
         $(SecondNumberQuestionPage.answer2()).setValue(321);
@@ -26,7 +26,7 @@ describe("Feature: Routing - And Operator", () => {
         expect(browser.getUrl()).to.contain(IncorrectAnswerPage.pageName);
       });
 
-      it("When I enter both answers incorrectly, Then I should be routed to the incorrect page", () => {
+      it("When I enter 555 and 444, Then I should be routed to the incorrect page", () => {
         $(FirstNumberQuestionPage.answer1()).setValue(555);
         $(FirstNumberQuestionPage.submit()).click();
         $(SecondNumberQuestionPage.answer2()).setValue(444);

--- a/tests/functional/spec/features/routing/and.spec.js
+++ b/tests/functional/spec/features/routing/and.spec.js
@@ -27,12 +27,12 @@ describe("Feature: Routing - And Operator", () => {
       });
 
       it("When I enter both answers incorrectly, Then I should be routed to the incorrect page", () => {
-          $(FirstNumberQuestionPage.answer1()).setValue(555);
-          $(FirstNumberQuestionPage.submit()).click();
-          $(SecondNumberQuestionPage.answer2()).setValue(444);
-          $(SecondNumberQuestionPage.submit()).click();
-          expect(browser.getUrl()).to.contain(IncorrectAnswerPage.pageName);
-        });
+        $(FirstNumberQuestionPage.answer1()).setValue(555);
+        $(FirstNumberQuestionPage.submit()).click();
+        $(SecondNumberQuestionPage.answer2()).setValue(444);
+        $(SecondNumberQuestionPage.submit()).click();
+        expect(browser.getUrl()).to.contain(IncorrectAnswerPage.pageName);
+      });
     });
   });
 });

--- a/tests/functional/spec/features/routing/and.spec.js
+++ b/tests/functional/spec/features/routing/and.spec.js
@@ -34,7 +34,7 @@ describe("Feature: Routing - And Operator", () => {
         expect(browser.getUrl()).to.contain(IncorrectAnswerPage.pageName);
       });
 
-      it("When I answer both questions incorrectly with 123 and 321, Then I should be routed to the incorrect page", () => {
+      it("When I answer both questions incorrectly with 555 and 444, Then I should be routed to the incorrect page", () => {
         $(FirstNumberQuestionPage.answer1()).setValue(555);
         $(FirstNumberQuestionPage.submit()).click();
         $(SecondNumberQuestionPage.answer2()).setValue(444);

--- a/tests/functional/spec/features/routing/and.spec.js
+++ b/tests/functional/spec/features/routing/and.spec.js
@@ -1,0 +1,38 @@
+import FirstNumberQuestionPage from "../../../generated_pages/new_routing_and/number-question-1.page";
+import SecondNumberQuestionPage from "../../../generated_pages/new_routing_and/number-question-2.page";
+import CorrectAnswerPage from "../../../generated_pages/new_routing_and/correct-answer.page";
+import IncorrectAnswerPage from "../../../generated_pages/new_routing_and/incorrect-answer.page";
+
+describe("Feature: Routing - And Operator", () => {
+  describe("Equals", () => {
+    describe("Given I start the and operator routing survey", () => {
+      beforeEach(() => {
+        browser.openQuestionnaire("test_new_routing_and.json");
+      });
+
+      it("When I enter both answers correctly, Then I should be routed to the correct page", () => {
+        $(FirstNumberQuestionPage.answer1()).setValue(123);
+        $(FirstNumberQuestionPage.submit()).click();
+        $(SecondNumberQuestionPage.answer2()).setValue(321);
+        $(SecondNumberQuestionPage.submit()).click();
+        expect(browser.getUrl()).to.contain(CorrectAnswerPage.pageName);
+      });
+
+      it("When I enter one of the answers incorrectly, Then I should be routed to the incorrect page", () => {
+        $(FirstNumberQuestionPage.answer1()).setValue(555);
+        $(FirstNumberQuestionPage.submit()).click();
+        $(SecondNumberQuestionPage.answer2()).setValue(321);
+        $(SecondNumberQuestionPage.submit()).click();
+        expect(browser.getUrl()).to.contain(IncorrectAnswerPage.pageName);
+      });
+
+      it("When I enter both answers incorrectly, Then I should be routed to the incorrect page", () => {
+          $(FirstNumberQuestionPage.answer1()).setValue(555);
+          $(FirstNumberQuestionPage.submit()).click();
+          $(SecondNumberQuestionPage.answer2()).setValue(444);
+          $(SecondNumberQuestionPage.submit()).click();
+          expect(browser.getUrl()).to.contain(IncorrectAnswerPage.pageName);
+        });
+    });
+  });
+});

--- a/tests/functional/spec/features/routing/and.spec.js
+++ b/tests/functional/spec/features/routing/and.spec.js
@@ -10,7 +10,7 @@ describe("Feature: Routing - And Operator", () => {
         browser.openQuestionnaire("test_new_routing_and.json");
       });
 
-      it("When I enter 123 and 321, Then I should be routed to the correct page", () => {
+      it("When I enter both answers correctly with 123 and 321, Then I should be routed to the correct page", () => {
         $(FirstNumberQuestionPage.answer1()).setValue(123);
         $(FirstNumberQuestionPage.submit()).click();
         $(SecondNumberQuestionPage.answer2()).setValue(321);
@@ -18,7 +18,7 @@ describe("Feature: Routing - And Operator", () => {
         expect(browser.getUrl()).to.contain(CorrectAnswerPage.pageName);
       });
 
-      it("When I enter 555 and 321, Then I should be routed to the incorrect page", () => {
+      it("When I only enter the second answer correctly with 555 and 321, Then I should be routed to the incorrect page", () => {
         $(FirstNumberQuestionPage.answer1()).setValue(555);
         $(FirstNumberQuestionPage.submit()).click();
         $(SecondNumberQuestionPage.answer2()).setValue(321);
@@ -26,7 +26,7 @@ describe("Feature: Routing - And Operator", () => {
         expect(browser.getUrl()).to.contain(IncorrectAnswerPage.pageName);
       });
 
-      it("When I enter 123 and 555, Then I should be routed to the incorrect page", () => {
+      it("When I only enter the first answer correctly with 123 and 555, Then I should be routed to the incorrect page", () => {
         $(FirstNumberQuestionPage.answer1()).setValue(123);
         $(FirstNumberQuestionPage.submit()).click();
         $(SecondNumberQuestionPage.answer2()).setValue(555);
@@ -34,7 +34,7 @@ describe("Feature: Routing - And Operator", () => {
         expect(browser.getUrl()).to.contain(IncorrectAnswerPage.pageName);
       });
 
-      it("When I do not enter 123 and 321, Then I should be routed to the incorrect page", () => {
+      it("When I answer both questions incorrectly with 123 and 321, Then I should be routed to the incorrect page", () => {
         $(FirstNumberQuestionPage.answer1()).setValue(555);
         $(FirstNumberQuestionPage.submit()).click();
         $(SecondNumberQuestionPage.answer2()).setValue(444);

--- a/tests/functional/spec/features/routing/and.spec.js
+++ b/tests/functional/spec/features/routing/and.spec.js
@@ -26,6 +26,14 @@ describe("Feature: Routing - And Operator", () => {
         expect(browser.getUrl()).to.contain(IncorrectAnswerPage.pageName);
       });
 
+      it("When I enter 123 and 555, Then I should be routed to the incorrect page", () => {
+        $(FirstNumberQuestionPage.answer1()).setValue(123);
+        $(FirstNumberQuestionPage.submit()).click();
+        $(SecondNumberQuestionPage.answer2()).setValue(555);
+        $(SecondNumberQuestionPage.submit()).click();
+        expect(browser.getUrl()).to.contain(IncorrectAnswerPage.pageName);
+      });
+
       it("When I do not enter 123 and 321, Then I should be routed to the incorrect page", () => {
         $(FirstNumberQuestionPage.answer1()).setValue(555);
         $(FirstNumberQuestionPage.submit()).click();

--- a/tests/functional/spec/features/routing/and.spec.js
+++ b/tests/functional/spec/features/routing/and.spec.js
@@ -26,7 +26,7 @@ describe("Feature: Routing - And Operator", () => {
         expect(browser.getUrl()).to.contain(IncorrectAnswerPage.pageName);
       });
 
-      it("When I enter 555 and 444, Then I should be routed to the incorrect page", () => {
+      it("When I do not enter 123 and 321, Then I should be routed to the incorrect page", () => {
         $(FirstNumberQuestionPage.answer1()).setValue(555);
         $(FirstNumberQuestionPage.submit()).click();
         $(SecondNumberQuestionPage.answer2()).setValue(444);

--- a/tests/functional/spec/features/routing/not.spec.js
+++ b/tests/functional/spec/features/routing/not.spec.js
@@ -10,13 +10,13 @@ describe("Feature: Routing - Not Operator", () => {
       });
 
       it("When I do not select India, Then I should be routed to the interstitial page", () => {
-        $(CountryCheckboxPage.India()).setValue(1);
+        $(CountryCheckboxPage.India()).click();
         $(CountryCheckboxPage.submit()).click();
         expect(browser.getUrl()).to.contain(CountryInterstitialPage.pageName);
       });
 
       it("When I do select India, Then I should be routed to the submit page", () => {
-        $(CountryCheckboxPage.India()).setValue(1);
+        $(CountryCheckboxPage.India()).click();
         $(CountryCheckboxPage.submit()).click();
         expect(browser.getUrl()).to.contain(SubmitPage.pageName);
       });

--- a/tests/functional/spec/features/routing/not.spec.js
+++ b/tests/functional/spec/features/routing/not.spec.js
@@ -10,13 +10,13 @@ describe("Feature: Routing - Not Operator", () => {
       });
 
       it("When I do not select India, Then I should be routed to the interstitial page", () => {
-        $(CountryCheckboxPage.India()).click();
+        $(CountryCheckboxPage.india()).click();
         $(CountryCheckboxPage.submit()).click();
         expect(browser.getUrl()).to.contain(CountryInterstitialPage.pageName);
       });
 
       it("When I do select India, Then I should be routed to the submit page", () => {
-        $(CountryCheckboxPage.India()).click();
+        $(CountryCheckboxPage.india()).click();
         $(CountryCheckboxPage.submit()).click();
         expect(browser.getUrl()).to.contain(SubmitPage.pageName);
       });

--- a/tests/functional/spec/features/routing/not.spec.js
+++ b/tests/functional/spec/features/routing/not.spec.js
@@ -1,6 +1,6 @@
 import CountryCheckboxPage from "../../../generated_pages/new_routing_not/country-checkbox.page";
-import CountryInterstitialPage from "../../../generated_pages/new_routing_not/country-interstitial-india.page";
-import SubmitPage from "../../../generated_pages/new_routing_not/submit.page";
+import CountryInterstitialPage from "../../../generated_pages/new_routing_not/country-interstitial-not-india.page";
+import IndiaInterstitialPage from "../../../generated_pages/new_routing_not/country-interstitial-india.page";
 
 describe("Feature: Routing - Not Operator", () => {
   describe("Equals", () => {
@@ -9,16 +9,16 @@ describe("Feature: Routing - Not Operator", () => {
         browser.openQuestionnaire("test_new_routing_not.json");
       });
 
-      it("When I do not select India, Then I should be routed to the interstitial page", () => {
+      it("When I do not select India, Then I should be routed to the not India interstitial page", () => {
         $(CountryCheckboxPage.azerbaijan()).click();
         $(CountryCheckboxPage.submit()).click();
         expect(browser.getUrl()).to.contain(CountryInterstitialPage.pageName);
       });
 
-      it("When I do select India, Then I should be routed to the submit page", () => {
+      it("When I select India, Then I should be routed to the India interstitial page", () => {
         $(CountryCheckboxPage.india()).click();
         $(CountryCheckboxPage.submit()).click();
-        expect(browser.getUrl()).to.contain(SubmitPage.pageName);
+        expect(browser.getUrl()).to.contain(IndiaInterstitialPage.pageName);
       });
     });
   });

--- a/tests/functional/spec/features/routing/not.spec.js
+++ b/tests/functional/spec/features/routing/not.spec.js
@@ -1,7 +1,6 @@
-import FirstNumberQuestionPage from "../../../generated_pages/new_routing_not/number-question-1.page";
-import SecondNumberQuestionPage from "../../../generated_pages/new_routing_not/number-question-2.page";
-import CorrectAnswerPage from "../../../generated_pages/new_routing_not/correct-answer.page";
-import IncorrectAnswerPage from "../../../generated_pages/new_routing_not/incorrect-answer.page";
+import CountryCheckboxPage from "../../../generated_pages/new_routing_not/country-checkbox.page";
+import CountryInterstitialPage from "../../../generated_pages/new_routing_not/country-interstitial-india.page";
+import SubmitPage from "../../../generated_pages/new_routing_not/submit.page";
 
 describe("Feature: Routing - Not Operator", () => {
   describe("Equals", () => {
@@ -10,28 +9,16 @@ describe("Feature: Routing - Not Operator", () => {
         browser.openQuestionnaire("test_new_routing_not.json");
       });
 
-      it("When I enter both answers correctly, Then I should be routed to the correct page", () => {
-        $(FirstNumberQuestionPage.answer1()).setValue(1);
-        $(FirstNumberQuestionPage.submit()).click();
-        $(SecondNumberQuestionPage.answer2()).setValue(2);
-        $(SecondNumberQuestionPage.submit()).click();
-        expect(browser.getUrl()).to.contain(CorrectAnswerPage.pageName);
+      it("When I do not select India, Then I should be routed to the interstitial page", () => {
+        $(CountryCheckboxPage.India()).setValue(1);
+        $(CountryCheckboxPage.submit()).click();
+        expect(browser.getUrl()).to.contain(CountryInterstitialPage.pageName);
       });
 
-      it("When I enter one of the answers incorrectly, Then I should be routed to the correct page", () => {
-        $(FirstNumberQuestionPage.answer1()).setValue(555);
-        $(FirstNumberQuestionPage.submit()).click();
-        $(SecondNumberQuestionPage.answer2()).setValue(321);
-        $(SecondNumberQuestionPage.submit()).click();
-        expect(browser.getUrl()).to.contain(CorrectAnswerPage.pageName);
-      });
-
-      it("When I enter both answers incorrectly, Then I should be routed to the incorrect page", () => {
-        $(FirstNumberQuestionPage.answer1()).setValue(123);
-        $(FirstNumberQuestionPage.submit()).click();
-        $(SecondNumberQuestionPage.answer2()).setValue(321);
-        $(SecondNumberQuestionPage.submit()).click();
-        expect(browser.getUrl()).to.contain(IncorrectAnswerPage.pageName);
+      it("When I do select India, Then I should be routed to the submit page", () => {
+        $(CountryCheckboxPage.India()).setValue(1);
+        $(CountryCheckboxPage.submit()).click();
+        expect(browser.getUrl()).to.contain(SubmitPage.pageName);
       });
     });
   });

--- a/tests/functional/spec/features/routing/not.spec.js
+++ b/tests/functional/spec/features/routing/not.spec.js
@@ -27,12 +27,12 @@ describe("Feature: Routing - Not Operator", () => {
       });
 
       it("When I enter both answers incorrectly, Then I should be routed to the incorrect page", () => {
-          $(FirstNumberQuestionPage.answer1()).setValue(123);
-          $(FirstNumberQuestionPage.submit()).click();
-          $(SecondNumberQuestionPage.answer2()).setValue(321);
-          $(SecondNumberQuestionPage.submit()).click();
-          expect(browser.getUrl()).to.contain(IncorrectAnswerPage.pageName);
-        });
+        $(FirstNumberQuestionPage.answer1()).setValue(123);
+        $(FirstNumberQuestionPage.submit()).click();
+        $(SecondNumberQuestionPage.answer2()).setValue(321);
+        $(SecondNumberQuestionPage.submit()).click();
+        expect(browser.getUrl()).to.contain(IncorrectAnswerPage.pageName);
+      });
     });
   });
 });

--- a/tests/functional/spec/features/routing/not.spec.js
+++ b/tests/functional/spec/features/routing/not.spec.js
@@ -1,0 +1,38 @@
+import FirstNumberQuestionPage from "../../../generated_pages/new_routing_not/number-question-1.page";
+import SecondNumberQuestionPage from "../../../generated_pages/new_routing_not/number-question-2.page";
+import CorrectAnswerPage from "../../../generated_pages/new_routing_not/correct-answer.page";
+import IncorrectAnswerPage from "../../../generated_pages/new_routing_not/incorrect-answer.page";
+
+describe("Feature: Routing - Not Operator", () => {
+  describe("Equals", () => {
+    describe("Given I start the not operator routing survey", () => {
+      beforeEach(() => {
+        browser.openQuestionnaire("test_new_routing_not.json");
+      });
+
+      it("When I enter both answers correctly, Then I should be routed to the correct page", () => {
+        $(FirstNumberQuestionPage.answer1()).setValue(1);
+        $(FirstNumberQuestionPage.submit()).click();
+        $(SecondNumberQuestionPage.answer2()).setValue(2);
+        $(SecondNumberQuestionPage.submit()).click();
+        expect(browser.getUrl()).to.contain(CorrectAnswerPage.pageName);
+      });
+
+      it("When I enter one of the answers incorrectly, Then I should be routed to the correct page", () => {
+        $(FirstNumberQuestionPage.answer1()).setValue(555);
+        $(FirstNumberQuestionPage.submit()).click();
+        $(SecondNumberQuestionPage.answer2()).setValue(321);
+        $(SecondNumberQuestionPage.submit()).click();
+        expect(browser.getUrl()).to.contain(CorrectAnswerPage.pageName);
+      });
+
+      it("When I enter both answers incorrectly, Then I should be routed to the incorrect page", () => {
+          $(FirstNumberQuestionPage.answer1()).setValue(123);
+          $(FirstNumberQuestionPage.submit()).click();
+          $(SecondNumberQuestionPage.answer2()).setValue(321);
+          $(SecondNumberQuestionPage.submit()).click();
+          expect(browser.getUrl()).to.contain(IncorrectAnswerPage.pageName);
+        });
+    });
+  });
+});

--- a/tests/functional/spec/features/routing/not.spec.js
+++ b/tests/functional/spec/features/routing/not.spec.js
@@ -10,7 +10,7 @@ describe("Feature: Routing - Not Operator", () => {
       });
 
       it("When I do not select India, Then I should be routed to the interstitial page", () => {
-        $(CountryCheckboxPage.india()).click();
+        $(CountryCheckboxPage.azerbaijan()).click();
         $(CountryCheckboxPage.submit()).click();
         expect(browser.getUrl()).to.contain(CountryInterstitialPage.pageName);
       });

--- a/tests/functional/spec/features/routing/or.spec.js
+++ b/tests/functional/spec/features/routing/or.spec.js
@@ -10,7 +10,7 @@ describe("Feature: Routing - OR Operator", () => {
         browser.openQuestionnaire("test_new_routing_or.json");
       });
 
-      it("When I enter both answers correctly, Then I should be routed to the correct page", () => {
+      it("When I enter 123 and 321, Then I should be routed to the correct page", () => {
         $(FirstNumberQuestionPage.answer1()).setValue(123);
         $(FirstNumberQuestionPage.submit()).click();
         $(SecondNumberQuestionPage.answer2()).setValue(321);
@@ -18,7 +18,7 @@ describe("Feature: Routing - OR Operator", () => {
         expect(browser.getUrl()).to.contain(CorrectAnswerPage.pageName);
       });
 
-      it("When I enter one of the answers correctly, Then I should be routed to the correct page", () => {
+      it("When I enter 555 and 321, Then I should be routed to the correct page", () => {
         $(FirstNumberQuestionPage.answer1()).setValue(555);
         $(FirstNumberQuestionPage.submit()).click();
         $(SecondNumberQuestionPage.answer2()).setValue(321);
@@ -26,7 +26,7 @@ describe("Feature: Routing - OR Operator", () => {
         expect(browser.getUrl()).to.contain(CorrectAnswerPage.pageName);
       });
 
-      it("When I enter both answers incorrectly, Then I should be routed to the incorrect page", () => {
+      it("When I enter 555 and 444, Then I should be routed to the incorrect page", () => {
         $(FirstNumberQuestionPage.answer1()).setValue(555);
         $(FirstNumberQuestionPage.submit()).click();
         $(SecondNumberQuestionPage.answer2()).setValue(444);

--- a/tests/functional/spec/features/routing/or.spec.js
+++ b/tests/functional/spec/features/routing/or.spec.js
@@ -1,0 +1,38 @@
+import FirstNumberQuestionPage from "../../../generated_pages/new_routing_or/number-question-1.page";
+import SecondNumberQuestionPage from "../../../generated_pages/new_routing_or/number-question-2.page";
+import CorrectAnswerPage from "../../../generated_pages/new_routing_or/correct-answer.page";
+import IncorrectAnswerPage from "../../../generated_pages/new_routing_or/incorrect-answer.page";
+
+describe("Feature: Routing - OR Operator", () => {
+  describe("Equals", () => {
+    describe("Given I start the or operator routing survey", () => {
+      beforeEach(() => {
+        browser.openQuestionnaire("test_new_routing_or.json");
+      });
+
+      it("When I enter both answers correctly, Then I should be routed to the correct page", () => {
+        $(FirstNumberQuestionPage.answer1()).setValue(123);
+        $(FirstNumberQuestionPage.submit()).click();
+        $(SecondNumberQuestionPage.answer2()).setValue(321);
+        $(SecondNumberQuestionPage.submit()).click();
+        expect(browser.getUrl()).to.contain(CorrectAnswerPage.pageName);
+      });
+
+      it("When I enter one of the answers correctly, Then I should be routed to the correct page", () => {
+        $(FirstNumberQuestionPage.answer1()).setValue(555);
+        $(FirstNumberQuestionPage.submit()).click();
+        $(SecondNumberQuestionPage.answer2()).setValue(321);
+        $(SecondNumberQuestionPage.submit()).click();
+        expect(browser.getUrl()).to.contain(CorrectAnswerPage.pageName);
+      });
+
+      it("When I enter both answers incorrectly, Then I should be routed to the incorrect page", () => {
+          $(FirstNumberQuestionPage.answer1()).setValue(555);
+          $(FirstNumberQuestionPage.submit()).click();
+          $(SecondNumberQuestionPage.answer2()).setValue(444);
+          $(SecondNumberQuestionPage.submit()).click();
+          expect(browser.getUrl()).to.contain(IncorrectAnswerPage.pageName);
+        });
+    });
+  });
+});

--- a/tests/functional/spec/features/routing/or.spec.js
+++ b/tests/functional/spec/features/routing/or.spec.js
@@ -10,7 +10,7 @@ describe("Feature: Routing - OR Operator", () => {
         browser.openQuestionnaire("test_new_routing_or.json");
       });
 
-      it("When I enter 123 and 321, Then I should be routed to the correct page", () => {
+      it("When I enter both answers correctly with 123 and 321, Then I should be routed to the correct page", () => {
         $(FirstNumberQuestionPage.answer1()).setValue(123);
         $(FirstNumberQuestionPage.submit()).click();
         $(SecondNumberQuestionPage.answer2()).setValue(321);
@@ -18,7 +18,7 @@ describe("Feature: Routing - OR Operator", () => {
         expect(browser.getUrl()).to.contain(CorrectAnswerPage.pageName);
       });
 
-      it("When I enter 555 and 321, Then I should be routed to the correct page", () => {
+      it("When I only enter the second answer correctly with 555 and 321, Then I should be routed to the correct page", () => {
         $(FirstNumberQuestionPage.answer1()).setValue(555);
         $(FirstNumberQuestionPage.submit()).click();
         $(SecondNumberQuestionPage.answer2()).setValue(321);
@@ -26,7 +26,7 @@ describe("Feature: Routing - OR Operator", () => {
         expect(browser.getUrl()).to.contain(CorrectAnswerPage.pageName);
       });
 
-      it("When I enter 123 and 555, Then I should be routed to the correct page", () => {
+      it("When I only enter the first answer correctly with 123 and 555, Then I should be routed to the correct page", () => {
         $(FirstNumberQuestionPage.answer1()).setValue(123);
         $(FirstNumberQuestionPage.submit()).click();
         $(SecondNumberQuestionPage.answer2()).setValue(555);
@@ -34,7 +34,7 @@ describe("Feature: Routing - OR Operator", () => {
         expect(browser.getUrl()).to.contain(CorrectAnswerPage.pageName);
       });
 
-      it("When I do not enter 123 or 321, Then I should be routed to the incorrect page", () => {
+      it("When I answer both questions incorrectly with 123 and 321, Then I should be routed to the incorrect page", () => {
         $(FirstNumberQuestionPage.answer1()).setValue(555);
         $(FirstNumberQuestionPage.submit()).click();
         $(SecondNumberQuestionPage.answer2()).setValue(444);

--- a/tests/functional/spec/features/routing/or.spec.js
+++ b/tests/functional/spec/features/routing/or.spec.js
@@ -26,6 +26,14 @@ describe("Feature: Routing - OR Operator", () => {
         expect(browser.getUrl()).to.contain(CorrectAnswerPage.pageName);
       });
 
+      it("When I enter 123 and 555, Then I should be routed to the correct page", () => {
+        $(FirstNumberQuestionPage.answer1()).setValue(123);
+        $(FirstNumberQuestionPage.submit()).click();
+        $(SecondNumberQuestionPage.answer2()).setValue(555);
+        $(SecondNumberQuestionPage.submit()).click();
+        expect(browser.getUrl()).to.contain(CorrectAnswerPage.pageName);
+      });
+
       it("When I do not enter 123 or 321, Then I should be routed to the incorrect page", () => {
         $(FirstNumberQuestionPage.answer1()).setValue(555);
         $(FirstNumberQuestionPage.submit()).click();

--- a/tests/functional/spec/features/routing/or.spec.js
+++ b/tests/functional/spec/features/routing/or.spec.js
@@ -34,7 +34,7 @@ describe("Feature: Routing - OR Operator", () => {
         expect(browser.getUrl()).to.contain(CorrectAnswerPage.pageName);
       });
 
-      it("When I answer both questions incorrectly with 123 and 321, Then I should be routed to the incorrect page", () => {
+      it("When I answer both questions incorrectly with 555 and 444, Then I should be routed to the incorrect page", () => {
         $(FirstNumberQuestionPage.answer1()).setValue(555);
         $(FirstNumberQuestionPage.submit()).click();
         $(SecondNumberQuestionPage.answer2()).setValue(444);

--- a/tests/functional/spec/features/routing/or.spec.js
+++ b/tests/functional/spec/features/routing/or.spec.js
@@ -27,12 +27,12 @@ describe("Feature: Routing - OR Operator", () => {
       });
 
       it("When I enter both answers incorrectly, Then I should be routed to the incorrect page", () => {
-          $(FirstNumberQuestionPage.answer1()).setValue(555);
-          $(FirstNumberQuestionPage.submit()).click();
-          $(SecondNumberQuestionPage.answer2()).setValue(444);
-          $(SecondNumberQuestionPage.submit()).click();
-          expect(browser.getUrl()).to.contain(IncorrectAnswerPage.pageName);
-        });
+        $(FirstNumberQuestionPage.answer1()).setValue(555);
+        $(FirstNumberQuestionPage.submit()).click();
+        $(SecondNumberQuestionPage.answer2()).setValue(444);
+        $(SecondNumberQuestionPage.submit()).click();
+        expect(browser.getUrl()).to.contain(IncorrectAnswerPage.pageName);
+      });
     });
   });
 });

--- a/tests/functional/spec/features/routing/or.spec.js
+++ b/tests/functional/spec/features/routing/or.spec.js
@@ -26,7 +26,7 @@ describe("Feature: Routing - OR Operator", () => {
         expect(browser.getUrl()).to.contain(CorrectAnswerPage.pageName);
       });
 
-      it("When I enter 555 and 444, Then I should be routed to the incorrect page", () => {
+      it("When I do not enter 123 or 321, Then I should be routed to the incorrect page", () => {
         $(FirstNumberQuestionPage.answer1()).setValue(555);
         $(FirstNumberQuestionPage.submit()).click();
         $(SecondNumberQuestionPage.answer2()).setValue(444);


### PR DESCRIPTION
### What is the context of this PR?

Adds the new routing rules schemas and functional tests for the `and`, `or` and `not` operators.

### How to review 

Make sure the new schemas and functional tests work


### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
