### PR TITLE
Add type hint form module - validtors.py and duration_form.py

### DIFF
--- a/app/forms/duration_form.py
+++ b/app/forms/duration_form.py
@@ -1,10 +1,18 @@
+from __future__ import annotations
+
+from typing import Callable, Mapping, Optional, Type
+
 from wtforms import Form
 
 from app.forms.fields import IntegerFieldWithSeparator
 
+ErrorMessageType = dict[str, str]
+
 
 class DurationForm(Form):
-    def validate(self, extra_validators=None):
+    def validate(
+        self, extra_validators: Optional[dict[str, list[Callable]]] = None
+    ) -> bool:
         super(DurationForm, self).validate(extra_validators)
 
         if all(not field.raw_data[0] for field in self._fields.values()):
@@ -30,18 +38,20 @@ class DurationForm(Form):
 
         return True
 
-    def _set_error(self, key):
+    def _set_error(self, key: str) -> None:
         list(self._fields.values())[0].errors = [self.answer_errors[key]]
 
     @property
-    def data(self):
-        data = super().data
+    def data(self) -> Optional[dict[str, Optional[str]]]:
+        data: dict[str, Optional[str]] = super().data
         if all(value is None for value in data.values()):
             return None
         return data
 
 
-def get_duration_form(answer, error_messages):
+def get_duration_form(
+    answer: Mapping, error_messages: ErrorMessageType
+) -> Type[DurationForm]:
     class CustomDurationForm(DurationForm):
         mandatory = answer["mandatory"]
         units = answer["units"]
@@ -56,7 +66,9 @@ def get_duration_form(answer, error_messages):
     return CustomDurationForm
 
 
-def _get_answer_errors(answer, error_messages):
+def _get_answer_errors(
+    answer: Mapping, error_messages: ErrorMessageType
+) -> dict[str, str]:
     answer_errors = error_messages.copy()
 
     if "validation" in answer and "messages" in answer["validation"]:

--- a/app/forms/field_handlers/number_handler.py
+++ b/app/forms/field_handlers/number_handler.py
@@ -1,5 +1,5 @@
 from functools import cached_property
-from typing import Union
+from typing import Any, Union
 
 from wtforms import DecimalField, IntegerField
 
@@ -11,11 +11,7 @@ from app.forms.validators import (
     NumberRange,
     ResponseRequired,
 )
-from app.questionnaire.value_source_resolver import (
-    ValueSourceEscapedTypes,
-    ValueSourceResolver,
-    ValueSourceTypes,
-)
+from app.questionnaire.value_source_resolver import ValueSourceResolver
 from app.settings import MAX_NUMBER
 
 NumberValidatorTypes = list[
@@ -30,7 +26,7 @@ class NumberHandler(FieldHandler):
         self,
         answer_schema: dict,
         value_source_resolver: ValueSourceResolver,
-        error_messages: dict = None,
+        error_messages: dict[str, str],
         disable_validation: bool = False,
         question_title: str = None,
     ):
@@ -68,9 +64,13 @@ class NumberHandler(FieldHandler):
 
     def get_field_references(
         self,
-    ) -> dict[str, Union[bool, ValueSourceEscapedTypes, ValueSourceTypes]]:
-        schema_minimum = self.answer_schema.get("minimum", {})
-        schema_maximum = self.answer_schema.get("maximum", {})
+    ) -> dict[str, Any]:
+
+        schema_minimum: dict = self.answer_schema.get("minimum", {})
+        schema_maximum: dict = self.answer_schema.get("maximum", {})
+
+        min_exclusive: bool = schema_minimum.get("exclusive", False)
+        max_exclusive: bool = schema_maximum.get("exclusive", False)
 
         minimum = self.get_schema_value(schema_minimum) if schema_minimum else 0
         maximum = (
@@ -78,8 +78,8 @@ class NumberHandler(FieldHandler):
         )
 
         return {
-            "min_exclusive": schema_minimum.get("exclusive", False),
-            "max_exclusive": schema_maximum.get("exclusive", False),
+            "min_exclusive": min_exclusive,
+            "max_exclusive": max_exclusive,
             "minimum": minimum,
             "maximum": maximum,
         }

--- a/app/forms/questionnaire_form.py
+++ b/app/forms/questionnaire_form.py
@@ -8,6 +8,7 @@ from flask_wtf import FlaskForm
 from werkzeug.datastructures import ImmutableMultiDict, MultiDict
 from wtforms import validators
 
+from app.forms import error_messages
 from app.forms.field_handlers import DateHandler, get_field_handler
 from app.forms.validators import DateRangeCheck, MutuallyExclusiveCheck, SumCheck
 from app.questionnaire.value_source_resolver import ValueSourceResolver
@@ -246,7 +247,7 @@ class QuestionnaireForm(FlaskForm):
             escape_answer_values=False,
         )
 
-        handler = DateHandler(date_from, value_source_resolver)
+        handler = DateHandler(date_from, value_source_resolver, error_messages)
         from_min_period_date = handler.get_date_value("minimum")
         from_max_period_date = handler.get_date_value("maximum")
 

--- a/app/jinja_filters.py
+++ b/app/jinja_filters.py
@@ -35,7 +35,7 @@ def get_formatted_address(address_fields):
     return "<br>".join(address_field for address_field in address_fields.values())
 
 
-def get_formatted_currency(value, currency="GBP"):
+def get_formatted_currency(value, currency="GBP") -> str:
     if value or value == 0:
         return numbers.format_currency(
             number=value, currency=currency, locale=flask_babel.get_locale()

--- a/mypy.ini
+++ b/mypy.ini
@@ -65,3 +65,11 @@ warn_return_any = True
 [mypy-app.forms.field_handlers.*]
 disallow_untyped_defs = True
 warn_return_any = True
+
+[mypy-app.forms.validators]
+disallow_untyped_defs = True
+warn_return_any = True
+
+[mypy-app.forms.duration_form]
+disallow_untyped_defs = True
+warn_return_any = True

--- a/tests/app/forms/field_handlers/test_address_handler.py
+++ b/tests/app/forms/field_handlers/test_address_handler.py
@@ -6,7 +6,7 @@ from app.forms import error_messages
 from app.forms.field_handlers import AddressHandler
 
 
-def get_test_form_class(answer_schema, value_source_resolver, messages=None):
+def get_test_form_class(answer_schema, value_source_resolver, messages=error_messages):
     address_handler = AddressHandler(
         answer_schema, value_source_resolver, error_messages=messages
     )
@@ -19,7 +19,7 @@ def get_test_form_class(answer_schema, value_source_resolver, messages=None):
 
 def test_address_fields(value_source_resolver):
     answer_json = {"id": "address", "mandatory": True, "type": "Address"}
-    address_handler = AddressHandler(answer_json, value_source_resolver)
+    address_handler = AddressHandler(answer_json, value_source_resolver, error_messages)
 
     class TestForm(Form):
         test_field = address_handler.get_field()
@@ -57,9 +57,7 @@ def test_no_validation_when_address_not_mandatory(value_source_resolver):
 def test_mandatory_validation_when_address_line_1_missing(value_source_resolver):
     answer_json = {"id": "address", "mandatory": True, "type": "Address"}
 
-    test_form_class = get_test_form_class(
-        answer_json, value_source_resolver, messages=error_messages
-    )
+    test_form_class = get_test_form_class(answer_json, value_source_resolver)
     form = test_form_class(MultiDict({"test_field": "1"}), value_source_resolver)
     form.validate()
 
@@ -77,7 +75,7 @@ def test_address_validator_with_message_override(value_source_resolver):
             }
         },
     }
-    address_handler = AddressHandler(answer_json, value_source_resolver)
+    address_handler = AddressHandler(answer_json, value_source_resolver, error_messages)
 
     validator = address_handler.validators
 

--- a/tests/app/forms/field_handlers/test_date_handler.py
+++ b/tests/app/forms/field_handlers/test_date_handler.py
@@ -8,6 +8,7 @@ from wtforms import Form
 
 from app.data_models.answer import Answer
 from app.data_models.answer_store import AnswerStore
+from app.forms import error_messages
 from app.forms.field_handlers import DateHandler
 from app.forms.fields import date_field
 from app.questionnaire.location import Location
@@ -31,7 +32,7 @@ def test_date_field_created_with_guidance(value_source_resolver):
         },
     }
 
-    handler = DateHandler(date_json, value_source_resolver)
+    handler = DateHandler(date_json, value_source_resolver, error_messages)
 
     class TestForm(Form):
         test_field = handler.get_field()
@@ -51,6 +52,7 @@ def test_generate_date_form_validates_single_date_period(app, value_source_resol
     handler = DateHandler(
         schema.get_answers_by_answer_id("date-range-from")[0],
         value_source_resolver,
+        error_messages,
     )
     form = date_field.get_form_class(handler.validators)
 
@@ -71,7 +73,7 @@ def test_generate_date_form_validates_single_date_period_with_bespoke_message(
         "maximum": {"value": "2017-06-11", "offset_by": {"days": 20}},
         "validation": {"messages": {"SINGLE_DATE_PERIOD_TOO_LATE": "Test Message"}},
     }
-    handler = DateHandler(answer, value_source_resolver)
+    handler = DateHandler(answer, value_source_resolver, error_messages)
     form = date_field.get_form_class(handler.validators)
 
     assert hasattr(form, "day")
@@ -82,7 +84,7 @@ def test_generate_date_form_validates_single_date_period_with_bespoke_message(
 def test_get_referenced_offset_value_for_value(app, value_source_resolver):
     answer = {"minimum": {"value": "2017-06-11"}}
 
-    handler = DateHandler(answer, value_source_resolver)
+    handler = DateHandler(answer, value_source_resolver, error_messages)
     minimum_date = handler.get_date_value("minimum")
     minimum_date = handler.transform_date_by_offset(minimum_date, {"days": 10})
 
@@ -92,7 +94,7 @@ def test_get_referenced_offset_value_for_value(app, value_source_resolver):
 def test_get_referenced_offset_value_for_now_value(app, value_source_resolver):
     answer = {"minimum": {"value": "now"}}
 
-    handler = DateHandler(answer, value_source_resolver)
+    handler = DateHandler(answer, value_source_resolver, error_messages)
     minimum_date = handler.get_date_value("minimum")
     minimum_date = handler.transform_date_by_offset(minimum_date, {"days": 10})
 
@@ -105,7 +107,7 @@ def test_get_referenced_offset_value_for_meta(app, value_source_resolver):
     value_source_resolver.metadata = {"date": "2018-02-20"}
     answer = {"minimum": {"value": {"identifier": "date", "source": "metadata"}}}
 
-    handler = DateHandler(answer, value_source_resolver)
+    handler = DateHandler(answer, value_source_resolver, error_messages)
     minimum_date = handler.get_date_value("minimum")
     minimum_date = handler.transform_date_by_offset(minimum_date, {"days": -10})
 
@@ -123,7 +125,7 @@ def test_get_referenced_offset_value_for_answer_id(app, value_source_resolver):
     value_source_resolver.answer_store = answer_store
     answer = {"maximum": {"value": {"identifier": "date", "source": "answers"}}}
 
-    handler = DateHandler(answer, value_source_resolver)
+    handler = DateHandler(answer, value_source_resolver, error_messages)
     maximum_date = handler.get_date_value("maximum")
     maximum_date = handler.transform_date_by_offset(maximum_date, {"months": 1})
 
@@ -156,7 +158,7 @@ def test_get_referenced_offset_value_with_list_item_id(app, value_source_resolve
         }
     }
 
-    handler = DateHandler(answer, value_source_resolver)
+    handler = DateHandler(answer, value_source_resolver, error_messages)
     maximum_date = handler.get_date_value("maximum")
 
     assert maximum_date == convert_to_datetime("2018-04-20")
@@ -165,7 +167,7 @@ def test_get_referenced_offset_value_with_list_item_id(app, value_source_resolve
 def test_get_referenced_offset_value_with_no_offset(app, value_source_resolver):
     answer = {"minimum": {"value": "2017-06-11"}}
 
-    handler = DateHandler(answer, value_source_resolver)
+    handler = DateHandler(answer, value_source_resolver, error_messages)
     minimum_date = handler.get_date_value("minimum")
     minimum_date = handler.transform_date_by_offset(minimum_date, {})
 
@@ -195,7 +197,7 @@ def test_minimum_and_maximum_offset_dates(app, value_source_resolver):
         },
     }
 
-    handler = DateHandler(answer, value_source_resolver)
+    handler = DateHandler(answer, value_source_resolver, error_messages)
     minimum_date = handler.get_date_value("minimum")
     maximum_date = handler.get_date_value("maximum")
 
@@ -211,7 +213,7 @@ def test_greater_minimum_date_than_maximum_date(app, value_source_resolver):
         "maximum": {"value": "2018-01-15", "offset_by": {"days": 10}},
     }
 
-    handler = DateHandler(answer, value_source_resolver)
+    handler = DateHandler(answer, value_source_resolver, error_messages)
 
     with pytest.raises(Exception) as ite:
         handler.get_date_value("minimum")
@@ -233,7 +235,7 @@ def test_validate_mandatory_date(app, value_source_resolver):
         "validation": {"messages": {"MANDATORY_DATE": "Test Mandatory Date Message"}},
     }
 
-    handler = DateHandler(answer, value_source_resolver)
+    handler = DateHandler(answer, value_source_resolver, error_messages)
     validator = handler.get_mandatory_validator()
 
     assert validator.message == "Test Mandatory Date Message"

--- a/tests/app/forms/field_handlers/test_dropdown_handler.py
+++ b/tests/app/forms/field_handlers/test_dropdown_handler.py
@@ -1,6 +1,7 @@
 from pytest import fixture
 from wtforms import Form, SelectField
 
+from app.forms import error_messages
 from app.forms.field_handlers.dropdown_handler import DropdownHandler
 
 
@@ -23,7 +24,9 @@ def dropdown_answer_schema():
 def test_build_choices_without_placeholder(
     dropdown_answer_schema, value_source_resolver
 ):
-    handler = DropdownHandler(dropdown_answer_schema, value_source_resolver)
+    handler = DropdownHandler(
+        dropdown_answer_schema, value_source_resolver, error_messages
+    )
 
     expected_choices = [("", "Select an answer")] + [
         (option["label"], option["value"])
@@ -35,7 +38,9 @@ def test_build_choices_without_placeholder(
 
 def test_build_choices_with_placeholder(dropdown_answer_schema, value_source_resolver):
     dropdown_answer_schema["placeholder"] = "Select an option"
-    handler = DropdownHandler(dropdown_answer_schema, value_source_resolver)
+    handler = DropdownHandler(
+        dropdown_answer_schema, value_source_resolver, error_messages
+    )
 
     expected_choices = [("", "Select an option")] + [
         (option["label"], option["value"])
@@ -46,7 +51,9 @@ def test_build_choices_with_placeholder(dropdown_answer_schema, value_source_res
 
 
 def test_get_field(dropdown_answer_schema, value_source_resolver):
-    handler = DropdownHandler(dropdown_answer_schema, value_source_resolver)
+    handler = DropdownHandler(
+        dropdown_answer_schema, value_source_resolver, error_messages
+    )
 
     expected_choices = [("", "Select an answer")] + [
         (option["label"], option["value"])

--- a/tests/app/forms/field_handlers/test_duration_handler.py
+++ b/tests/app/forms/field_handlers/test_duration_handler.py
@@ -1,5 +1,6 @@
 from wtforms import Form, FormField
 
+from app.forms import error_messages
 from app.forms.field_handlers.duration_handler import DurationHandler
 
 
@@ -12,7 +13,7 @@ def test_get_field(value_source_resolver):
         "type": "Duration",
         "units": ["years", "months"],
     }
-    handler = DurationHandler(date_json, value_source_resolver)
+    handler = DurationHandler(date_json, value_source_resolver, error_messages)
 
     class TestForm(Form):
         test_field = handler.get_field()

--- a/tests/app/forms/field_handlers/test_field_handler.py
+++ b/tests/app/forms/field_handlers/test_field_handler.py
@@ -1,5 +1,6 @@
 from wtforms import validators
 
+from app.forms import error_messages
 from app.forms.field_handlers.string_handler import StringHandler
 from app.forms.validators import ResponseRequired
 
@@ -7,7 +8,7 @@ from app.forms.validators import ResponseRequired
 def test_get_mandatory_validator_optional(value_source_resolver):
     answer = {"mandatory": False}
 
-    text_area_handler = StringHandler(answer, value_source_resolver)
+    text_area_handler = StringHandler(answer, value_source_resolver, error_messages)
     validate_with = text_area_handler.get_mandatory_validator()
 
     assert isinstance(validate_with, validators.Optional)
@@ -37,7 +38,7 @@ def test_get_mandatory_validator_mandatory_with_error(value_source_resolver):
         },
     }
 
-    text_area_handler = StringHandler(answer, value_source_resolver)
+    text_area_handler = StringHandler(answer, value_source_resolver, error_messages)
     validate_with = text_area_handler.get_mandatory_validator()
 
     assert isinstance(validate_with, ResponseRequired)

--- a/tests/app/forms/field_handlers/test_mobile_number_handler.py
+++ b/tests/app/forms/field_handlers/test_mobile_number_handler.py
@@ -1,5 +1,6 @@
 from wtforms import Form, StringField
 
+from app.forms import error_messages
 from app.forms.field_handlers.mobile_number_handler import MobileNumberHandler
 
 
@@ -14,6 +15,7 @@ def test_phone_number_handler(value_source_resolver):
     mobile_number_handler = MobileNumberHandler(
         answer_schema,
         value_source_resolver,
+        error_messages,
         disable_validation=False,
     )
 

--- a/tests/app/forms/field_handlers/test_month_year_date_handler.py
+++ b/tests/app/forms/field_handlers/test_month_year_date_handler.py
@@ -1,5 +1,6 @@
 from wtforms import Form
 
+from app.forms import error_messages
 from app.forms.field_handlers import MonthYearDateHandler
 from app.forms.fields import MonthYearDateField
 
@@ -19,7 +20,7 @@ def test_month_year_date_field_created_with_guidance(value_source_resolver):
         },
     }
 
-    handler = MonthYearDateHandler(date_json, value_source_resolver)
+    handler = MonthYearDateHandler(date_json, value_source_resolver, error_messages)
 
     class TestForm(Form):
         test_field = handler.get_field()

--- a/tests/app/forms/field_handlers/test_number_handler.py
+++ b/tests/app/forms/field_handlers/test_number_handler.py
@@ -10,7 +10,7 @@ from app.forms.fields import DecimalFieldWithSeparator, IntegerFieldWithSeparato
 from app.settings import MAX_NUMBER
 
 
-def get_test_form_class(answer_schema, value_source_resolver, messages=None):
+def get_test_form_class(answer_schema, value_source_resolver, messages=error_messages):
     handler = NumberHandler(
         answer_schema, value_source_resolver, error_messages=messages
     )
@@ -32,7 +32,9 @@ def test_integer_field(value_source_resolver):
         "validation": {"messages": {"INVALID_NUMBER": "Please enter your age."}},
     }
 
-    form_class = get_test_form_class(answer_schema, value_source_resolver)
+    form_class = get_test_form_class(
+        answer_schema, value_source_resolver, error_messages
+    )
     form = form_class()
 
     assert isinstance(form.test_field, IntegerFieldWithSeparator)
@@ -55,7 +57,9 @@ def test_decimal_field(value_source_resolver):
         },
     }
 
-    form_class = get_test_form_class(answer_schema, value_source_resolver)
+    form_class = get_test_form_class(
+        answer_schema, value_source_resolver, error_messages
+    )
     form = form_class()
 
     assert isinstance(form.test_field, DecimalFieldWithSeparator)
@@ -77,7 +81,9 @@ def test_currency_field(value_source_resolver):
         },
     }
 
-    form_class = get_test_form_class(answer_schema, value_source_resolver)
+    form_class = get_test_form_class(
+        answer_schema, value_source_resolver, error_messages
+    )
     form = form_class()
 
     assert isinstance(form.test_field, IntegerFieldWithSeparator)
@@ -103,7 +109,9 @@ def test_percentage_field(value_source_resolver):
         },
     }
 
-    form_class = get_test_form_class(answer_schema, value_source_resolver)
+    form_class = get_test_form_class(
+        answer_schema, value_source_resolver, error_messages
+    )
     form = form_class()
 
     assert isinstance(form.test_field, IntegerFieldWithSeparator)
@@ -126,7 +134,9 @@ def test_manual_min(app, value_source_resolver):
         "type": "Currency",
     }
 
-    test_form_class = get_test_form_class(answer_schema, value_source_resolver)
+    test_form_class = get_test_form_class(
+        answer_schema, value_source_resolver, error_messages
+    )
     form = test_form_class(MultiDict({"test_field": "9"}))
 
     form.validate()
@@ -330,7 +340,7 @@ def test_default_range(value_source_resolver):
         "id": "test-range",
         "type": "Currency",
     }
-    handler = NumberHandler(answer, value_source_resolver)
+    handler = NumberHandler(answer, value_source_resolver, error_messages)
     field_references = handler.get_field_references()
 
     assert field_references["maximum"] == MAX_NUMBER
@@ -357,10 +367,7 @@ def test_get_schema_value_answer_store(value_source_resolver):
     answer_store.add_or_update(Answer(answer_id="set-maximum", value=10))
     answer_store.add_or_update(Answer(answer_id="set-minimum", value=1))
     value_source_resolver.answer_store = answer_store
-    number_handler = NumberHandler(
-        answer_schema,
-        value_source_resolver,
-    )
+    number_handler = NumberHandler(answer_schema, value_source_resolver, error_messages)
 
     maximum = number_handler.get_schema_value(answer_schema["maximum"])
     minimum = number_handler.get_schema_value(answer_schema["minimum"])

--- a/tests/app/forms/field_handlers/test_select_handler.py
+++ b/tests/app/forms/field_handlers/test_select_handler.py
@@ -1,5 +1,6 @@
 from wtforms import Form
 
+from app.forms import error_messages
 from app.forms.field_handlers import SelectHandler
 from app.forms.fields import SelectFieldWithDetailAnswer
 
@@ -38,7 +39,7 @@ def test_get_field(value_source_resolver):
         "validation": {"messages": {"MANDATORY_RADIO": "This answer is required"}},
     }
 
-    handler = SelectHandler(radio_json, value_source_resolver)
+    handler = SelectHandler(radio_json, value_source_resolver, error_messages)
 
     class TestForm(Form):
         test_field = handler.get_field()

--- a/tests/app/forms/field_handlers/test_select_multiple_handler.py
+++ b/tests/app/forms/field_handlers/test_select_multiple_handler.py
@@ -1,5 +1,6 @@
 from wtforms import Form
 
+from app.forms import error_messages
 from app.forms.field_handlers import SelectMultipleHandler
 from app.forms.fields import MultipleSelectFieldWithDetailAnswer
 
@@ -22,7 +23,9 @@ def test_get_field(value_source_resolver):
         "type": "Checkbox",
     }
 
-    handler = SelectMultipleHandler(checkbox_json, value_source_resolver)
+    handler = SelectMultipleHandler(
+        checkbox_json, value_source_resolver, error_messages
+    )
 
     class TestForm(Form):
         test_field = handler.get_field()

--- a/tests/app/forms/field_handlers/test_string_handler.py
+++ b/tests/app/forms/field_handlers/test_string_handler.py
@@ -1,5 +1,6 @@
 from wtforms import Form, StringField, validators
 
+from app.forms import error_messages
 from app.forms.field_handlers.string_handler import StringHandler
 
 
@@ -14,6 +15,7 @@ def test_string_field(value_source_resolver):
     string_handler = StringHandler(
         textfield_json,
         value_source_resolver,
+        error_messages,
         disable_validation=True,
     )
 
@@ -28,7 +30,7 @@ def test_string_field(value_source_resolver):
 
 
 def test_get_length_validator(value_source_resolver):
-    string_handler = StringHandler({}, value_source_resolver)
+    string_handler = StringHandler({}, value_source_resolver, error_messages)
 
     validator = string_handler.get_length_validator
 
@@ -40,7 +42,7 @@ def test_get_length_validator_with_message_override(value_source_resolver):
         "validation": {"messages": {"MAX_LENGTH_EXCEEDED": "The message is too long!"}}
     }
 
-    string_handler = StringHandler(answer, value_source_resolver)
+    string_handler = StringHandler(answer, value_source_resolver, error_messages)
 
     validator = string_handler.get_length_validator
 
@@ -50,7 +52,7 @@ def test_get_length_validator_with_message_override(value_source_resolver):
 def test_get_length_validator_with_max_length_override(value_source_resolver):
     answer = {"max_length": 30}
 
-    string_handler = StringHandler(answer, value_source_resolver)
+    string_handler = StringHandler(answer, value_source_resolver, error_messages)
     validator = string_handler.get_length_validator
 
     assert validator.max == 30

--- a/tests/app/forms/field_handlers/test_text_area_handler.py
+++ b/tests/app/forms/field_handlers/test_text_area_handler.py
@@ -1,5 +1,6 @@
 from wtforms import Form
 
+from app.forms import error_messages
 from app.forms.field_handlers import TextAreaHandler
 from app.forms.fields import MaxTextAreaField
 
@@ -19,7 +20,9 @@ def test_get_field(value_source_resolver):
         },
     }
 
-    text_area_handler = TextAreaHandler(textarea_json, value_source_resolver)
+    text_area_handler = TextAreaHandler(
+        textarea_json, value_source_resolver, error_messages
+    )
 
     class TestForm(Form):
         test_field = text_area_handler.get_field()
@@ -75,7 +78,7 @@ def test_get_text_area_rows_with_default(value_source_resolver):
     }
 
     text_area_handler = TextAreaHandler(
-        answer, value_source_resolver, disable_validation=True
+        answer, value_source_resolver, error_messages, disable_validation=True
     )
 
     class TestForm(Form):
@@ -96,7 +99,7 @@ def test_get_text_area_rows(value_source_resolver):
     }
 
     text_area_handler = TextAreaHandler(
-        answer, value_source_resolver, disable_validation=True
+        answer, value_source_resolver, error_messages, disable_validation=True
     )
 
     class TestForm(Form):

--- a/tests/app/forms/field_handlers/test_year_date_handler.py
+++ b/tests/app/forms/field_handlers/test_year_date_handler.py
@@ -1,5 +1,6 @@
 from wtforms import Form
 
+from app.forms import error_messages
 from app.forms.field_handlers import YearDateHandler
 from app.forms.fields import YearDateField
 
@@ -19,7 +20,7 @@ def test_get_field(value_source_resolver):
         },
     }
 
-    handler = YearDateHandler(date_json, value_source_resolver)
+    handler = YearDateHandler(date_json, value_source_resolver, error_messages)
 
     class TestForm(Form):
         test_field = handler.get_field()

--- a/tests/app/forms/validation/test_number_range_validator.py
+++ b/tests/app/forms/validation/test_number_range_validator.py
@@ -94,3 +94,15 @@ class TestNumberRangeValidator(unittest.TestCase):
             validator(mock_form, mock_field)
         except ValidationError:
             self.fail("Valid integer raised ValidationError")
+
+    def test_number_range_for_no_min_or_max(self):
+        validator = NumberRange()
+
+        mock_form = Mock()
+        mock_field = Mock()
+        mock_field.data = 9999999999
+
+        try:
+            validator(mock_form, mock_field)
+        except ValidationError:
+            self.fail("Valid integer raised ValidationError")


### PR DESCRIPTION
### What is the context of this PR?

- Add type hints to `app/forms/validators.py` , `app/forms/duration_form.py` 
- `error_messages` are not optional to `FieldHandler` class
-  Updated unit test to pass `error_messages` `dict`
- Add unit tests to reflect code changes and have 100% code coverage due to typing


companion PR adding type hints to the other modules in `forms` is https://github.com/ONSdigital/eq-questionnaire-runner/pull/665
### How to review 
Run the python linter and unit tests to ensure nothing is broken. Verify where code has changed to accommodate the typing errors(raised by mypy) and previous types were updated.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
