### PR TITLE
Add session expiry end point

### DIFF
--- a/app/authentication/authenticator.py
+++ b/app/authentication/authenticator.py
@@ -29,17 +29,20 @@ def user_loader(user_id: str) -> Optional[str]:
 
 
 @login_manager.request_loader
-def request_load_user(
-    request: Request,
-) -> Optional[User]:  # pylint: disable=unused-argument
+def request_load_user(request: Request) -> Optional[User]:
     logger.debug("load user")
-    return load_user()
+
+    extend_session = not (
+        request.endpoint == "session.session_expiry" and request.method == "GET"
+    )
+
+    return load_user(extend_session=extend_session)
 
 
 @user_logged_out.connect_via(ANY)
 def when_user_logged_out(
-    sender_app: Flask, user: str
-) -> None:  # pylint: disable=unused-argument
+    sender_app: Flask, user: str  # pylint: disable=unused-argument
+) -> None:
     logger.debug("log out user")
     session_store = get_session_store()
     if session_store:
@@ -82,10 +85,12 @@ def _is_session_valid(session_store: SessionStore) -> bool:
     )
 
 
-def load_user() -> Optional[User]:
+def load_user(extend_session: bool = True) -> Optional[User]:
     """
     Checks for the present of the JWT in the users sessions
     :return: A user object if a JWT token is available in the session
+
+    :param extend_session: bool, whether to extend the session
     """
     session_store = get_session_store()
 
@@ -99,14 +104,14 @@ def load_user() -> Optional[User]:
         if session_store.session_data.tx_id:
             logger.bind(tx_id=session_store.session_data.tx_id)
 
-        _extend_session_expiry(session_store)
+        if extend_session:
+            _extend_session_expiry(session_store)
 
         return user
 
     logger.info("session does not exist")
 
     cookie_session.pop(USER_IK, None)
-    return None
 
 
 def _create_session_data_from_metadata(

--- a/app/routes/session.py
+++ b/app/routes/session.py
@@ -121,9 +121,9 @@ def get_session_expired():
     return render_template("errors/401")
 
 
-@session_blueprint.route("/session-expiry", methods=["GET"])
+@session_blueprint.route("/session-expiry", methods=["GET", "PATCH"])
 @login_required
-def get_session_expiry():
+def session_expiry():
     return jsonify(expires_at=get_session_store().expiration_time.isoformat())
 
 

--- a/app/routes/session.py
+++ b/app/routes/session.py
@@ -1,9 +1,9 @@
 from datetime import datetime, timezone
 
-from flask import Blueprint, g, redirect, request
+from flask import Blueprint, g, jsonify, redirect, request
 from flask import session as cookie_session
 from flask import url_for
-from flask_login import logout_user
+from flask_login import login_required, logout_user
 from marshmallow import ValidationError
 from sdc.crypto.exceptions import InvalidTokenException
 from structlog import get_logger
@@ -11,7 +11,7 @@ from werkzeug.exceptions import Unauthorized
 
 from app.authentication.authenticator import decrypt_token, store_session
 from app.authentication.jti_claim_storage import JtiTokenUsed, use_jti_claim
-from app.globals import get_session_timeout_in_seconds
+from app.globals import get_session_store, get_session_timeout_in_seconds
 from app.helpers.template_helpers import get_survey_config, render_template
 from app.storage.metadata_parser import (
     validate_questionnaire_claims,
@@ -119,6 +119,12 @@ def get_session_expired():
         logout_user()
 
     return render_template("errors/401")
+
+
+@session_blueprint.route("/session-expiry", methods=["GET"])
+@login_required
+def get_session_expiry():
+    return jsonify(expires_at=get_session_store().expiration_time.isoformat())
 
 
 @session_blueprint.route("/sign-out", methods=["GET"])

--- a/tests/app/authentication/test_authenticator.py
+++ b/tests/app/authentication/test_authenticator.py
@@ -1,6 +1,8 @@
 from datetime import datetime, timedelta, timezone
+from unittest.mock import Mock
 
 from flask import session as cookie_session
+from flask.wrappers import Request
 from mock import patch
 
 from app.authentication.authenticator import load_user, request_load_user, user_loader
@@ -90,7 +92,7 @@ class TestAuthenticator(AppContextTestCase):  # pylint: disable=too-many-public-
                 cookie_session[USER_IK] = "user_ik"
 
                 # When
-                user = request_load_user(None)
+                user = request_load_user(Mock(spec=Request))
 
                 # Then
                 self.assertEqual(user.user_id, "user_id")

--- a/tests/integration/integration_test_case.py
+++ b/tests/integration/integration_test_case.py
@@ -201,6 +201,31 @@ class IntegrationTestCase(unittest.TestCase):  # pylint: disable=too-many-public
 
         self._cache_response(response)
 
+    def patch(self, patch_data=None, url=None, **kwargs):
+        """
+        PATCHes to the specified URL with patch_data and performs a GET
+        with the URL from the re-direct.
+
+        Will add the last received CSRF token to the patch_data automatically.
+
+        :param url: the URL to PATCH to; use None to use the last received URL
+        :param patch_data: the data to PATCH
+        """
+        if url is None:
+            url = self.last_url
+
+        self.assertIsNotNone(url)
+
+        _patch_data = (patch_data.copy() or {}) if patch_data else {}
+        if self.last_csrf_token is not None:
+            _patch_data.update({"csrf_token": self.last_csrf_token})
+
+        response = self._client.patch(
+            url, data=_patch_data, follow_redirects=True, **kwargs
+        )
+
+        self._cache_response(response)
+
     def head(self, url, **kwargs):
         """
         Send a HEAD request to the specified URL.

--- a/tests/integration/routes/test_session.py
+++ b/tests/integration/routes/test_session.py
@@ -3,9 +3,8 @@ from datetime import datetime, timedelta, timezone
 
 from freezegun import freeze_time
 
-from app.utilities.json import json_loads
 from app.settings import ACCOUNT_SERVICE_BASE_URL, EQ_SESSION_TIMEOUT_SECONDS
-
+from app.utilities.json import json_loads
 from tests.integration.integration_test_case import IntegrationTestCase
 
 TIME_TO_FREEZE = datetime(2020, 1, 1, 12, 0, 0, tzinfo=timezone.utc)


### PR DESCRIPTION
### What is the context of this PR?
This PR adds the session-expiry end point, which returns expires_at in response object with the application/json mimetype

### How to review 
Launch a questionnaire and then visit /session-expiry to check it works and changes with time

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
