### PR TITLE
Add new rules engine for section enabled rules

### DIFF
--- a/app/questionnaire/router.py
+++ b/app/questionnaire/router.py
@@ -1,4 +1,4 @@
-from typing import Optional, Sequence, Tuple
+from typing import Optional, Tuple
 
 from flask import url_for
 
@@ -272,17 +272,7 @@ class Router:
             return True
 
         enabled = section["enabled"]
-        if isinstance(enabled, Sequence):
-            for condition in enabled:
-                if evaluate_when_rules(
-                    condition["when"],
-                    self._schema,
-                    self._metadata,
-                    self._answer_store,
-                    self._list_store,
-                ):
-                    return True
-        else:
+        if isinstance(enabled, dict):
             location = Location(section_id=section["id"])
             when_rule_evaluator = WhenRuleEvaluator(
                 self._schema,
@@ -294,7 +284,18 @@ class Router:
                 routing_path_block_ids=None,
             )
 
-            return when_rule_evaluator.evaluate(enabled.get("when"))
+            return when_rule_evaluator.evaluate(enabled["when"])
+
+        else:
+            for condition in enabled:
+                if evaluate_when_rules(
+                    condition["when"],
+                    self._schema,
+                    self._metadata,
+                    self._answer_store,
+                    self._list_store,
+                ):
+                    return True
 
         return False
 

--- a/app/questionnaire/router.py
+++ b/app/questionnaire/router.py
@@ -273,14 +273,13 @@ class Router:
 
         enabled = section["enabled"]
         if isinstance(enabled, dict):
-            location = Location(section_id=section["id"])
             when_rule_evaluator = WhenRuleEvaluator(
                 self._schema,
                 self._answer_store,
                 self._list_store,
                 self._metadata,
                 self._response_metadata,
-                location=location,
+                location=None,
                 routing_path_block_ids=None,
             )
 

--- a/app/questionnaire/router.py
+++ b/app/questionnaire/router.py
@@ -286,18 +286,16 @@ class Router:
 
             return when_rule_evaluator.evaluate(enabled["when"])
 
-        else:
-            for condition in enabled:
-                if evaluate_when_rules(
-                    condition["when"],
-                    self._schema,
-                    self._metadata,
-                    self._answer_store,
-                    self._list_store,
-                ):
-                    return True
-
-        return False
+        return any(
+            evaluate_when_rules(
+                condition["when"],
+                self._schema,
+                self._metadata,
+                self._answer_store,
+                self._list_store,
+            )
+            for condition in enabled
+        )
 
     @staticmethod
     def get_next_block_url(location, routing_path):

--- a/app/questionnaire/routing/when_rule_evaluator.py
+++ b/app/questionnaire/routing/when_rule_evaluator.py
@@ -19,11 +19,12 @@ class WhenRuleEvaluator:
     list_store: ListStore
     metadata: Mapping
     response_metadata: Mapping
-    location: Union[Location, RelationshipLocation]
+    location: Optional[Union[Location, RelationshipLocation]]
     routing_path_block_ids: Optional[list] = None
 
     # pylint: disable=attribute-defined-outside-init
     def __post_init__(self) -> None:
+        list_item_id = self.location.list_item_id if self.location else None
         self.value_source_resolver = ValueSourceResolver(
             answer_store=self.answer_store,
             list_store=self.list_store,
@@ -31,7 +32,7 @@ class WhenRuleEvaluator:
             response_metadata=self.response_metadata,
             schema=self.schema,
             location=self.location,
-            list_item_id=self.location.list_item_id,
+            list_item_id=list_item_id,
             routing_path_block_ids=self.routing_path_block_ids,
             use_default_answer=True,
         )

--- a/app/questionnaire/routing/when_rule_evaluator.py
+++ b/app/questionnaire/routing/when_rule_evaluator.py
@@ -19,7 +19,7 @@ class WhenRuleEvaluator:
     list_store: ListStore
     metadata: Mapping
     response_metadata: Mapping
-    location: Optional[Union[Location, RelationshipLocation]]
+    location: Union[None, Location, RelationshipLocation]
     routing_path_block_ids: Optional[list] = None
 
     # pylint: disable=attribute-defined-outside-init

--- a/test_schemas/en/test_new_hub_section_required_and_enabled.json
+++ b/test_schemas/en/test_new_hub_section_required_and_enabled.json
@@ -1,0 +1,122 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "language": "en",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.3",
+    "survey_id": "0",
+    "title": "Hub & Spoke required and enabled sections",
+    "theme": "default",
+    "description": "A questionnaire to demo hub and spoke required and enabled sections",
+    "metadata": [
+        {
+            "name": "user_id",
+            "type": "string"
+        },
+        {
+            "name": "period_id",
+            "type": "string"
+        },
+        {
+            "name": "ru_name",
+            "type": "string"
+        }
+    ],
+    "questionnaire_flow": {
+        "type": "Hub",
+        "options": { "required_completed_sections": ["household-section", "relationships-section"] }
+    },
+    "sections": [
+        {
+            "id": "household-section",
+            "title": "Household",
+            "groups": [
+                {
+                    "id": "radio",
+                    "title": "Household Relationships",
+                    "blocks": [
+                        {
+                            "type": "Question",
+                            "id": "household-relationships-block",
+                            "question": {
+                                "type": "General",
+                                "id": "household-relationships-question",
+                                "title": "Is anyone related in this household?",
+                                "answers": [
+                                    {
+                                        "type": "Radio",
+                                        "id": "household-relationships-answer",
+                                        "mandatory": true,
+                                        "options": [
+                                            {
+                                                "label": "Yes",
+                                                "value": "Yes"
+                                            },
+                                            {
+                                                "label": "No",
+                                                "value": "No"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "relationships-section",
+            "title": "Relationships",
+            "show_on_hub": false,
+            "groups": [
+                {
+                    "blocks": [
+                        {
+                            "id": "relationships-count",
+                            "question": {
+                                "type": "General",
+                                "id": "relationships-count-question",
+                                "title": "How many people are related?",
+                                "answers": [
+                                    {
+                                        "type": "Radio",
+                                        "id": "relationships-count-answer",
+                                        "mandatory": true,
+                                        "options": [
+                                            {
+                                                "label": "1",
+                                                "value": "1"
+                                            },
+                                            {
+                                                "label": "2",
+                                                "value": "2"
+                                            },
+                                            {
+                                                "label": "3+",
+                                                "value": "3+"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "type": "Question"
+                        }
+                    ],
+                    "id": "relationships-count-group",
+                    "title": "Relationships count"
+                }
+            ],
+            "enabled": {
+                "when": {
+                    "==": [
+                        "Yes",
+                        {
+                            "source": "answers",
+                            "identifier": "household-relationships-answer"
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+}

--- a/test_schemas/en/test_new_routing_to_questionnaire_end_multiple_sections.json
+++ b/test_schemas/en/test_new_routing_to_questionnaire_end_multiple_sections.json
@@ -102,17 +102,17 @@
         {
             "id": "test-section-2",
             "title": "Section 2",
-            "enabled": [
-                {
-                    "when": [
+            "enabled": {
+                "when": {
+                    "==": [
+                        "Yes",
                         {
-                            "id": "test-answer",
-                            "condition": "equals",
-                            "value": "Yes"
+                            "source": "answers",
+                            "identifier": "test-answer"
                         }
                     ]
                 }
-            ],
+            },
             "groups": [
                 {
                     "blocks": [

--- a/test_schemas/en/test_new_section_enabled_checkbox.json
+++ b/test_schemas/en/test_new_section_enabled_checkbox.json
@@ -1,0 +1,168 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "language": "en",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.3",
+    "survey_id": "0",
+    "title": "Test Section Enabled",
+    "theme": "default",
+    "description": "A questionnaire to demo section enabled key usage with checkbox options",
+    "metadata": [
+        {
+            "name": "user_id",
+            "type": "string"
+        },
+        {
+            "name": "period_id",
+            "type": "string"
+        },
+        {
+            "name": "ru_name",
+            "type": "string"
+        }
+    ],
+    "questionnaire_flow": {
+        "type": "Linear",
+        "options": {
+            "summary": {
+                "collapsible": false
+            }
+        }
+    },
+    "sections": [
+        {
+            "id": "section-1",
+            "title": "Section 1",
+            "groups": [
+                {
+                    "blocks": [
+                        {
+                            "id": "section-1-block",
+                            "type": "Question",
+                            "question": {
+                                "answers": [
+                                    {
+                                        "id": "section-1-answer",
+                                        "label": "label 1",
+                                        "mandatory": false,
+                                        "options": [
+                                            {
+                                                "label": "Section 2",
+                                                "value": "Section 2"
+                                            },
+                                            {
+                                                "label": "Section 3",
+                                                "value": "Section 3"
+                                            }
+                                        ],
+                                        "type": "Checkbox"
+                                    },
+                                    {
+                                        "id": "section-1-answer-exclusive",
+                                        "mandatory": false,
+                                        "options": [
+                                            {
+                                                "label": "Neither",
+                                                "value": "Neither"
+                                            }
+                                        ],
+                                        "type": "Checkbox"
+                                    }
+                                ],
+                                "mandatory": false,
+                                "description": ["This is section 1."],
+                                "id": "section-1-question",
+                                "title": "Which sections do you want to enable?",
+                                "type": "MutuallyExclusive"
+                            }
+                        }
+                    ],
+                    "id": "section-1-group",
+                    "title": "Section 1"
+                }
+            ]
+        },
+        {
+            "id": "section-2",
+            "title": "Section 2",
+            "enabled": {
+                "when": {
+                    "in": [
+                        "Section 2",
+                        {
+                            "source": "answers",
+                            "identifier": "section-1-answer"
+                        }
+                    ]
+                }
+            },
+            "groups": [
+                {
+                    "blocks": [
+                        {
+                            "id": "section-2-block",
+                            "type": "Question",
+                            "question": {
+                                "answers": [
+                                    {
+                                        "id": "section-2-answer",
+                                        "label": "label 2",
+                                        "mandatory": false,
+                                        "type": "Number"
+                                    }
+                                ],
+                                "description": ["This is section 2."],
+                                "id": "section-2-question",
+                                "title": "Which section is this?",
+                                "type": "General"
+                            }
+                        }
+                    ],
+                    "id": "section-2-group",
+                    "title": "Section 2"
+                }
+            ]
+        },
+        {
+            "id": "section-3",
+            "title": "Section 3",
+            "enabled": [
+                {
+                    "when": [
+                        {
+                            "id": "section-1-answer",
+                            "condition": "contains",
+                            "value": "Section 3"
+                        }
+                    ]
+                }
+            ],
+            "groups": [
+                {
+                    "blocks": [
+                        {
+                            "id": "section-3-block",
+                            "type": "Question",
+                            "question": {
+                                "answers": [
+                                    {
+                                        "id": "section-3-answer",
+                                        "label": "label 3",
+                                        "mandatory": false,
+                                        "type": "Number"
+                                    }
+                                ],
+                                "description": ["This is section 3."],
+                                "id": "section-3-question",
+                                "title": "Which section is this?",
+                                "type": "General"
+                            }
+                        }
+                    ],
+                    "id": "section-3-group",
+                    "title": "Section 3"
+                }
+            ]
+        }
+    ]
+}

--- a/test_schemas/en/test_new_section_enabled_checkbox.json
+++ b/test_schemas/en/test_new_section_enabled_checkbox.json
@@ -126,17 +126,17 @@
         {
             "id": "section-3",
             "title": "Section 3",
-            "enabled": [
-                {
-                    "when": [
+            "enabled": {
+                "when": {
+                    "in": [
+                        "Section 3",
                         {
-                            "id": "section-1-answer",
-                            "condition": "contains",
-                            "value": "Section 3"
+                            "source": "answers",
+                            "identifier": "section-1-answer"
                         }
                     ]
                 }
-            ],
+            },
             "groups": [
                 {
                     "blocks": [

--- a/test_schemas/en/test_new_section_enabled_hub.json
+++ b/test_schemas/en/test_new_section_enabled_hub.json
@@ -1,0 +1,163 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "language": "en",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.3",
+    "survey_id": "0",
+    "title": "Test Section Enabled",
+    "theme": "default",
+    "description": "A questionnaire to demo section enabled key usage with hub enabled",
+    "metadata": [
+        {
+            "name": "user_id",
+            "type": "string"
+        },
+        {
+            "name": "period_id",
+            "type": "string"
+        },
+        {
+            "name": "ru_name",
+            "type": "string"
+        }
+    ],
+    "questionnaire_flow": {
+        "type": "Hub",
+        "options": { "required_completed_sections": ["section-1"] }
+    },
+    "sections": [
+        {
+            "id": "section-1",
+            "title": "Section 1",
+            "groups": [
+                {
+                    "blocks": [
+                        {
+                            "id": "section-1-block",
+                            "type": "Question",
+                            "question": {
+                                "answers": [
+                                    {
+                                        "id": "section-1-answer",
+                                        "mandatory": false,
+                                        "options": [
+                                            {
+                                                "label": "Section 2",
+                                                "value": "Section 2"
+                                            },
+                                            {
+                                                "label": "Section 3",
+                                                "value": "Section 3"
+                                            }
+                                        ],
+                                        "type": "Checkbox"
+                                    },
+                                    {
+                                        "id": "section-1-answer-exclusive",
+                                        "mandatory": false,
+                                        "options": [
+                                            {
+                                                "label": "Neither",
+                                                "value": "Neither"
+                                            }
+                                        ],
+                                        "type": "Checkbox"
+                                    }
+                                ],
+                                "mandatory": false,
+                                "description": ["This is section 1."],
+                                "id": "section-1-question",
+                                "title": "Which sections do you want to enable?",
+                                "type": "MutuallyExclusive"
+                            }
+                        }
+                    ],
+                    "id": "section-1-group",
+                    "title": "Section 1"
+                }
+            ]
+        },
+        {
+            "id": "section-2",
+            "title": "Section 2",
+            "enabled": {
+                "when": {
+                    "in": [
+                        "Section 2",
+                        {
+                            "source": "answers",
+                            "identifier": "section-1-answer"
+                        }
+                    ]
+                }
+            },
+            "groups": [
+                {
+                    "blocks": [
+                        {
+                            "id": "section-2-block",
+                            "type": "Question",
+                            "question": {
+                                "answers": [
+                                    {
+                                        "id": "section-2-answer",
+                                        "label": "Section 2",
+                                        "mandatory": false,
+                                        "type": "Number"
+                                    }
+                                ],
+                                "description": ["This is section 2."],
+                                "id": "section-2-question",
+                                "title": "Which section is this?",
+                                "type": "General"
+                            }
+                        }
+                    ],
+                    "id": "section-2-group",
+                    "title": "Section 2"
+                }
+            ]
+        },
+        {
+            "id": "section-3",
+            "title": "Section 3",
+            "enabled": {
+                "when": {
+                    "in": [
+                        "Section 3",
+                        {
+                            "source": "answers",
+                            "identifier": "section-1-answer"
+                        }
+                    ]
+                }
+            },
+            "groups": [
+                {
+                    "blocks": [
+                        {
+                            "id": "section-3-block",
+                            "type": "Question",
+                            "question": {
+                                "answers": [
+                                    {
+                                        "id": "section-3-answer",
+                                        "label": "Section 3",
+                                        "mandatory": false,
+                                        "type": "Number"
+                                    }
+                                ],
+                                "description": ["This is section 3."],
+                                "id": "section-3-question",
+                                "title": "Which section is this?",
+                                "type": "General"
+                            }
+                        }
+                    ],
+                    "id": "section-3-group",
+                    "title": "Section 3"
+                }
+            ]
+        }
+    ]
+}

--- a/test_schemas/en/test_new_section_enabled_radio.json
+++ b/test_schemas/en/test_new_section_enabled_radio.json
@@ -1,0 +1,115 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "language": "en",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.3",
+    "survey_id": "0",
+    "title": "Test Section Enabled",
+    "theme": "default",
+    "description": "A questionnaire to demo section enabled key usage with radio options",
+    "metadata": [
+        {
+            "name": "user_id",
+            "type": "string"
+        },
+        {
+            "name": "period_id",
+            "type": "string"
+        },
+        {
+            "name": "ru_name",
+            "type": "string"
+        }
+    ],
+    "questionnaire_flow": {
+        "type": "Linear",
+        "options": {
+            "summary": {
+                "collapsible": false
+            }
+        }
+    },
+    "sections": [
+        {
+            "id": "section-1",
+            "title": "Section 1",
+            "groups": [
+                {
+                    "blocks": [
+                        {
+                            "id": "section-1-block",
+                            "type": "Question",
+                            "question": {
+                                "answers": [
+                                    {
+                                        "id": "section-1-answer",
+                                        "label": "Section 1",
+                                        "mandatory": false,
+                                        "options": [
+                                            {
+                                                "label": "Yes, enable section 2",
+                                                "value": "Yes, enable section 2"
+                                            },
+                                            {
+                                                "label": "No, disable section 2",
+                                                "value": "No, disable section 2"
+                                            }
+                                        ],
+                                        "type": "Radio"
+                                    }
+                                ],
+                                "description": ["This is section 1."],
+                                "id": "section-1-question",
+                                "title": "Do you want to enable section 2?",
+                                "type": "General"
+                            }
+                        }
+                    ],
+                    "id": "section-1-group",
+                    "title": "Section 1"
+                }
+            ]
+        },
+        {
+            "id": "section-2",
+            "title": "Section 2",
+            "enabled": {
+                "when": {
+                    "==": [
+                        "Yes, enable section 2",
+                        {
+                            "source": "answers",
+                            "identifier": "section-1-answer"
+                        }
+                    ]
+                }
+            },
+            "groups": [
+                {
+                    "blocks": [
+                        {
+                            "id": "section-2-block",
+                            "type": "Question",
+                            "question": {
+                                "answers": [
+                                    {
+                                        "id": "section-2-answer",
+                                        "label": "Section 2",
+                                        "mandatory": false,
+                                        "type": "Number"
+                                    }
+                                ],
+                                "description": ["This is section 2."],
+                                "id": "section-2-question",
+                                "title": "Which section is this?",
+                                "type": "General"
+                            }
+                        }
+                    ],
+                    "id": "section-2-group",
+                    "title": "Section 2"
+                }
+            ]
+        }
+    ]
+}

--- a/tests/app/questionnaire/test_router.py
+++ b/tests/app/questionnaire/test_router.py
@@ -53,6 +53,10 @@ class TestRouter(RouterTestCase):
 
         self.assertEqual(expected_section_ids, self.router.enabled_section_ids)
 
+        self.schema = load_schema_from_name("test_new_section_enabled_checkbox")
+
+        self.assertEqual(expected_section_ids, self.router.enabled_section_ids)
+
     def test_full_routing_path_without_repeating_sections(self):
         self.schema = load_schema_from_name("test_checkbox")
         routing_path = self.router.full_routing_path()
@@ -268,7 +272,7 @@ class TestRouterLocationValidity(RouterTestCase):
         self.assertFalse(can_access_location)
 
     def test_cant_access_section_disabled(self):
-        self.schema = load_schema_from_name("test_section_enabled_checkbox")
+        self.schema = load_schema_from_name("test_new_section_enabled_checkbox")
 
         current_location = Location(
             section_id="section-2", block_id="section-2-block", list_item_id=None

--- a/tests/functional/spec/features/enabled-sections/enabled_section_checkbox.spec.js
+++ b/tests/functional/spec/features/enabled-sections/enabled_section_checkbox.spec.js
@@ -4,7 +4,7 @@ import SubmitPage from "../../../generated_pages/section_enabled_checkbox/submit
 
 describe("Feature: Section Enabled Based On Checkbox Answers", () => {
   beforeEach("Open survey", () => {
-    browser.openQuestionnaire("test_section_enabled_checkbox.json");
+    browser.openQuestionnaire("test_new_section_enabled_checkbox.json");
   });
 
   it("When the user selects `Section 2` and submits, Then section 2 should be displayed", () => {

--- a/tests/functional/spec/features/enabled-sections/enabled_section_hub.spec.js
+++ b/tests/functional/spec/features/enabled-sections/enabled_section_hub.spec.js
@@ -3,7 +3,7 @@ import hubPage from "../../../base_pages/hub.page";
 
 describe("Feature: Section Enabled With Hub", () => {
   beforeEach("Open survey", () => {
-    browser.openQuestionnaire("test_section_enabled_hub.json");
+    browser.openQuestionnaire("test_new_section_enabled_hub.json");
   });
 
   it("When the user selects `Section 2` and submits, Then only section 2 should be displayed on the hub", () => {

--- a/tests/functional/spec/features/enabled-sections/enabled_section_radio.spec.js
+++ b/tests/functional/spec/features/enabled-sections/enabled_section_radio.spec.js
@@ -3,7 +3,7 @@ import SubmitPage from "../../../generated_pages/section_enabled_radio/submit.pa
 
 describe("Feature: Section Enabled Based On Radio Answers", () => {
   beforeEach("Open survey", () => {
-    browser.openQuestionnaire("test_section_enabled_radio.json");
+    browser.openQuestionnaire("test_new_section_enabled_radio.json");
   });
 
   it("When the user answers `Yes, enable section 2` and submits, Then section 2 should be displayed", () => {

--- a/tests/integration/questionnaire/test_questionnaire_hub.py
+++ b/tests/integration/questionnaire/test_questionnaire_hub.py
@@ -157,7 +157,7 @@ class TestQuestionnaireHub(IntegrationTestCase):
 
     def test_hub_section_required_but_enabled_false(self):
         # Given the hub is enabled and there are two required sections
-        self.launchSurvey("test_hub_section_required_and_enabled")
+        self.launchSurvey("test_new_hub_section_required_and_enabled")
 
         # When I answer 'No' to the first section, meaning the second section is not enabled
         self.post({"household-relationships-answer": "No"})
@@ -169,7 +169,7 @@ class TestQuestionnaireHub(IntegrationTestCase):
 
     def test_hub_section_required_but_enabled_true(self):
         # Given the hub is enabled and there are two required sections
-        self.launchSurvey("test_hub_section_required_and_enabled")
+        self.launchSurvey("test_new_hub_section_required_and_enabled")
 
         # When I answer 'Yes' to the first section, meaning the second section is enabled
         self.post({"household-relationships-answer": "Yes"})

--- a/tests/integration/session/test_sign_out_and_exit.py
+++ b/tests/integration/session/test_sign_out_and_exit.py
@@ -74,14 +74,14 @@ class TestExitPostSubmissionWithHubDefaultTheme(IntegrationTestCase):
 
     def test_no_account_service_log_out_url_redirects_to_signed_out_page(self):
         self._launch_and_submit_questionnaire(
-            schema="test_hub_section_required_and_enabled"
+            schema="test_new_hub_section_required_and_enabled"
         )
         self.get(SIGN_OUT_URL_PATH, follow_redirects=False)
         self.assertInUrl(SIGN_OUT_URL_PATH)
 
     def test_redirects_to_account_service_log_out_url_when_present(self):
         self._launch_and_submit_questionnaire(
-            schema="test_hub_section_required_and_enabled",
+            schema="test_new_hub_section_required_and_enabled",
             account_service_log_out_url=ACCOUNT_SERVICE_LOG_OUT_URL,
         )
         self.get(SIGN_OUT_URL_PATH)


### PR DESCRIPTION
### What is the context of this PR?
This adds new rules engine for the section enabled element of schemas, based on element type it will now evaluate `when` rules using old or new when rule evaluation. All schemas that use that used old type of when rules in section enabled has been updated and added to schemas with `new` prefix.

### How to review 
Run new test schemas manually or run unit tests.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
