### PR TITLE
Move feedback metadata update before encryption

### DIFF
--- a/app/submitter/submitter.py
+++ b/app/submitter/submitter.py
@@ -5,8 +5,6 @@ from pika import BasicProperties, BlockingConnection, URLParameters
 from pika.exceptions import AMQPError, NackError, UnroutableError
 from structlog import get_logger
 
-from app.utilities.json import json_dumps
-
 logger = get_logger()
 
 
@@ -139,7 +137,7 @@ class GCSFeedbackSubmitter:
     def upload(self, metadata, payload):
         blob = self.bucket.blob(str(uuid4()))
         blob.metadata = metadata
-        blob.upload_from_string(json_dumps(payload).encode("utf8"))
+        blob.upload_from_string(payload.encode("utf8"))
 
         return True
 

--- a/app/submitter/submitter.py
+++ b/app/submitter/submitter.py
@@ -137,12 +137,9 @@ class GCSFeedbackSubmitter:
         self.bucket = client.get_bucket(bucket_name)
 
     def upload(self, metadata, payload):
-        payload.update(metadata)
         blob = self.bucket.blob(str(uuid4()))
         blob.metadata = metadata
-        blob.upload_from_string(
-            json_dumps(payload).encode("utf8"), content_type="application/json"
-        )
+        blob.upload_from_string(json_dumps(payload).encode("utf8"))
 
         return True
 

--- a/app/views/handlers/feedback.py
+++ b/app/views/handlers/feedback.py
@@ -21,7 +21,6 @@ from app.submitter.converter import (
     build_metadata,
     get_optional_payload_properties,
 )
-from app.utilities.json import json_dumps
 from app.views.contexts.feedback_form_context import build_feedback_context
 
 
@@ -105,7 +104,7 @@ class Feedback:
             feedback_type=self.form.data.get("feedback-type"),
         )
 
-        message = json_dumps(feedback_message())
+        message = feedback_message()
         message.update(feedback_metadata())
         encrypted_message = encrypt(
             message, current_app.eq["key_store"], KEY_PURPOSE_SUBMISSION  # type: ignore

--- a/app/views/handlers/feedback.py
+++ b/app/views/handlers/feedback.py
@@ -87,11 +87,11 @@ class Feedback:
     def handle_post(self) -> None:
         session_data = self._session_store.session_data
         session_data.feedback_count += 1
-
         feedback_metadata = FeedbackMetadata(
             session_data.case_id,
             session_data.tx_id,
         )
+
         # pylint: disable=no-member
         # wtforms Form parents are not discoverable in the 2.3.3 implementation
         feedback_message = FeedbackPayload(
@@ -106,7 +106,7 @@ class Feedback:
         )
 
         message = json_dumps(feedback_message())
-
+        message.update(feedback_metadata())
         encrypted_message = encrypt(
             message, current_app.eq["key_store"], KEY_PURPOSE_SUBMISSION  # type: ignore
         )

--- a/app/views/handlers/feedback.py
+++ b/app/views/handlers/feedback.py
@@ -86,6 +86,7 @@ class Feedback:
     def handle_post(self) -> None:
         session_data = self._session_store.session_data
         session_data.feedback_count += 1
+
         feedback_metadata = FeedbackMetadata(
             session_data.case_id,
             session_data.tx_id,
@@ -103,15 +104,15 @@ class Feedback:
             feedback_text=self.form.data.get("feedback-text"),
             feedback_type=self.form.data.get("feedback-type"),
         )
-
         message = feedback_message()
-        message.update(feedback_metadata())
+        metadata = feedback_metadata()
+        message.update(metadata)
         encrypted_message = encrypt(
             message, current_app.eq["key_store"], KEY_PURPOSE_SUBMISSION  # type: ignore
         )
 
         if not current_app.eq["feedback_submitter"].upload(  # type: ignore
-            feedback_metadata(), encrypted_message
+            metadata, encrypted_message
         ):
             raise FeedbackUploadFailed()
 

--- a/tests/app/submitter/test_submitter.py
+++ b/tests/app/submitter/test_submitter.py
@@ -247,6 +247,7 @@ class TestGCSFeedbackSubmitter(TestCase):
             "feedback-type": "Feedback type",
             "feedback-text": "Feedback text",
         }
+        payload.update(metadata)
 
         # When
         feedback_upload = feedback.upload(metadata, payload)

--- a/tests/app/submitter/test_submitter.py
+++ b/tests/app/submitter/test_submitter.py
@@ -5,6 +5,7 @@ from mock import Mock, call, patch
 from pika.exceptions import AMQPError, NackError
 
 from app.submitter import GCSFeedbackSubmitter, GCSSubmitter, RabbitMQSubmitter
+from app.utilities.json import json_dumps
 
 
 class TestRabbitMQSubmitter(TestCase):
@@ -247,10 +248,11 @@ class TestGCSFeedbackSubmitter(TestCase):
             "feedback-type": "Feedback type",
             "feedback-text": "Feedback text",
         }
+
         payload.update(metadata)
 
         # When
-        feedback_upload = feedback.upload(metadata, payload)
+        feedback_upload = feedback.upload(metadata, json_dumps(payload))
 
         # Then
         bucket = client.return_value.get_bucket.return_value


### PR DESCRIPTION
### What is the context of this PR?
Feedback metadata was being updated after encryption meaning this would break using GCSFeedbackSubmitter, this moves if before encryption

### How to review 
Check locally and on GCP feedback now works

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
