### PR TITLE
Conditionally extend session from PATCH/GET /session-expiry

### DIFF
--- a/app/authentication/authenticator.py
+++ b/app/authentication/authenticator.py
@@ -32,7 +32,7 @@ def user_loader(user_id: str) -> Optional[str]:
 def request_load_user(request: Request) -> Optional[User]:
     logger.debug("load user")
 
-    if request.endpoint:
+    if request and request.endpoint:
         extend_session = not (
             request.endpoint == "session.session_expiry" and request.method == "GET"
         )

--- a/app/authentication/authenticator.py
+++ b/app/authentication/authenticator.py
@@ -90,7 +90,7 @@ def _is_session_valid(session_store: SessionStore) -> bool:
     )
 
 
-def load_user(extend_session: bool) -> Optional[User]:
+def load_user(extend_session: bool = True) -> Optional[User]:
     """
     Checks for the present of the JWT in the users sessions
     :return: A user object if a JWT token is available in the session
@@ -108,10 +108,7 @@ def load_user(extend_session: bool) -> Optional[User]:
             logger.bind(tx_id=session_store.session_data.tx_id)
 
         if extend_session:
-            print("session extended")
             _extend_session_expiry(session_store)
-        else:
-            print("session not extended")
 
         return user
 

--- a/app/authentication/authenticator.py
+++ b/app/authentication/authenticator.py
@@ -34,7 +34,7 @@ def request_load_user(request: Request) -> Optional[User]:
 
     if request.endpoint:
         extend_session = not (
-            "session_expiry" in request.endpoint and request.method == "GET"
+            request.endpoint == "session.session_expiry" and request.method == "GET"
         )
     else:
         extend_session = True

--- a/app/authentication/authenticator.py
+++ b/app/authentication/authenticator.py
@@ -29,14 +29,12 @@ def user_loader(user_id: str) -> Optional[str]:
 
 
 @login_manager.request_loader
-def request_load_user(
-    request: Request,  # pylint: disable=unused-argument
-) -> Optional[User]:
+def request_load_user(request: Request) -> Optional[User]:
     logger.debug("load user")
 
-    if request:
+    if request.endpoint:
         extend_session = not (
-            "session-expiry" in request.path and request.method == "GET"
+            "session_expiry" in request.endpoint and request.method == "GET"
         )
     else:
         extend_session = True

--- a/app/authentication/authenticator.py
+++ b/app/authentication/authenticator.py
@@ -94,6 +94,8 @@ def load_user(extend_session: bool = True) -> Optional[User]:
     """
     Checks for the present of the JWT in the users sessions
     :return: A user object if a JWT token is available in the session
+
+    :param extend_session: bool, whether to extend the session
     """
     session_store = get_session_store()
 

--- a/app/authentication/authenticator.py
+++ b/app/authentication/authenticator.py
@@ -33,13 +33,15 @@ def request_load_user(
     request: Request,  # pylint: disable=unused-argument
 ) -> Optional[User]:
     logger.debug("load user")
+
     if request:
         extend_session = not (
             "session-expiry" in request.path and request.method == "GET"
         )
     else:
         extend_session = True
-    return load_user(extend_session)
+
+    return load_user(extend_session=extend_session)
 
 
 @user_logged_out.connect_via(ANY)
@@ -88,7 +90,7 @@ def _is_session_valid(session_store: SessionStore) -> bool:
     )
 
 
-def load_user(extend_session=True) -> Optional[User]:
+def load_user(extend_session: bool) -> Optional[User]:
     """
     Checks for the present of the JWT in the users sessions
     :return: A user object if a JWT token is available in the session
@@ -106,14 +108,16 @@ def load_user(extend_session=True) -> Optional[User]:
             logger.bind(tx_id=session_store.session_data.tx_id)
 
         if extend_session:
+            print("session extended")
             _extend_session_expiry(session_store)
+        else:
+            print("session not extended")
 
         return user
 
     logger.info("session does not exist")
 
     cookie_session.pop(USER_IK, None)
-    return None
 
 
 def _create_session_data_from_metadata(

--- a/app/authentication/authenticator.py
+++ b/app/authentication/authenticator.py
@@ -32,12 +32,9 @@ def user_loader(user_id: str) -> Optional[str]:
 def request_load_user(request: Request) -> Optional[User]:
     logger.debug("load user")
 
-    if request and request.endpoint:
-        extend_session = not (
-            request.endpoint == "session.session_expiry" and request.method == "GET"
-        )
-    else:
-        extend_session = True
+    extend_session = not (
+        request.endpoint == "session.session_expiry" and request.method == "GET"
+    )
 
     return load_user(extend_session=extend_session)
 

--- a/app/routes/session.py
+++ b/app/routes/session.py
@@ -121,9 +121,9 @@ def get_session_expired():
     return render_template("errors/401")
 
 
-@session_blueprint.route("/session-expiry", methods=["GET"])
+@session_blueprint.route("/session-expiry", methods=["GET", "PATCH"])
 @login_required
-def get_session_expiry():
+def session_expiry():
     return jsonify(expires_at=get_session_store().expiration_time.isoformat())
 
 

--- a/tests/app/authentication/test_authenticator.py
+++ b/tests/app/authentication/test_authenticator.py
@@ -1,6 +1,8 @@
 from datetime import datetime, timedelta, timezone
+from collections import namedtuple
 
 from flask import session as cookie_session
+from flask.wrappers import Request
 from mock import patch
 
 from app.authentication.authenticator import load_user, request_load_user, user_loader
@@ -89,8 +91,10 @@ class TestAuthenticator(AppContextTestCase):  # pylint: disable=too-many-public-
                 )
                 cookie_session[USER_IK] = "user_ik"
 
+                request = namedtuple("request", "endpoint method")
+
                 # When
-                user = request_load_user(None)
+                user = request_load_user(request("dummy", "GET"))
 
                 # Then
                 self.assertEqual(user.user_id, "user_id")

--- a/tests/app/authentication/test_authenticator.py
+++ b/tests/app/authentication/test_authenticator.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta, timezone
-from collections import namedtuple
+from unittest.mock import Mock
 
 from flask import session as cookie_session
 from flask.wrappers import Request
@@ -91,10 +91,8 @@ class TestAuthenticator(AppContextTestCase):  # pylint: disable=too-many-public-
                 )
                 cookie_session[USER_IK] = "user_ik"
 
-                request = namedtuple("request", "endpoint method")
-
                 # When
-                user = request_load_user(request("dummy", "GET"))
+                user = request_load_user(Mock(spec=Request))
 
                 # Then
                 self.assertEqual(user.user_id, "user_id")

--- a/tests/integration/integration_test_case.py
+++ b/tests/integration/integration_test_case.py
@@ -201,6 +201,35 @@ class IntegrationTestCase(unittest.TestCase):  # pylint: disable=too-many-public
 
         self._cache_response(response)
 
+    def patch(self, patch_data=None, url=None, action=None, **kwargs):
+        """
+        PATCHes to the specified URL with patch_data and performs a GET
+        with the URL from the re-direct.
+
+        Will add the last received CSRF token to the patch_data automatically.
+
+        :param url: the URL to POST to; use None to use the last received URL
+        :param patch_data: the data to POST
+        :param action: The button action to post
+        """
+        if url is None:
+            url = self.last_url
+
+        self.assertIsNotNone(url)
+
+        _patch_data = (patch_data.copy() or {}) if patch_data else {}
+        if self.last_csrf_token is not None:
+            _patch_data.update({"csrf_token": self.last_csrf_token})
+
+        if action:
+            _patch_data.update({f"action[{action}]": ""})
+
+        response = self._client.patch(
+            url, data=_patch_data, follow_redirects=True, **kwargs
+        )
+
+        self._cache_response(response)
+
     def head(self, url, **kwargs):
         """
         Send a HEAD request to the specified URL.

--- a/tests/integration/integration_test_case.py
+++ b/tests/integration/integration_test_case.py
@@ -201,16 +201,15 @@ class IntegrationTestCase(unittest.TestCase):  # pylint: disable=too-many-public
 
         self._cache_response(response)
 
-    def patch(self, patch_data=None, url=None, action=None, **kwargs):
+    def patch(self, patch_data=None, url=None, **kwargs):
         """
         PATCHes to the specified URL with patch_data and performs a GET
         with the URL from the re-direct.
 
         Will add the last received CSRF token to the patch_data automatically.
 
-        :param url: the URL to POST to; use None to use the last received URL
-        :param patch_data: the data to POST
-        :param action: The button action to post
+        :param url: the URL to PATCH to; use None to use the last received URL
+        :param patch_data: the data to PATCH
         """
         if url is None:
             url = self.last_url
@@ -220,9 +219,6 @@ class IntegrationTestCase(unittest.TestCase):  # pylint: disable=too-many-public
         _patch_data = (patch_data.copy() or {}) if patch_data else {}
         if self.last_csrf_token is not None:
             _patch_data.update({"csrf_token": self.last_csrf_token})
-
-        if action:
-            _patch_data.update({f"action[{action}]": ""})
 
         response = self._client.patch(
             url, data=_patch_data, follow_redirects=True, **kwargs

--- a/tests/integration/routes/test_session.py
+++ b/tests/integration/routes/test_session.py
@@ -66,7 +66,7 @@ class TestSession(IntegrationTestCase):
     def test_get_session_expiry_doesnt_extend_session(self):
         self.launchSurvey()
         # Advance time by 20 mins...
-        with freeze_time(TIME_TO_FREEZE + timedelta(seconds=20 * 60)):
+        with freeze_time(TIME_TO_FREEZE + timedelta(minutes=20)):
             self.get("/session-expiry")
             response = self.getResponseData()
             parsed_json = json_loads(response)
@@ -83,7 +83,7 @@ class TestSession(IntegrationTestCase):
     def test_patch_session_expiry_extends_session(self):
         self.launchSurvey()
         # Advance time by 20 mins...
-        request_time = TIME_TO_FREEZE + timedelta(seconds=20 * 60)
+        request_time = TIME_TO_FREEZE + timedelta(minutes=20)
         with freeze_time(request_time):
             self.patch(None, "/session-expiry")
             response = self.getResponseData()

--- a/tests/integration/routes/test_session.py
+++ b/tests/integration/routes/test_session.py
@@ -19,11 +19,7 @@ class TestSession(IntegrationTestCase):
         self.redirect_url = None
 
         # Perform setup steps
-        self._set_up_app(
-            setting_overrides={
-                "SURVEY_TYPE": "default",
-            }
-        )
+        self._set_up_app(setting_overrides={"SURVEY_TYPE": "default"})
 
     def test_session_expired(self):
         self.get("/session-expired")

--- a/tests/integration/routes/test_session.py
+++ b/tests/integration/routes/test_session.py
@@ -3,11 +3,12 @@ from datetime import datetime, timedelta, timezone
 
 from freezegun import freeze_time
 
-from app.settings import ACCOUNT_SERVICE_BASE_URL, EQ_SESSION_TIMEOUT_SECONDS
+from app.settings import ACCOUNT_SERVICE_BASE_URL
 from app.utilities.json import json_loads
 from tests.integration.integration_test_case import IntegrationTestCase
 
 TIME_TO_FREEZE = datetime(2020, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+EQ_SESSION_TIMEOUT_SECONDS = 45 * 60
 
 
 class TestSession(IntegrationTestCase):
@@ -19,7 +20,12 @@ class TestSession(IntegrationTestCase):
         self.redirect_url = None
 
         # Perform setup steps
-        self._set_up_app(setting_overrides={"SURVEY_TYPE": "default"})
+        self._set_up_app(
+            setting_overrides={
+                "SURVEY_TYPE": "default",
+                "EQ_SESSION_TIMEOUT_SECONDS": EQ_SESSION_TIMEOUT_SECONDS,
+            }
+        )
 
     def test_session_expired(self):
         self.get("/session-expired")


### PR DESCRIPTION
### What is the context of this PR?
The /session-expiry endpoints needed to be provided for PATCH and GET; PATCH will extend the session and return the updated expires_at value, GET will not extend the session and return the current expires_at value.

### How to review 

- Launch a survey
- Within 1 min, go to http://localhost:5000/session-expiry to show the GET request returns the initial expires_at timestamp
- Also within 1 min, run this command from chrome dev tools to show the PATCH request returns the inital expires_at timestamp 
```
fetch('http://localhost:5000/session-expiry', {
  method: 'PATCH',
  headers: {
    'Content-type': 'application/json; charset=UTF-8'
  }
})
.then(res => res.json())
.then(console.log)
```
- Wait for longer than 1 min
- Go to http://localhost:5000/session-expiry again to show the GET endpoint doesn't update the expires_at time
- Send the PATCH request again and check the expires_at time has been updated to 45mins from now
- Go to http://localhost:5000/session-expiry yet again to show the GET response reflects the time set by the PATCH request.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
