### PR TITLE
Prevent non-test schemas from being part of acceptance test

### DIFF
--- a/tests/functional/generate_pages.py
+++ b/tests/functional/generate_pages.py
@@ -893,15 +893,19 @@ if __name__ == "__main__":
             for root, dirs, files in os.walk(args.SCHEMA):
                 for file in [os.path.join(root, file) for file in files]:
                     filename = os.path.basename(file)
-                    logger.info("File %s", filename)
-                    if filename[0] == ".":
-                        continue
-                    output_dir = os.path.join(
-                        args.OUT_DIRECTORY, filename.split(".")[0].replace("test_", "")
-                    )
-                    if not os.path.exists(output_dir):
-                        os.makedirs(output_dir)
-                    process_schema(file, output_dir, None, args.require_path)
+                    logger.info(f"File {filename}")
+                    if filename.startswith("test_"):
+                        if filename[0] == ".":
+                            continue
+                        output_dir = os.path.join(
+                            args.OUT_DIRECTORY,
+                            filename.split(".")[0].replace("test_", ""),
+                        )
+                        if not os.path.exists(output_dir):
+                            os.makedirs(output_dir)
+                        process_schema(file, output_dir, None, args.require_path)
+                    else:
+                        logger.info(f"File {filename} is not a test schema")
 
         else:
             process_schema(

--- a/tests/functional/generate_pages.py
+++ b/tests/functional/generate_pages.py
@@ -893,7 +893,7 @@ if __name__ == "__main__":
             for root, dirs, files in os.walk(args.SCHEMA):
                 for file in [os.path.join(root, file) for file in files]:
                     filename = os.path.basename(file)
-                    logger.info(f"File {filename}")
+                    logger.info("File %s", filename)
                     if filename.startswith("test_"):
                         if filename[0] == ".":
                             continue
@@ -905,7 +905,7 @@ if __name__ == "__main__":
                             os.makedirs(output_dir)
                         process_schema(file, output_dir, None, args.require_path)
                     else:
-                        logger.info(f"File {filename} is not a test schema")
+                        logger.info("File %s is not a test schema, skipping", filename)
 
         else:
             process_schema(


### PR DESCRIPTION
### What is the context of this PR?
Prevents non-test schemas from being part of acceptance tests (and pages generation/linting process) in runner, which solves our problem with social schema. This would fix the build process issue in Social demo PR.

### How to review 
In the build check if non-test schemas are being skipped (for example `mbs_0253.json`.) and the appropriate message is being displayed.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
