### PR TITLE
Refactor operations.py into class

### DIFF
--- a/app/questionnaire/placeholder_transforms.py
+++ b/app/questionnaire/placeholder_transforms.py
@@ -8,7 +8,7 @@ from babel.numbers import format_currency, format_decimal
 from dateutil.relativedelta import relativedelta
 from flask_babel import ngettext
 
-from app.questionnaire.routing.operations import evaluate_count
+from app.questionnaire.routing.operations import Operations
 from app.settings import DEFAULT_LOCALE
 
 DAYS_OF_WEEK = {
@@ -332,4 +332,4 @@ class PlaceholderTransforms:
 
     @staticmethod
     def list_item_count(list_to_count: Optional[Sized]) -> int:
-        return evaluate_count(list_to_count)
+        return Operations().evaluate_count(list_to_count)

--- a/app/questionnaire/routing/operations.py
+++ b/app/questionnaire/routing/operations.py
@@ -11,82 +11,90 @@ ComparableValue = TypeVar("ComparableValue", str, int, float, Decimal, date)
 NonArrayPrimitiveTypes = Union[str, int, float, Decimal, None]
 
 
-@casefold
-def evaluate_equal(lhs: ValueTypes, rhs: ValueTypes) -> bool:
-    return lhs == rhs
-
-
-@casefold
-def evaluate_not_equal(lhs: ValueTypes, rhs: ValueTypes) -> bool:
-    return lhs != rhs
-
-
-def evaluate_greater_than(lhs: ComparableValue, rhs: ComparableValue) -> bool:
-    return lhs > rhs
-
-
-def evaluate_greater_than_or_equal(lhs: ComparableValue, rhs: ComparableValue) -> bool:
-    return lhs >= rhs
-
-
-def evaluate_less_than(lhs: ComparableValue, rhs: ComparableValue) -> bool:
-    return lhs < rhs
-
-
-def evaluate_less_than_or_equal(lhs: ComparableValue, rhs: ComparableValue) -> bool:
-    return lhs <= rhs
-
-
-def evaluate_not(value: bool) -> bool:
-    return not value
-
-
-def evaluate_and(values: Iterable[bool]) -> bool:
-    return all(iter(values))
-
-
-def evaluate_or(values: Iterable[bool]) -> bool:
-    return any(iter(values))
-
-
-def evaluate_count(values: Optional[Sized]) -> int:
-    return len(values or [])
-
-
-@casefold
-def evaluate_in(lhs: NonArrayPrimitiveTypes, rhs: Sequence) -> bool:
+class Operations:
     """
-    The NoneType check for rhs is done inline because this supports operations such as `None in [None, "Yes"]`
-    which is the short form of `value == None or value == "Yes"`.
+    A class to group the operations
     """
-    return rhs is not None and lhs in rhs
 
+    @staticmethod
+    @casefold
+    def evaluate_equal(lhs: ValueTypes, rhs: ValueTypes) -> bool:
+        return lhs == rhs
 
-@casefold
-def evaluate_all_in(lhs: Sequence, rhs: Sequence) -> bool:
-    return all(x in rhs for x in lhs)
+    @staticmethod
+    @casefold
+    def evaluate_not_equal(lhs: ValueTypes, rhs: ValueTypes) -> bool:
+        return lhs != rhs
 
+    @staticmethod
+    def evaluate_greater_than(lhs: ComparableValue, rhs: ComparableValue) -> bool:
+        return lhs > rhs
 
-@casefold
-def evaluate_any_in(lhs: Sequence, rhs: Sequence) -> bool:
-    return any(x in rhs for x in lhs)
+    @staticmethod
+    def evaluate_greater_than_or_equal(
+        lhs: ComparableValue, rhs: ComparableValue
+    ) -> bool:
+        return lhs >= rhs
 
+    @staticmethod
+    def evaluate_less_than(lhs: ComparableValue, rhs: ComparableValue) -> bool:
+        return lhs < rhs
 
-def resolve_date_from_string(
-    date_string: Optional[str], offset: Optional[dict[str, int]] = None
-) -> Optional[date]:
-    datetime_value = (
-        datetime.now(timezone.utc)
-        if date_string == "now"
-        else convert_to_datetime(date_string)
-    )
-    value_as_date = datetime_value.date() if datetime_value else None
+    @staticmethod
+    def evaluate_less_than_or_equal(lhs: ComparableValue, rhs: ComparableValue) -> bool:
+        return lhs <= rhs
 
-    if offset and value_as_date:
-        value_as_date += relativedelta(
-            days=offset.get("days", 0),
-            months=offset.get("months", 0),
-            years=offset.get("years", 0),
+    @staticmethod
+    def evaluate_not(value: bool) -> bool:
+        return not value
+
+    @staticmethod
+    def evaluate_and(values: Iterable[bool]) -> bool:
+        return all(iter(values))
+
+    @staticmethod
+    def evaluate_or(values: Iterable[bool]) -> bool:
+        return any(iter(values))
+
+    @staticmethod
+    def evaluate_count(values: Optional[Sized]) -> int:
+        return len(values or [])
+
+    @staticmethod
+    @casefold
+    def evaluate_in(lhs: NonArrayPrimitiveTypes, rhs: Sequence) -> bool:
+        """
+        The NoneType check for rhs is done inline because this supports operations such as `None in [None, "Yes"]`
+        which is the short form of `value == None or value == "Yes"`.
+        """
+        return rhs is not None and lhs in rhs
+
+    @staticmethod
+    @casefold
+    def evaluate_all_in(lhs: Sequence, rhs: Sequence) -> bool:
+        return all(x in rhs for x in lhs)
+
+    @staticmethod
+    @casefold
+    def evaluate_any_in(lhs: Sequence, rhs: Sequence) -> bool:
+        return any(x in rhs for x in lhs)
+
+    @staticmethod
+    def resolve_date_from_string(
+        date_string: Optional[str], offset: Optional[dict[str, int]] = None
+    ) -> Optional[date]:
+        datetime_value = (
+            datetime.now(timezone.utc)
+            if date_string == "now"
+            else convert_to_datetime(date_string)
         )
+        value_as_date = datetime_value.date() if datetime_value else None
 
-    return value_as_date
+        if offset and value_as_date:
+            value_as_date += relativedelta(
+                days=offset.get("days", 0),
+                months=offset.get("months", 0),
+                years=offset.get("years", 0),
+            )
+
+        return value_as_date

--- a/app/questionnaire/routing/operator.py
+++ b/app/questionnaire/routing/operator.py
@@ -2,7 +2,6 @@ from datetime import date
 from typing import Callable, Generator, Iterable, Optional, Sequence, Union
 
 from app.questionnaire.routing.helpers import ValueTypes
-from app.questionnaire.routing.operations import Operations
 
 
 class Operator:
@@ -21,9 +20,9 @@ class Operator:
     COUNT: str = "count"
     DATE: str = "date"
 
-    def __init__(self, name: str) -> None:
+    def __init__(self, name: str, operation: Callable) -> None:
         self.name = name
-        self._operation = OPERATIONS_MAPPINGS[self.name]
+        self._operation = operation
         self._ensure_operands_not_none = self.name in {
             Operator.GREATER_THAN,
             Operator.GREATER_THAN_OR_EQUAL,
@@ -51,23 +50,3 @@ class Operator:
     @staticmethod
     def _any_operands_none(*operands: Union[Sequence, ValueTypes]) -> bool:
         return any(operand is None for operand in operands)
-
-
-operations = Operations()
-
-OPERATIONS_MAPPINGS: dict[str, Callable] = {
-    Operator.NOT: operations.evaluate_not,
-    Operator.AND: operations.evaluate_and,
-    Operator.OR: operations.evaluate_or,
-    Operator.EQUAL: operations.evaluate_equal,
-    Operator.NOT_EQUAL: operations.evaluate_not_equal,
-    Operator.GREATER_THAN: operations.evaluate_greater_than,
-    Operator.LESS_THAN: operations.evaluate_less_than,
-    Operator.GREATER_THAN_OR_EQUAL: operations.evaluate_greater_than_or_equal,
-    Operator.LESS_THAN_OR_EQUAL: operations.evaluate_less_than_or_equal,
-    Operator.IN: operations.evaluate_in,
-    Operator.ALL_IN: operations.evaluate_all_in,
-    Operator.ANY_IN: operations.evaluate_any_in,
-    Operator.COUNT: operations.evaluate_count,
-    Operator.DATE: operations.resolve_date_from_string,
-}

--- a/app/questionnaire/routing/operator.py
+++ b/app/questionnaire/routing/operator.py
@@ -2,22 +2,7 @@ from datetime import date
 from typing import Callable, Generator, Iterable, Optional, Sequence, Union
 
 from app.questionnaire.routing.helpers import ValueTypes
-from app.questionnaire.routing.operations import (
-    evaluate_all_in,
-    evaluate_and,
-    evaluate_any_in,
-    evaluate_count,
-    evaluate_equal,
-    evaluate_greater_than,
-    evaluate_greater_than_or_equal,
-    evaluate_in,
-    evaluate_less_than,
-    evaluate_less_than_or_equal,
-    evaluate_not,
-    evaluate_not_equal,
-    evaluate_or,
-    resolve_date_from_string,
-)
+from app.questionnaire.routing.operations import Operations
 
 
 class Operator:
@@ -38,7 +23,7 @@ class Operator:
 
     def __init__(self, name: str) -> None:
         self.name = name
-        self._operation = OPERATIONS[self.name]
+        self._operation = OPERATIONS_MAPPINGS[self.name]
         self._ensure_operands_not_none = self.name in {
             Operator.GREATER_THAN,
             Operator.GREATER_THAN_OR_EQUAL,
@@ -68,19 +53,21 @@ class Operator:
         return any(operand is None for operand in operands)
 
 
-OPERATIONS: dict[str, Callable] = {
-    Operator.NOT: evaluate_not,
-    Operator.AND: evaluate_and,
-    Operator.OR: evaluate_or,
-    Operator.EQUAL: evaluate_equal,
-    Operator.NOT_EQUAL: evaluate_not_equal,
-    Operator.GREATER_THAN: evaluate_greater_than,
-    Operator.LESS_THAN: evaluate_less_than,
-    Operator.GREATER_THAN_OR_EQUAL: evaluate_greater_than_or_equal,
-    Operator.LESS_THAN_OR_EQUAL: evaluate_less_than_or_equal,
-    Operator.IN: evaluate_in,
-    Operator.ALL_IN: evaluate_all_in,
-    Operator.ANY_IN: evaluate_any_in,
-    Operator.COUNT: evaluate_count,
-    Operator.DATE: resolve_date_from_string,
+operations = Operations()
+
+OPERATIONS_MAPPINGS: dict[str, Callable] = {
+    Operator.NOT: operations.evaluate_not,
+    Operator.AND: operations.evaluate_and,
+    Operator.OR: operations.evaluate_or,
+    Operator.EQUAL: operations.evaluate_equal,
+    Operator.NOT_EQUAL: operations.evaluate_not_equal,
+    Operator.GREATER_THAN: operations.evaluate_greater_than,
+    Operator.LESS_THAN: operations.evaluate_less_than,
+    Operator.GREATER_THAN_OR_EQUAL: operations.evaluate_greater_than_or_equal,
+    Operator.LESS_THAN_OR_EQUAL: operations.evaluate_less_than_or_equal,
+    Operator.IN: operations.evaluate_in,
+    Operator.ALL_IN: operations.evaluate_all_in,
+    Operator.ANY_IN: operations.evaluate_any_in,
+    Operator.COUNT: operations.evaluate_count,
+    Operator.DATE: operations.resolve_date_from_string,
 }

--- a/app/questionnaire/routing/when_rule_evaluator.py
+++ b/app/questionnaire/routing/when_rule_evaluator.py
@@ -5,7 +5,7 @@ from typing import Generator, Mapping, Optional, Sequence, Union
 from app.data_models import AnswerStore, ListStore
 from app.questionnaire import Location, QuestionnaireSchema
 from app.questionnaire.relationship_location import RelationshipLocation
-from app.questionnaire.routing.operator import OPERATIONS, Operator
+from app.questionnaire.routing.operator import OPERATIONS_MAPPINGS, Operator
 from app.questionnaire.value_source_resolver import (
     ValueSourceResolver,
     ValueSourceTypes,
@@ -56,7 +56,7 @@ class WhenRuleEvaluator:
             if isinstance(operand, dict) and "source" in operand:
                 yield self.value_source_resolver.resolve(operand)
             elif isinstance(operand, dict) and any(
-                operator in operand for operator in OPERATIONS
+                operator in operand for operator in OPERATIONS_MAPPINGS
             ):
                 yield self._evaluate(operand)
             else:

--- a/app/questionnaire/routing/when_rule_evaluator.py
+++ b/app/questionnaire/routing/when_rule_evaluator.py
@@ -60,7 +60,7 @@ class WhenRuleEvaluator:
         operator = Operator(next_rule, self.operation_mapping[next_rule])
         operands = rule[next_rule]
 
-        if not isinstance(rule[next_rule], Sequence):
+        if not isinstance(operands, Sequence):
             raise TypeError(
                 f"The rule is invalid, operands should be of type Sequence and not {type(operands)}"
             )

--- a/app/questionnaire/routing/when_rule_evaluator.py
+++ b/app/questionnaire/routing/when_rule_evaluator.py
@@ -1,15 +1,35 @@
 from dataclasses import dataclass
 from datetime import date
-from typing import Generator, Mapping, Optional, Sequence, Union
+from typing import Callable, Generator, Mapping, Optional, Sequence, Union
 
 from app.data_models import AnswerStore, ListStore
 from app.questionnaire import Location, QuestionnaireSchema
 from app.questionnaire.relationship_location import RelationshipLocation
-from app.questionnaire.routing.operator import OPERATIONS_MAPPINGS, Operator
+from app.questionnaire.routing.operations import Operations
+from app.questionnaire.routing.operator import Operator
 from app.questionnaire.value_source_resolver import (
     ValueSourceResolver,
     ValueSourceTypes,
 )
+
+operations = Operations()
+
+OPERATIONS_MAPPINGS: dict[str, Callable] = {
+    Operator.NOT: operations.evaluate_not,
+    Operator.AND: operations.evaluate_and,
+    Operator.OR: operations.evaluate_or,
+    Operator.EQUAL: operations.evaluate_equal,
+    Operator.NOT_EQUAL: operations.evaluate_not_equal,
+    Operator.GREATER_THAN: operations.evaluate_greater_than,
+    Operator.LESS_THAN: operations.evaluate_less_than,
+    Operator.GREATER_THAN_OR_EQUAL: operations.evaluate_greater_than_or_equal,
+    Operator.LESS_THAN_OR_EQUAL: operations.evaluate_less_than_or_equal,
+    Operator.IN: operations.evaluate_in,
+    Operator.ALL_IN: operations.evaluate_all_in,
+    Operator.ANY_IN: operations.evaluate_any_in,
+    Operator.COUNT: operations.evaluate_count,
+    Operator.DATE: operations.resolve_date_from_string,
+}
 
 
 @dataclass
@@ -38,10 +58,11 @@ class WhenRuleEvaluator:
         )
 
     def _evaluate(self, rule: dict[str, Sequence]) -> Union[bool, Optional[date]]:
-        operator = Operator(next(iter(rule)))
-        operands = rule[operator.name]
+        next_rule = next(iter(rule))
+        operator = Operator(next_rule, OPERATIONS_MAPPINGS[next_rule])
+        operands = rule[next_rule]
 
-        if not isinstance(operands, Sequence):
+        if not isinstance(rule[next_rule], Sequence):
             raise TypeError(
                 f"The rule is invalid, operands should be of type Sequence and not {type(operands)}"
             )

--- a/tests/app/questionnaire/routing/test_operators.py
+++ b/tests/app/questionnaire/routing/test_operators.py
@@ -40,7 +40,7 @@ equals_operations = [
     equals_operations,
 )
 def test_operation_equal(operands, expected_result):
-    operation = get_operations(Operator.EQUAL)
+    operation = get_operation(Operator.EQUAL)
     operator = Operator(Operator.EQUAL, operation)
     assert operator.evaluate(operands) is expected_result
 
@@ -50,7 +50,7 @@ def test_operation_equal(operands, expected_result):
     equals_operations,
 )
 def test_operation_not_equal(operands, expected_result):
-    operation = get_operations(Operator.NOT_EQUAL)
+    operation = get_operation(Operator.NOT_EQUAL)
     operator = Operator(Operator.NOT_EQUAL, operation)
     assert operator.evaluate(operands) is not expected_result
 
@@ -79,7 +79,7 @@ greater_than_and_less_than_operations_equals = [
     greater_than_and_less_than_operations,
 )
 def test_operation_greater_than(operands, expected_result):
-    operation = get_operations(Operator.GREATER_THAN)
+    operation = get_operation(Operator.GREATER_THAN)
     operator = Operator(Operator.GREATER_THAN, operation)
     assert operator.evaluate(operands) is expected_result
 
@@ -89,7 +89,7 @@ def test_operation_greater_than(operands, expected_result):
     greater_than_and_less_than_operations_equals,
 )
 def test_operation_greater_than_same_number(operands, expected_result):
-    operation = get_operations(Operator.GREATER_THAN)
+    operation = get_operation(Operator.GREATER_THAN)
     operator = Operator(Operator.GREATER_THAN, operation)
     assert operator.evaluate(operands) is expected_result
 
@@ -99,7 +99,7 @@ def test_operation_greater_than_same_number(operands, expected_result):
     greater_than_and_less_than_operations,
 )
 def test_operation_less_than(operands, expected_result):
-    operation = get_operations(Operator.LESS_THAN)
+    operation = get_operation(Operator.LESS_THAN)
     operator = Operator(Operator.LESS_THAN, operation)
     assert operator.evaluate(operands) is not expected_result
 
@@ -109,7 +109,7 @@ def test_operation_less_than(operands, expected_result):
     greater_than_and_less_than_operations_equals,
 )
 def test_operation_less_than_same_number(operands, expected_result):
-    operation = get_operations(Operator.LESS_THAN)
+    operation = get_operation(Operator.LESS_THAN)
     operator = Operator(Operator.LESS_THAN, operation)
     assert operator.evaluate(operands) is expected_result
 
@@ -134,7 +134,7 @@ def test_operation_less_than_same_number(operands, expected_result):
     ],
 )
 def test_operation_less_than_or_equal(operands, expected_result):
-    operation = get_operations(Operator.LESS_THAN_OR_EQUAL)
+    operation = get_operation(Operator.LESS_THAN_OR_EQUAL)
     operator = Operator(Operator.LESS_THAN_OR_EQUAL, operation)
     assert operator.evaluate(operands) is expected_result
 
@@ -159,7 +159,7 @@ def test_operation_less_than_or_equal(operands, expected_result):
     ],
 )
 def test_operation_greater_than_or_equal(operands, expected_result):
-    operation = get_operations(Operator.GREATER_THAN_OR_EQUAL)
+    operation = get_operation(Operator.GREATER_THAN_OR_EQUAL)
     operator = Operator(
         Operator.GREATER_THAN_OR_EQUAL,
         operation,
@@ -169,7 +169,7 @@ def test_operation_greater_than_or_equal(operands, expected_result):
 
 @pytest.mark.parametrize("operand, expected_result", [[False, True], [True, False]])
 def test_operation_not(operand, expected_result):
-    operation = get_operations(Operator.NOT)
+    operation = get_operation(Operator.NOT)
     operator = Operator(Operator.NOT, operation)
     assert operator.evaluate([operand]) is expected_result
 
@@ -186,7 +186,7 @@ def test_operation_not(operand, expected_result):
     ],
 )
 def test_operation_and(operands, expected_result):
-    operation = get_operations(Operator.AND)
+    operation = get_operation(Operator.AND)
     operator = Operator(Operator.AND, operation)
     assert operator.evaluate(operands) is expected_result
 
@@ -204,7 +204,7 @@ def test_operation_and(operands, expected_result):
     ],
 )
 def test_operation_or(operands, expected_result):
-    operation = get_operations(Operator.OR)
+    operation = get_operation(Operator.OR)
     operator = Operator(Operator.OR, operation)
     assert operator.evaluate(operands) is expected_result
 
@@ -226,7 +226,7 @@ def test_operation_or(operands, expected_result):
     ],
 )
 def test_operation_in(operands, expected_result):
-    operation = get_operations(Operator.IN)
+    operation = get_operation(Operator.IN)
     operator = Operator(Operator.IN, operation)
     assert operator.evaluate(operands) is expected_result
 
@@ -249,7 +249,7 @@ def test_operation_in(operands, expected_result):
     ],
 )
 def test_operation_all_in(operands, expected_result):
-    operation = get_operations(Operator.ALL_IN)
+    operation = get_operation(Operator.ALL_IN)
     operator = Operator(Operator.ALL_IN, operation)
     assert operator.evaluate(operands) is expected_result
 
@@ -271,7 +271,7 @@ def test_operation_all_in(operands, expected_result):
     ],
 )
 def test_operation_any_in(operands, expected_result):
-    operation = get_operations(Operator.ANY_IN)
+    operation = get_operation(Operator.ANY_IN)
     operator = Operator(Operator.ANY_IN, operation)
     assert operator.evaluate(operands) is expected_result
 
@@ -296,7 +296,7 @@ def test_operation_any_in(operands, expected_result):
 )
 def test_operation_date(date_string: str, offset):
     operands = (date_string, offset)
-    operation = get_operations(Operator.DATE)
+    operation = get_operation(Operator.DATE)
     operator = Operator(Operator.DATE, operation)
 
     offset = offset or {}
@@ -332,7 +332,7 @@ def test_operation_date(date_string: str, offset):
     ],
 )
 def test_nonetype_operands_for_comparison_operators(operator_name, operands):
-    operation = get_operations(operator_name)
+    operation = get_operation(operator_name)
     operator = Operator(operator_name, operation)
     assert operator.evaluate(operands) is False
 
@@ -354,7 +354,7 @@ def test_nonetype_operands_for_comparison_operators(operator_name, operands):
     ],
 )
 def test_nonetype_operands_for_array_operators(operator_name, operands):
-    operation = get_operations(operator_name)
+    operation = get_operation(operator_name)
     operator = Operator(operator_name, operation)
     assert operator.evaluate(operands) is False
 
@@ -369,12 +369,12 @@ def test_nonetype_operands_for_array_operators(operator_name, operands):
     ],
 )
 def test_operation_count(operands, expected_result):
-    operation = get_operations(Operator.COUNT)
+    operation = get_operation(Operator.COUNT)
     operator = Operator(Operator.COUNT, operation)
     assert operator.evaluate(operands) is expected_result
 
 
-def get_operations(operator):
+def get_operation(operator):
     operations = Operations()
     operation_mapping = {
         Operator.NOT: operations.evaluate_not,

--- a/tests/app/questionnaire/routing/test_operators.py
+++ b/tests/app/questionnaire/routing/test_operators.py
@@ -40,7 +40,8 @@ equals_operations = [
     equals_operations,
 )
 def test_operation_equal(operands, expected_result):
-    operator = Operator(Operator.EQUAL, get_operations().evaluate_equal)
+    operation = get_operations(Operator.EQUAL)
+    operator = Operator(Operator.EQUAL, operation)
     assert operator.evaluate(operands) is expected_result
 
 
@@ -49,7 +50,8 @@ def test_operation_equal(operands, expected_result):
     equals_operations,
 )
 def test_operation_not_equal(operands, expected_result):
-    operator = Operator(Operator.NOT_EQUAL, get_operations().evaluate_not_equal)
+    operation = get_operations(Operator.NOT_EQUAL)
+    operator = Operator(Operator.NOT_EQUAL, operation)
     assert operator.evaluate(operands) is not expected_result
 
 
@@ -77,7 +79,8 @@ greater_than_and_less_than_operations_equals = [
     greater_than_and_less_than_operations,
 )
 def test_operation_greater_than(operands, expected_result):
-    operator = Operator(Operator.GREATER_THAN, get_operations().evaluate_greater_than)
+    operation = get_operations(Operator.GREATER_THAN)
+    operator = Operator(Operator.GREATER_THAN, operation)
     assert operator.evaluate(operands) is expected_result
 
 
@@ -86,7 +89,8 @@ def test_operation_greater_than(operands, expected_result):
     greater_than_and_less_than_operations_equals,
 )
 def test_operation_greater_than_same_number(operands, expected_result):
-    operator = Operator(Operator.GREATER_THAN, get_operations().evaluate_greater_than)
+    operation = get_operations(Operator.GREATER_THAN)
+    operator = Operator(Operator.GREATER_THAN, operation)
     assert operator.evaluate(operands) is expected_result
 
 
@@ -95,7 +99,8 @@ def test_operation_greater_than_same_number(operands, expected_result):
     greater_than_and_less_than_operations,
 )
 def test_operation_less_than(operands, expected_result):
-    operator = Operator(Operator.LESS_THAN, get_operations().evaluate_less_than)
+    operation = get_operations(Operator.LESS_THAN)
+    operator = Operator(Operator.LESS_THAN, operation)
     assert operator.evaluate(operands) is not expected_result
 
 
@@ -104,7 +109,8 @@ def test_operation_less_than(operands, expected_result):
     greater_than_and_less_than_operations_equals,
 )
 def test_operation_less_than_same_number(operands, expected_result):
-    operator = Operator(Operator.LESS_THAN, get_operations().evaluate_less_than)
+    operation = get_operations(Operator.LESS_THAN)
+    operator = Operator(Operator.LESS_THAN, operation)
     assert operator.evaluate(operands) is expected_result
 
 
@@ -128,9 +134,8 @@ def test_operation_less_than_same_number(operands, expected_result):
     ],
 )
 def test_operation_less_than_or_equal(operands, expected_result):
-    operator = Operator(
-        Operator.LESS_THAN_OR_EQUAL, get_operations().evaluate_less_than_or_equal
-    )
+    operation = get_operations(Operator.LESS_THAN_OR_EQUAL)
+    operator = Operator(Operator.LESS_THAN_OR_EQUAL, operation)
     assert operator.evaluate(operands) is expected_result
 
 
@@ -154,16 +159,18 @@ def test_operation_less_than_or_equal(operands, expected_result):
     ],
 )
 def test_operation_greater_than_or_equal(operands, expected_result):
+    operation = get_operations(Operator.GREATER_THAN_OR_EQUAL)
     operator = Operator(
         Operator.GREATER_THAN_OR_EQUAL,
-        get_operations().evaluate_greater_than_or_equal,
+        operation,
     )
     assert operator.evaluate(operands) is expected_result
 
 
 @pytest.mark.parametrize("operand, expected_result", [[False, True], [True, False]])
 def test_operation_not(operand, expected_result):
-    operator = Operator(Operator.NOT, get_operations().evaluate_not)
+    operation = get_operations(Operator.NOT)
+    operator = Operator(Operator.NOT, operation)
     assert operator.evaluate([operand]) is expected_result
 
 
@@ -179,7 +186,8 @@ def test_operation_not(operand, expected_result):
     ],
 )
 def test_operation_and(operands, expected_result):
-    operator = Operator(Operator.AND, get_operations().evaluate_and)
+    operation = get_operations(Operator.AND)
+    operator = Operator(Operator.AND, operation)
     assert operator.evaluate(operands) is expected_result
 
 
@@ -196,7 +204,8 @@ def test_operation_and(operands, expected_result):
     ],
 )
 def test_operation_or(operands, expected_result):
-    operator = Operator(Operator.OR, get_operations().evaluate_or)
+    operation = get_operations(Operator.OR)
+    operator = Operator(Operator.OR, operation)
     assert operator.evaluate(operands) is expected_result
 
 
@@ -217,7 +226,8 @@ def test_operation_or(operands, expected_result):
     ],
 )
 def test_operation_in(operands, expected_result):
-    operator = Operator(Operator.IN, get_operations().evaluate_in)
+    operation = get_operations(Operator.IN)
+    operator = Operator(Operator.IN, operation)
     assert operator.evaluate(operands) is expected_result
 
 
@@ -239,7 +249,8 @@ def test_operation_in(operands, expected_result):
     ],
 )
 def test_operation_all_in(operands, expected_result):
-    operator = Operator(Operator.ALL_IN, get_operations().evaluate_all_in)
+    operation = get_operations(Operator.ALL_IN)
+    operator = Operator(Operator.ALL_IN, operation)
     assert operator.evaluate(operands) is expected_result
 
 
@@ -260,7 +271,8 @@ def test_operation_all_in(operands, expected_result):
     ],
 )
 def test_operation_any_in(operands, expected_result):
-    operator = Operator(Operator.ANY_IN, get_operations().evaluate_any_in)
+    operation = get_operations(Operator.ANY_IN)
+    operator = Operator(Operator.ANY_IN, operation)
     assert operator.evaluate(operands) is expected_result
 
 
@@ -284,7 +296,8 @@ def test_operation_any_in(operands, expected_result):
 )
 def test_operation_date(date_string: str, offset):
     operands = (date_string, offset)
-    operator = Operator(Operator.DATE, get_operations().resolve_date_from_string)
+    operation = get_operations(Operator.DATE)
+    operator = Operator(Operator.DATE, operation)
 
     offset = offset or {}
     expected_result = (
@@ -310,15 +323,16 @@ def test_operation_date(date_string: str, offset):
     ],
 )
 @pytest.mark.parametrize(
-    "operator_name, operation",
+    "operator_name",
     [
-        (Operator.GREATER_THAN, Operations().evaluate_greater_than),
-        (Operator.GREATER_THAN_OR_EQUAL, Operations().evaluate_greater_than_or_equal),
-        (Operator.LESS_THAN, Operations().evaluate_less_than),
-        (Operator.LESS_THAN_OR_EQUAL, Operations().evaluate_less_than_or_equal),
+        Operator.GREATER_THAN,
+        Operator.GREATER_THAN_OR_EQUAL,
+        Operator.LESS_THAN,
+        Operator.LESS_THAN_OR_EQUAL,
     ],
 )
-def test_nonetype_operands_for_comparison_operators(operator_name, operands, operation):
+def test_nonetype_operands_for_comparison_operators(operator_name, operands):
+    operation = get_operations(operator_name)
     operator = Operator(operator_name, operation)
     assert operator.evaluate(operands) is False
 
@@ -332,14 +346,15 @@ def test_nonetype_operands_for_comparison_operators(operator_name, operands, ope
     ],
 )
 @pytest.mark.parametrize(
-    "operator_name, operation",
+    "operator_name",
     [
-        (Operator.ALL_IN, Operations().evaluate_all_in),
-        (Operator.ANY_IN, Operations().evaluate_any_in),
-        (Operator.IN, Operations().evaluate_in),
+        Operator.ALL_IN,
+        Operator.ANY_IN,
+        Operator.IN,
     ],
 )
-def test_nonetype_operands_for_array_operators(operator_name, operands, operation):
+def test_nonetype_operands_for_array_operators(operator_name, operands):
+    operation = get_operations(operator_name)
     operator = Operator(operator_name, operation)
     assert operator.evaluate(operands) is False
 
@@ -354,9 +369,27 @@ def test_nonetype_operands_for_array_operators(operator_name, operands, operatio
     ],
 )
 def test_operation_count(operands, expected_result):
-    operator = Operator(Operator.COUNT, get_operations().evaluate_count)
+    operation = get_operations(Operator.COUNT)
+    operator = Operator(Operator.COUNT, operation)
     assert operator.evaluate(operands) is expected_result
 
 
-def get_operations():
-    return Operations()
+def get_operations(operator):
+    operations = Operations()
+    operation_mapping = {
+        Operator.NOT: operations.evaluate_not,
+        Operator.AND: operations.evaluate_and,
+        Operator.OR: operations.evaluate_or,
+        Operator.EQUAL: operations.evaluate_equal,
+        Operator.NOT_EQUAL: operations.evaluate_not_equal,
+        Operator.GREATER_THAN: operations.evaluate_greater_than,
+        Operator.LESS_THAN: operations.evaluate_less_than,
+        Operator.GREATER_THAN_OR_EQUAL: operations.evaluate_greater_than_or_equal,
+        Operator.LESS_THAN_OR_EQUAL: operations.evaluate_less_than_or_equal,
+        Operator.IN: operations.evaluate_in,
+        Operator.ALL_IN: operations.evaluate_all_in,
+        Operator.ANY_IN: operations.evaluate_any_in,
+        Operator.COUNT: operations.evaluate_count,
+        Operator.DATE: operations.resolve_date_from_string,
+    }
+    return operation_mapping[operator]

--- a/tests/app/questionnaire/routing/test_operators.py
+++ b/tests/app/questionnaire/routing/test_operators.py
@@ -3,8 +3,8 @@ from datetime import datetime, timezone
 import pytest
 from dateutil.relativedelta import relativedelta
 
+from app.questionnaire.routing.operations import Operations
 from app.questionnaire.routing.operator import Operator
-from app.questionnaire.routing.when_rule_evaluator import OPERATIONS_MAPPINGS
 from app.questionnaire.rules import convert_to_datetime
 
 current_date = datetime.now(timezone.utc)
@@ -40,7 +40,7 @@ equals_operations = [
     equals_operations,
 )
 def test_operation_equal(operands, expected_result):
-    operator = Operator(Operator.EQUAL, OPERATIONS_MAPPINGS[Operator.EQUAL])
+    operator = Operator(Operator.EQUAL, get_operations().evaluate_equal)
     assert operator.evaluate(operands) is expected_result
 
 
@@ -49,7 +49,7 @@ def test_operation_equal(operands, expected_result):
     equals_operations,
 )
 def test_operation_not_equal(operands, expected_result):
-    operator = Operator(Operator.NOT_EQUAL, OPERATIONS_MAPPINGS[Operator.NOT_EQUAL])
+    operator = Operator(Operator.NOT_EQUAL, get_operations().evaluate_not_equal)
     assert operator.evaluate(operands) is not expected_result
 
 
@@ -77,9 +77,7 @@ greater_than_and_less_than_operations_equals = [
     greater_than_and_less_than_operations,
 )
 def test_operation_greater_than(operands, expected_result):
-    operator = Operator(
-        Operator.GREATER_THAN, OPERATIONS_MAPPINGS[Operator.GREATER_THAN]
-    )
+    operator = Operator(Operator.GREATER_THAN, get_operations().evaluate_greater_than)
     assert operator.evaluate(operands) is expected_result
 
 
@@ -88,9 +86,7 @@ def test_operation_greater_than(operands, expected_result):
     greater_than_and_less_than_operations_equals,
 )
 def test_operation_greater_than_same_number(operands, expected_result):
-    operator = Operator(
-        Operator.GREATER_THAN, OPERATIONS_MAPPINGS[Operator.GREATER_THAN]
-    )
+    operator = Operator(Operator.GREATER_THAN, get_operations().evaluate_greater_than)
     assert operator.evaluate(operands) is expected_result
 
 
@@ -99,7 +95,7 @@ def test_operation_greater_than_same_number(operands, expected_result):
     greater_than_and_less_than_operations,
 )
 def test_operation_less_than(operands, expected_result):
-    operator = Operator(Operator.LESS_THAN, OPERATIONS_MAPPINGS[Operator.LESS_THAN])
+    operator = Operator(Operator.LESS_THAN, get_operations().evaluate_less_than)
     assert operator.evaluate(operands) is not expected_result
 
 
@@ -108,7 +104,7 @@ def test_operation_less_than(operands, expected_result):
     greater_than_and_less_than_operations_equals,
 )
 def test_operation_less_than_same_number(operands, expected_result):
-    operator = Operator(Operator.LESS_THAN, OPERATIONS_MAPPINGS[Operator.LESS_THAN])
+    operator = Operator(Operator.LESS_THAN, get_operations().evaluate_less_than)
     assert operator.evaluate(operands) is expected_result
 
 
@@ -133,7 +129,7 @@ def test_operation_less_than_same_number(operands, expected_result):
 )
 def test_operation_less_than_or_equal(operands, expected_result):
     operator = Operator(
-        Operator.LESS_THAN_OR_EQUAL, OPERATIONS_MAPPINGS[Operator.LESS_THAN_OR_EQUAL]
+        Operator.LESS_THAN_OR_EQUAL, get_operations().evaluate_less_than_or_equal
     )
     assert operator.evaluate(operands) is expected_result
 
@@ -160,14 +156,14 @@ def test_operation_less_than_or_equal(operands, expected_result):
 def test_operation_greater_than_or_equal(operands, expected_result):
     operator = Operator(
         Operator.GREATER_THAN_OR_EQUAL,
-        OPERATIONS_MAPPINGS[Operator.GREATER_THAN_OR_EQUAL],
+        get_operations().evaluate_greater_than_or_equal,
     )
     assert operator.evaluate(operands) is expected_result
 
 
 @pytest.mark.parametrize("operand, expected_result", [[False, True], [True, False]])
 def test_operation_not(operand, expected_result):
-    operator = Operator(Operator.NOT, OPERATIONS_MAPPINGS[Operator.NOT])
+    operator = Operator(Operator.NOT, get_operations().evaluate_not)
     assert operator.evaluate([operand]) is expected_result
 
 
@@ -183,7 +179,7 @@ def test_operation_not(operand, expected_result):
     ],
 )
 def test_operation_and(operands, expected_result):
-    operator = Operator(Operator.AND, OPERATIONS_MAPPINGS[Operator.AND])
+    operator = Operator(Operator.AND, get_operations().evaluate_and)
     assert operator.evaluate(operands) is expected_result
 
 
@@ -200,7 +196,7 @@ def test_operation_and(operands, expected_result):
     ],
 )
 def test_operation_or(operands, expected_result):
-    operator = Operator(Operator.OR, OPERATIONS_MAPPINGS[Operator.OR])
+    operator = Operator(Operator.OR, get_operations().evaluate_or)
     assert operator.evaluate(operands) is expected_result
 
 
@@ -221,7 +217,7 @@ def test_operation_or(operands, expected_result):
     ],
 )
 def test_operation_in(operands, expected_result):
-    operator = Operator(Operator.IN, OPERATIONS_MAPPINGS[Operator.IN])
+    operator = Operator(Operator.IN, get_operations().evaluate_in)
     assert operator.evaluate(operands) is expected_result
 
 
@@ -243,7 +239,7 @@ def test_operation_in(operands, expected_result):
     ],
 )
 def test_operation_all_in(operands, expected_result):
-    operator = Operator(Operator.ALL_IN, OPERATIONS_MAPPINGS[Operator.ALL_IN])
+    operator = Operator(Operator.ALL_IN, get_operations().evaluate_all_in)
     assert operator.evaluate(operands) is expected_result
 
 
@@ -264,7 +260,7 @@ def test_operation_all_in(operands, expected_result):
     ],
 )
 def test_operation_any_in(operands, expected_result):
-    operator = Operator(Operator.ANY_IN, OPERATIONS_MAPPINGS[Operator.ANY_IN])
+    operator = Operator(Operator.ANY_IN, get_operations().evaluate_any_in)
     assert operator.evaluate(operands) is expected_result
 
 
@@ -288,7 +284,7 @@ def test_operation_any_in(operands, expected_result):
 )
 def test_operation_date(date_string: str, offset):
     operands = (date_string, offset)
-    operator = Operator(Operator.DATE, OPERATIONS_MAPPINGS[Operator.DATE])
+    operator = Operator(Operator.DATE, get_operations().resolve_date_from_string)
 
     offset = offset or {}
     expected_result = (
@@ -314,16 +310,16 @@ def test_operation_date(date_string: str, offset):
     ],
 )
 @pytest.mark.parametrize(
-    "operator_name",
+    "operator_name, operation",
     [
-        Operator.GREATER_THAN,
-        Operator.GREATER_THAN_OR_EQUAL,
-        Operator.LESS_THAN,
-        Operator.LESS_THAN_OR_EQUAL,
+        (Operator.GREATER_THAN, Operations().evaluate_greater_than),
+        (Operator.GREATER_THAN_OR_EQUAL, Operations().evaluate_greater_than_or_equal),
+        (Operator.LESS_THAN, Operations().evaluate_less_than),
+        (Operator.LESS_THAN_OR_EQUAL, Operations().evaluate_less_than_or_equal),
     ],
 )
-def test_nonetype_operands_for_comparison_operators(operator_name, operands):
-    operator = Operator(operator_name, OPERATIONS_MAPPINGS[operator_name])
+def test_nonetype_operands_for_comparison_operators(operator_name, operands, operation):
+    operator = Operator(operator_name, operation)
     assert operator.evaluate(operands) is False
 
 
@@ -336,10 +332,15 @@ def test_nonetype_operands_for_comparison_operators(operator_name, operands):
     ],
 )
 @pytest.mark.parametrize(
-    "operator_name", [Operator.ALL_IN, Operator.ANY_IN, Operator.IN]
+    "operator_name, operation",
+    [
+        (Operator.ALL_IN, Operations().evaluate_all_in),
+        (Operator.ANY_IN, Operations().evaluate_any_in),
+        (Operator.IN, Operations().evaluate_in),
+    ],
 )
-def test_nonetype_operands_for_array_operators(operator_name, operands):
-    operator = Operator(operator_name, OPERATIONS_MAPPINGS[operator_name])
+def test_nonetype_operands_for_array_operators(operator_name, operands, operation):
+    operator = Operator(operator_name, operation)
     assert operator.evaluate(operands) is False
 
 
@@ -353,5 +354,9 @@ def test_nonetype_operands_for_array_operators(operator_name, operands):
     ],
 )
 def test_operation_count(operands, expected_result):
-    operator = Operator(Operator.COUNT, OPERATIONS_MAPPINGS[Operator.COUNT])
+    operator = Operator(Operator.COUNT, get_operations().evaluate_count)
     assert operator.evaluate(operands) is expected_result
+
+
+def get_operations():
+    return Operations()

--- a/tests/app/questionnaire/routing/test_operators.py
+++ b/tests/app/questionnaire/routing/test_operators.py
@@ -4,6 +4,7 @@ import pytest
 from dateutil.relativedelta import relativedelta
 
 from app.questionnaire.routing.operator import Operator
+from app.questionnaire.routing.when_rule_evaluator import OPERATIONS_MAPPINGS
 from app.questionnaire.rules import convert_to_datetime
 
 current_date = datetime.now(timezone.utc)
@@ -39,7 +40,7 @@ equals_operations = [
     equals_operations,
 )
 def test_operation_equal(operands, expected_result):
-    operator = Operator(Operator.EQUAL)
+    operator = Operator(Operator.EQUAL, OPERATIONS_MAPPINGS[Operator.EQUAL])
     assert operator.evaluate(operands) is expected_result
 
 
@@ -48,7 +49,7 @@ def test_operation_equal(operands, expected_result):
     equals_operations,
 )
 def test_operation_not_equal(operands, expected_result):
-    operator = Operator(Operator.NOT_EQUAL)
+    operator = Operator(Operator.NOT_EQUAL, OPERATIONS_MAPPINGS[Operator.NOT_EQUAL])
     assert operator.evaluate(operands) is not expected_result
 
 
@@ -76,7 +77,9 @@ greater_than_and_less_than_operations_equals = [
     greater_than_and_less_than_operations,
 )
 def test_operation_greater_than(operands, expected_result):
-    operator = Operator(Operator.GREATER_THAN)
+    operator = Operator(
+        Operator.GREATER_THAN, OPERATIONS_MAPPINGS[Operator.GREATER_THAN]
+    )
     assert operator.evaluate(operands) is expected_result
 
 
@@ -85,7 +88,9 @@ def test_operation_greater_than(operands, expected_result):
     greater_than_and_less_than_operations_equals,
 )
 def test_operation_greater_than_same_number(operands, expected_result):
-    operator = Operator(Operator.GREATER_THAN)
+    operator = Operator(
+        Operator.GREATER_THAN, OPERATIONS_MAPPINGS[Operator.GREATER_THAN]
+    )
     assert operator.evaluate(operands) is expected_result
 
 
@@ -94,7 +99,7 @@ def test_operation_greater_than_same_number(operands, expected_result):
     greater_than_and_less_than_operations,
 )
 def test_operation_less_than(operands, expected_result):
-    operator = Operator(Operator.LESS_THAN)
+    operator = Operator(Operator.LESS_THAN, OPERATIONS_MAPPINGS[Operator.LESS_THAN])
     assert operator.evaluate(operands) is not expected_result
 
 
@@ -103,7 +108,7 @@ def test_operation_less_than(operands, expected_result):
     greater_than_and_less_than_operations_equals,
 )
 def test_operation_less_than_same_number(operands, expected_result):
-    operator = Operator(Operator.LESS_THAN)
+    operator = Operator(Operator.LESS_THAN, OPERATIONS_MAPPINGS[Operator.LESS_THAN])
     assert operator.evaluate(operands) is expected_result
 
 
@@ -127,7 +132,9 @@ def test_operation_less_than_same_number(operands, expected_result):
     ],
 )
 def test_operation_less_than_or_equal(operands, expected_result):
-    operator = Operator(Operator.LESS_THAN_OR_EQUAL)
+    operator = Operator(
+        Operator.LESS_THAN_OR_EQUAL, OPERATIONS_MAPPINGS[Operator.LESS_THAN_OR_EQUAL]
+    )
     assert operator.evaluate(operands) is expected_result
 
 
@@ -151,13 +158,16 @@ def test_operation_less_than_or_equal(operands, expected_result):
     ],
 )
 def test_operation_greater_than_or_equal(operands, expected_result):
-    operator = Operator(Operator.GREATER_THAN_OR_EQUAL)
+    operator = Operator(
+        Operator.GREATER_THAN_OR_EQUAL,
+        OPERATIONS_MAPPINGS[Operator.GREATER_THAN_OR_EQUAL],
+    )
     assert operator.evaluate(operands) is expected_result
 
 
 @pytest.mark.parametrize("operand, expected_result", [[False, True], [True, False]])
 def test_operation_not(operand, expected_result):
-    operator = Operator(Operator.NOT)
+    operator = Operator(Operator.NOT, OPERATIONS_MAPPINGS[Operator.NOT])
     assert operator.evaluate([operand]) is expected_result
 
 
@@ -173,7 +183,7 @@ def test_operation_not(operand, expected_result):
     ],
 )
 def test_operation_and(operands, expected_result):
-    operator = Operator(Operator.AND)
+    operator = Operator(Operator.AND, OPERATIONS_MAPPINGS[Operator.AND])
     assert operator.evaluate(operands) is expected_result
 
 
@@ -190,7 +200,7 @@ def test_operation_and(operands, expected_result):
     ],
 )
 def test_operation_or(operands, expected_result):
-    operator = Operator(Operator.OR)
+    operator = Operator(Operator.OR, OPERATIONS_MAPPINGS[Operator.OR])
     assert operator.evaluate(operands) is expected_result
 
 
@@ -211,7 +221,7 @@ def test_operation_or(operands, expected_result):
     ],
 )
 def test_operation_in(operands, expected_result):
-    operator = Operator(Operator.IN)
+    operator = Operator(Operator.IN, OPERATIONS_MAPPINGS[Operator.IN])
     assert operator.evaluate(operands) is expected_result
 
 
@@ -233,7 +243,7 @@ def test_operation_in(operands, expected_result):
     ],
 )
 def test_operation_all_in(operands, expected_result):
-    operator = Operator(Operator.ALL_IN)
+    operator = Operator(Operator.ALL_IN, OPERATIONS_MAPPINGS[Operator.ALL_IN])
     assert operator.evaluate(operands) is expected_result
 
 
@@ -254,7 +264,7 @@ def test_operation_all_in(operands, expected_result):
     ],
 )
 def test_operation_any_in(operands, expected_result):
-    operator = Operator(Operator.ANY_IN)
+    operator = Operator(Operator.ANY_IN, OPERATIONS_MAPPINGS[Operator.ANY_IN])
     assert operator.evaluate(operands) is expected_result
 
 
@@ -278,7 +288,7 @@ def test_operation_any_in(operands, expected_result):
 )
 def test_operation_date(date_string: str, offset):
     operands = (date_string, offset)
-    operator = Operator(Operator.DATE)
+    operator = Operator(Operator.DATE, OPERATIONS_MAPPINGS[Operator.DATE])
 
     offset = offset or {}
     expected_result = (
@@ -313,7 +323,7 @@ def test_operation_date(date_string: str, offset):
     ],
 )
 def test_nonetype_operands_for_comparison_operators(operator_name, operands):
-    operator = Operator(operator_name)
+    operator = Operator(operator_name, OPERATIONS_MAPPINGS[operator_name])
     assert operator.evaluate(operands) is False
 
 
@@ -329,7 +339,7 @@ def test_nonetype_operands_for_comparison_operators(operator_name, operands):
     "operator_name", [Operator.ALL_IN, Operator.ANY_IN, Operator.IN]
 )
 def test_nonetype_operands_for_array_operators(operator_name, operands):
-    operator = Operator(operator_name)
+    operator = Operator(operator_name, OPERATIONS_MAPPINGS[operator_name])
     assert operator.evaluate(operands) is False
 
 
@@ -343,5 +353,5 @@ def test_nonetype_operands_for_array_operators(operator_name, operands):
     ],
 )
 def test_operation_count(operands, expected_result):
-    operator = Operator(Operator.COUNT)
+    operator = Operator(Operator.COUNT, OPERATIONS_MAPPINGS[Operator.COUNT])
     assert operator.evaluate(operands) is expected_result


### PR DESCRIPTION
### What is the context of this PR?
Make operations into a class, and move instantiated higher. The instantiation has been moved higher to allow access to schema etc, but at present that is not implemented and on a different card

### How to review 
Make sure everything still works

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
