### PR TITLE
Update Session purge to Firestore Delete

### DIFF
--- a/ci/purge_expired_sessions.yaml
+++ b/ci/purge_expired_sessions.yaml
@@ -6,7 +6,7 @@ image_resource:
 params:
   SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
   PROJECT_ID:
-  DATAFLOW_TEMPLATE_VERSION: '2021-08-02-00_RC00'
+  DATAFLOW_TEMPLATE_VERSION: '2021-11-12-00_RC00'
   EXPIRATION_TIME_OFFSET_IN_SECONDS: 10800
 run:
   path: bash
@@ -23,11 +23,11 @@ run:
 
       DATAFLOW_JOB=$(gcloud dataflow jobs run purge_session \
       --region europe-west2 \
-      --gcs-location gs://dataflow-templates/"${DATAFLOW_TEMPLATE_VERSION}"/Datastore_to_Datastore_Delete \
+      --gcs-location gs://dataflow-templates/"${DATAFLOW_TEMPLATE_VERSION}"/Firestore_to_Firestore_Delete \
       --parameters \
-      datastoreReadGqlQuery="SELECT * FROM \`eq-session\` WHERE expires_at < $((`date --utc +%s` - EXPIRATION_TIME_OFFSET_IN_SECONDS))",\
-      datastoreReadProjectId="${PROJECT_ID}",\
-      datastoreDeleteProjectId="${PROJECT_ID}" \
+      firestoreReadGqlQuery="SELECT * FROM \`eq-session\` WHERE expires_at < $((`date --utc +%s` - EXPIRATION_TIME_OFFSET_IN_SECONDS))",\
+      firestoreReadProjectId="${PROJECT_ID}",\
+      firestoreDeleteProjectId="${PROJECT_ID}" \
       --format="value(id.scope())")
 
       DATAFLOW_JOB_STATE=$(gcloud dataflow jobs describe "${DATAFLOW_JOB}" --region europe-west2 --format="value(currentState)")


### PR DESCRIPTION
### What is the context of this PR?
Datastore Bulk Delete template is now deprecated and will be removed in Q1 2022, this PR updates it to Firestore Bulk Delete

### How to review 
Either using a pipeline or deploying the yaml, make sure this purges all expired session. Don't forget there is on offset, so if you create a project for just this test and then launch a survey, the session that you have generated will need adjusting as it won't be removed. I found the best way to test was changing the expired_at in GCP to a different value I knew would be removed

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
