### PR TITLE
Add schema validator compose file

### DIFF
--- a/docker-compose-schema-validator.yml
+++ b/docker-compose-schema-validator.yml
@@ -1,23 +1,24 @@
+---
 version: '3'
 
 services:
-    ajv:
-        image: onsdigital/eq-questionnaire-validator:${TAG}-ajv # update image with latest-ajv
-        networks:
-            - eq-schema
-        ports:
-            - "5002:5002"
+  ajv-validator:
+    image: onsdigital/eq-questionnaire-validator:${TAG}-ajv
+    networks:
+      - eq-schema
+    ports:
+      - 5002:5002
 
-    py-validator:
-        image: onsdigital/eq-questionnaire-validator:${TAG} # update image with latest
-        networks:
-            - eq-schema
-        environment:
-            AJV_HOST: "ajv"
-        ports:
-            - "5001:5000"
-        depends_on:
-            - ajv
+  py-validator:
+    image: onsdigital/eq-questionnaire-validator:${TAG}
+    networks:
+      - eq-schema
+    environment:
+      AJV_HOST: ajv-validator
+    ports:
+      - 5001:5000
+    depends_on:
+      - ajv-validator
 networks:
-    eq-schema:
-        driver: bridge
+  eq-schema:
+    driver: bridge

--- a/docker-compose-schema-validator.yml
+++ b/docker-compose-schema-validator.yml
@@ -2,14 +2,14 @@ version: '3'
 
 services:
     ajv:
-        image: onsdigital/eq-questionnaire-validator:use-AJV-validator-ajv # update image with latest-ajv
+        image: onsdigital/eq-questionnaire-validator:${TAG}-ajv # update image with latest-ajv
         networks:
             - eq-schema
         ports:
             - "5002:5002"
 
     py-validator:
-        image: onsdigital/eq-questionnaire-validator:use-AJV-validator # update image with latest
+        image: onsdigital/eq-questionnaire-validator:${TAG} # update image with latest
         networks:
             - eq-schema
         environment:

--- a/docker-compose-schema-validator.yml
+++ b/docker-compose-schema-validator.yml
@@ -1,0 +1,23 @@
+version: '3'
+
+services:
+    ajv:
+        image: onsdigital/eq-questionnaire-validator:use-AJV-validator-ajv # update image with latest-ajv
+        networks:
+            - eq-schema
+        ports:
+            - "5002:5002"
+
+    py-validator:
+        image: onsdigital/eq-questionnaire-validator:use-AJV-validator # update image with latest
+        networks:
+            - eq-schema
+        environment:
+            AJV_HOST: "ajv"
+        ports:
+            - "5001:5000"
+        depends_on:
+            - ajv
+networks:
+    eq-schema:
+        driver: bridge

--- a/scripts/run_validator.sh
+++ b/scripts/run_validator.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 tag=use-AJV-validator
-TAG=${tag} docker-compose -f docker-compose-schema-validator.yml  up -d
+TAG=${tag} docker-compose -f docker-compose-schema-validator.yml up -d

--- a/scripts/run_validator.sh
+++ b/scripts/run_validator.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 tag=use-AJV-validator
-TAG=${tag} docker-compose -f docker-compose-schema-validator.yml  up
+TAG=${tag} docker-compose -f docker-compose-schema-validator.yml  up -d

--- a/scripts/run_validator.sh
+++ b/scripts/run_validator.sh
@@ -1,4 +1,3 @@
 #!/usr/bin/env bash
-tag=latest
-docker pull onsdigital/eq-questionnaire-validator:$tag
-docker run -d -p 5001:5000 "onsdigital/eq-questionnaire-validator:$tag"
+tag=use-AJV-validator
+TAG=${tag} docker-compose -f docker-compose-schema-validator.yml  up

--- a/scripts/run_validator.sh
+++ b/scripts/run_validator.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-tag=use-AJV-validator
+tag=latest
 TAG=${tag} docker-compose -f docker-compose-schema-validator.yml up -d

--- a/scripts/validate_test_schemas.sh
+++ b/scripts/validate_test_schemas.sh
@@ -6,7 +6,7 @@ default="$(tput sgr0)"
 checks=4
 
 until [ "$checks" == 0 ]; do
-    response="$(curl -so /dev/null -w '%{http_code}' http://localhost:5001/status)"
+    response="$(curl -so /dev/null -w '%{http_code}' http://localhost:5002/status)"
 
     if [ "$response" != "200" ]; then
         echo "${red}---Error: Schema Validator Not Reachable---"

--- a/test_schemas/en/test_new_routing_and.json
+++ b/test_schemas/en/test_new_routing_and.json
@@ -114,17 +114,17 @@
                                 "contents": [
                                     {
                                         "description": {
-                                            "text": "You were asked to enter <em>123</em> and <em>321</em> but you actually entered <em>{answer-1}</em> and <em>{answer-2}</em>.",
+                                            "text": "You were asked to enter <em>123</em> and <em>321</em> but you actually entered <em>{answer_1}</em> and <em>{answer_2}</em>.",
                                             "placeholders": [
                                                 {
-                                                    "placeholder": "answer-1",
+                                                    "placeholder": "answer_1",
                                                     "value": {
                                                         "source": "answers",
                                                         "identifier": "answer-1"
                                                     }
                                                 },
                                                 {
-                                                    "placeholder": "answer-2",
+                                                    "placeholder": "answer_2",
                                                     "value": {
                                                         "source": "answers",
                                                         "identifier": "answer-2"
@@ -149,17 +149,17 @@
                                 "contents": [
                                     {
                                         "description": {
-                                            "text": "You were asked to enter <em>123</em> and <em>321</em> and you entered <em>{answer-1}</em> and <em>{answer-2}</em>.",
+                                            "text": "You were asked to enter <em>123</em> and <em>321</em> and you entered <em>{answer_1}</em> and <em>{answer_2}</em>.",
                                             "placeholders": [
                                                 {
-                                                    "placeholder": "answer-1",
+                                                    "placeholder": "answer_1",
                                                     "value": {
                                                         "source": "answers",
                                                         "identifier": "answer-1"
                                                     }
                                                 },
                                                 {
-                                                    "placeholder": "answer-2",
+                                                    "placeholder": "answer_2",
                                                     "value": {
                                                         "source": "answers",
                                                         "identifier": "answer-2"

--- a/test_schemas/en/test_new_routing_or.json
+++ b/test_schemas/en/test_new_routing_or.json
@@ -114,17 +114,17 @@
                                 "contents": [
                                     {
                                         "description": {
-                                            "text": "You were asked to enter <em>123</em> or <em>321</em> but you actually entered <em>{answer-1}</em> and <em>{answer-2}</em>.",
+                                            "text": "You were asked to enter <em>123</em> or <em>321</em> but you actually entered <em>{answer_1}</em> and <em>{answer_2}</em>.",
                                             "placeholders": [
                                                 {
-                                                    "placeholder": "answer-1",
+                                                    "placeholder": "answer_1",
                                                     "value": {
                                                         "source": "answers",
                                                         "identifier": "answer-1"
                                                     }
                                                 },
                                                 {
-                                                    "placeholder": "answer-2",
+                                                    "placeholder": "answer_2",
                                                     "value": {
                                                         "source": "answers",
                                                         "identifier": "answer-2"
@@ -149,17 +149,17 @@
                                 "contents": [
                                     {
                                         "description": {
-                                            "text": "You were asked to enter <em>123</em> or <em>321</em> and you entered <em>{answer-1}</em> and <em>{answer-2}</em>.",
+                                            "text": "You were asked to enter <em>123</em> or <em>321</em> and you entered <em>{answer_1}</em> and <em>{answer_2}</em>.",
                                             "placeholders": [
                                                 {
-                                                    "placeholder": "answer-1",
+                                                    "placeholder": "answer_1",
                                                     "value": {
                                                         "source": "answers",
                                                         "identifier": "answer-1"
                                                     }
                                                 },
                                                 {
-                                                    "placeholder": "answer-2",
+                                                    "placeholder": "answer_2",
                                                     "value": {
                                                         "source": "answers",
                                                         "identifier": "answer-2"


### PR DESCRIPTION
### What is the context of this PR?

- Introduce new docker-compose file for validator.
- update run validator script to use new docker-compose
- update `validate_test_schema.sh` script to check for AJV service status instead of Python validator service
- Fix failing schema
- [Validator PR for this change ](https://github.com/ONSdigital/eq-questionnaire-validator/pull/128)

### How to review 
Run validator and validate test schema, ensure all schemas are passing

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
