### PR TITLE
Fix period limits when minimum not set

### DIFF
--- a/app/forms/questionnaire_form.py
+++ b/app/forms/questionnaire_form.py
@@ -203,14 +203,11 @@ class QuestionnaireForm(FlaskForm):
         period_limits_item = self._get_period_limits(period_limits)
         period_min = period_limits_item[0]
 
-        if period_min:
-            min_offset = self._get_offset_value(period_min)
+        # Exception to be raised if range available is smaller than minimum range allowed
+        if period_min and period_range < self._get_offset_value(period_min):
+            exception = f"The schema has invalid period_limits for {question_id}"
 
-            # Exception to be raised if range available is smaller than minimum range allowed
-            if period_range < min_offset:
-                exception = f"The schema has invalid period_limits for {question_id}"
-
-                raise Exception(exception)
+            raise Exception(exception)
 
     @staticmethod
     def validate_date_range_with_single_date_limits(

--- a/app/forms/questionnaire_form.py
+++ b/app/forms/questionnaire_form.py
@@ -200,15 +200,17 @@ class QuestionnaireForm(FlaskForm):
         period_range: timedelta,
     ) -> None:
         # Get period_limits from question
-        period_limits_item: tuple = self._get_period_limits(period_limits)
-        period_min: Mapping[str, int] = period_limits_item[0]
-        min_offset = self._get_offset_value(period_min)
+        period_limits_item = self._get_period_limits(period_limits)
+        period_min = period_limits_item[0]
 
-        # Exception to be raised if range available is smaller than minimum range allowed
-        if period_min and period_range < min_offset:
-            exception = f"The schema has invalid period_limits for {question_id}"
+        if period_min:
+            min_offset = self._get_offset_value(period_min)
 
-            raise Exception(exception)
+            # Exception to be raised if range available is smaller than minimum range allowed
+            if period_range < min_offset:
+                exception = f"The schema has invalid period_limits for {question_id}"
+
+                raise Exception(exception)
 
     @staticmethod
     def validate_date_range_with_single_date_limits(

--- a/tests/app/forms/test_questionnaire_form.py
+++ b/tests/app/forms/test_questionnaire_form.py
@@ -923,7 +923,7 @@ class TestQuestionnaireForm(
                 question_schema,
                 AnswerStore(),
                 ListStore(),
-                metadata=None,
+                metadata={},
                 response_metadata={},
                 form_data=form_data,
             )

--- a/tests/app/forms/test_questionnaire_form.py
+++ b/tests/app/forms/test_questionnaire_form.py
@@ -881,6 +881,60 @@ class TestQuestionnaireForm(
                         str(ite.exception),
                     )
 
+    def test_period_limits_minimum_not_set_and_single_date_periods(self):
+        with self.app_request_context():
+            schema = load_schema_from_name("test_date_validation_range")
+
+            question_schema = {
+                "id": "date-range-question",
+                "type": "DateRange",
+                "period_limits": {"maximum": {"days": 8}},
+                "answers": [
+                    {
+                        "id": "date-range-from",
+                        "label": "Period from",
+                        "mandatory": True,
+                        "type": "Date",
+                        "minimum": {"value": "2018-01-10"},
+                    },
+                    {
+                        "id": "date-range-to",
+                        "label": "Period to",
+                        "mandatory": True,
+                        "type": "Date",
+                        "maximum": {"value": "2018-01-18"},
+                    },
+                ],
+            }
+
+            form_data = MultiDict(
+                {
+                    "date-range-from-day": "10",
+                    "date-range-from-month": "1",
+                    "date-range-from-year": "2018",
+                    "date-range-to-day": "11",
+                    "date-range-to-month": "1",
+                    "date-range-to-year": "2018",
+                }
+            )
+
+            form = generate_form(
+                schema,
+                question_schema,
+                AnswerStore(),
+                ListStore(),
+                metadata=None,
+                response_metadata={},
+                form_data=form_data,
+            )
+
+            with patch(
+                "app.questionnaire.questionnaire_schema.QuestionnaireSchema.get_all_questions_for_block",
+                return_value=[question_schema],
+            ):
+                form.validate()
+            self.assertEqual(len(form.question_errors), 0)
+
     def test_invalid_date_range_and_single_date_periods(self):
         with self.app_request_context():
             answer_store = AnswerStore()


### PR DESCRIPTION
### What is the context of this PR?
This PR fixes period limits when minimum is not set. We were checking an object which could be None and therefore it was falling over. Our code just needed a tweak and min_offset = self._get_offset_value moved inside the initial part of the if

### How to review 
Make sure I have fixed it properly. You could lift the json from the test and put it in a schema (test_date_range is probably easiest) and try it if you like. You could also try lcree_0010.json if you want to use the schema that fell over because of it. It will be available in launcher (assuming you have .schemas-version >=v3.0.2)

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
