### PR TITLE
Fix exit button link on introduction page

### DIFF
--- a/app/translations/messages.pot
+++ b/app/translations/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-01-25 12:33+0000\n"
+"POT-Creation-Date: 2022-01-26 15:54+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -291,41 +291,41 @@ msgstr ""
 msgid "An individual access code has been sent by text"
 msgstr ""
 
-#: app/survey_config/business_config.py:31
+#: app/survey_config/business_config.py:33
 msgid "What we do"
 msgstr ""
 
-#: app/survey_config/business_config.py:32
+#: app/survey_config/business_config.py:34
 #: app/survey_config/census_config.py:30 app/survey_config/census_config.py:80
 #: app/survey_config/census_config.py:141
 msgid "Contact us"
 msgstr ""
 
-#: app/survey_config/business_config.py:34
+#: app/survey_config/business_config.py:36
 msgid "Accessibility"
 msgstr ""
 
-#: app/survey_config/business_config.py:39
+#: app/survey_config/business_config.py:41
 #: app/survey_config/census_config.py:44 app/survey_config/census_config.py:95
 #: app/survey_config/census_config.py:148
 msgid "Cookies"
 msgstr ""
 
-#: app/survey_config/business_config.py:41
+#: app/survey_config/business_config.py:43
 #: app/survey_config/census_config.py:50 app/survey_config/census_config.py:101
 #: app/survey_config/census_config.py:154
 msgid "Privacy and data protection"
 msgstr ""
 
-#: app/survey_config/business_config.py:52
+#: app/survey_config/business_config.py:54
 msgid "My account"
 msgstr ""
 
-#: app/survey_config/business_config.py:57
+#: app/survey_config/business_config.py:59
 msgid "Sign out"
 msgstr ""
 
-#: app/survey_config/business_config.py:69
+#: app/survey_config/business_config.py:78
 msgid "Northern Ireland Department of Finance logo"
 msgstr ""
 
@@ -1184,7 +1184,7 @@ msgstr ""
 msgid "Choose another section and return to this later"
 msgstr ""
 
-#: templates/layouts/configs/_save-sign-out-button.html:20
+#: templates/layouts/configs/_save-sign-out-button.html:21
 msgid "Exit"
 msgstr ""
 

--- a/templates/layouts/configs/_save-sign-out-button.html
+++ b/templates/layouts/configs/_save-sign-out-button.html
@@ -1,10 +1,11 @@
 {% if current_user.is_authenticated and not hide_sign_out_button %}
+    {% set sign_out_url = url_for('session.get_sign_out') %}
 
     {% if save_on_signout %}
         {% do pageConfig | setAttribute("signoutButton", {
             "text": sign_out_button_text,
             "name": "btn-save-sign-out",
-            "url": "/sign-out",
+            "url": sign_out_url,
             "attributes": {
                 "data-qa": "btn-save-sign-out",
                 "data-ga": "click",

--- a/tests/functional/spec/save_sign_out.spec.js
+++ b/tests/functional/spec/save_sign_out.spec.js
@@ -7,24 +7,33 @@ import IntroThankYouPagePage from "../base_pages/thank-you.page";
 import HouseHolderConfirmationPage from "../generated_pages/thank_you_census_household/household-confirmation.page";
 import { getRandomString } from "../jwt_helper";
 
-describe("SaveSignOut", () => {
+describe("Save sign out / Exit", () => {
   const responseId = getRandomString(16);
 
-  it("Given I am completing a survey, when I select save and complete later, then I am redirected to sign out page and my session is cleared", () => {
+  it("Given I am on an introduction page, when I click the exit button, then I am redirected to sign out page and my session is cleared", () => {
+    browser.openQuestionnaire("test_introduction.json");
+    $(IntroductionPage.exitButton()).click();
+
+    expect(browser.getUrl()).to.contain("/sign-in/logout");
+
+    browser.back();
+    expect($("body").getHTML()).to.contain("Sorry, you need to sign in again");
+  });
+
+  it("Given I am completing a questionnaire, when I select save and sign out, then I am redirected to sign out page and my session is cleared", () => {
     browser.openQuestionnaire("test_numbers.json", { userId: "test_user", responseId });
     $(SetMinMax.setMinimum()).setValue("10");
     $(SetMinMax.setMaximum()).setValue("1020");
     $(SetMinMax.submit()).click();
     $(TestMinMax.saveSignOut()).click();
 
-    expect(browser.getUrl()).to.contain("localhost");
+    expect(browser.getUrl()).to.contain("/sign-in/logout");
 
     browser.back();
-
     expect($("body").getHTML()).to.contain("Sorry, you need to sign in again");
   });
 
-  it("Given I have started a questionnaire, when I return to the questionnaire, then I am returned to the page I was on and can then complete the survey", () => {
+  it("Given I have started a questionnaire, when I return to the questionnaire, then I am returned to the page I was on and can then complete the questionnaire", () => {
     browser.openQuestionnaire("test_numbers.json", { userId: "test_user", responseId });
 
     $(TestMinMax.testRange()).setValue("10");


### PR DESCRIPTION
### What is the context of this PR?
Fixes the missing exit button link on the introduction page.

### How to review 
- Launch `test_introduction.json`
- Ensure when you click `Exit` you are signed out and taken to the log-out URL.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
