### PR TITLE
Update form validation dates to pytest and fix coverage

### DIFF
--- a/tests/app/forms/validation/conftest.py
+++ b/tests/app/forms/validation/conftest.py
@@ -1,0 +1,43 @@
+import pytest
+
+from app.forms.validators import DateCheck, DateRangeCheck, DateRequired
+
+
+@pytest.fixture
+def date_check():
+    return DateCheck()
+
+
+@pytest.fixture
+def date_required():
+    return DateRequired()
+
+
+@pytest.fixture
+def get_date_range_check():
+    def _date_range_check(messages=None, period_min=None, period_max=None):
+        return DateRangeCheck(
+            messages=messages, period_min=period_min, period_max=period_max
+        )
+
+    return _date_range_check
+
+
+@pytest.fixture
+def mock_form(mocker):
+    return mocker.Mock()
+
+
+@pytest.fixture
+def mock_field(mocker):
+    return mocker.Mock()
+
+
+@pytest.fixture
+def mock_period_from(mocker):
+    return mocker.Mock()
+
+
+@pytest.fixture
+def mock_period_to(mocker):
+    return mocker.Mock()

--- a/tests/app/forms/validation/test_date_check_validator.py
+++ b/tests/app/forms/validation/test_date_check_validator.py
@@ -1,198 +1,90 @@
-import unittest
-from unittest.mock import Mock
-
+import pytest
 from wtforms.validators import StopValidation
 
 from app.forms import error_messages
-from app.forms.validators import DateCheck
 
 
-class TestDateCheckValidator(unittest.TestCase):
-    def test_date_type_validator_empty_string(self):
-        validator = DateCheck()
-
-        mock_form = Mock()
-        mock_form.data = ""
-
-        mock_field = Mock()
-
-        with self.assertRaises(StopValidation) as ite:
-            validator(mock_form, mock_field)
-
-        self.assertEqual(error_messages["INVALID_DATE"], str(ite.exception))
-
-    def test_date_type_validator_missing_day(self):
-        validator = DateCheck()
-
-        mock_form = Mock()
-        mock_form.data = "2016-12-"
-        mock_form.year.data = "2016"
-
-        mock_field = Mock()
-
-        with self.assertRaises(StopValidation) as ite:
-            validator(mock_form, mock_field)
-
-        self.assertEqual(error_messages["INVALID_DATE"], str(ite.exception))
-
-    def test_date_type_validator_missing_month(self):
-        validator = DateCheck()
-
-        mock_form = Mock()
-        mock_form.data = "2016--03"
-        mock_form.year.data = "2016"
-
-        mock_field = Mock()
-
-        with self.assertRaises(StopValidation) as ite:
-            validator(mock_form, mock_field)
-
-        self.assertEqual(error_messages["INVALID_DATE"], str(ite.exception))
-
-    def test_date_type_validator_missing_year(self):
-        validator = DateCheck()
-
-        mock_form = Mock()
-        mock_form.data = "-12-03"
-
-        mock_field = Mock()
-
-        with self.assertRaises(StopValidation) as ite:
-            validator(mock_form, mock_field)
-
-        self.assertEqual(error_messages["INVALID_DATE"], str(ite.exception))
-
-    def test_date_type_validator_invalid_day(self):
-        validator = DateCheck()
-
-        mock_form = Mock()
-        mock_form.data = "2016-12-40"
-        mock_form.year.data = "2016"
-
-        mock_field = Mock()
-
-        with self.assertRaises(StopValidation) as ite:
-            validator(mock_form, mock_field)
-
-        self.assertEqual(error_messages["INVALID_DATE"], str(ite.exception))
-
-    def test_date_type_validator_invalid_month(self):
-        validator = DateCheck()
-
-        mock_form = Mock()
-        mock_form.data = "2016-13-20"
-        mock_form.year.data = "2016"
-
-        mock_field = Mock()
-
-        with self.assertRaises(StopValidation) as ite:
-            validator(mock_form, mock_field)
-
-        self.assertEqual(error_messages["INVALID_DATE"], str(ite.exception))
-
-    def test_date_type_validator_invalid_year(self):
-        validator = DateCheck()
-
-        mock_form = Mock()
-        mock_form.data = "20000-12-20"
-        mock_form.year.data = "20000"
-
-        mock_field = Mock()
-
-        with self.assertRaises(StopValidation) as ite:
-            validator(mock_form, mock_field)
-
-        self.assertEqual(error_messages["INVALID_DATE"], str(ite.exception))
-
-    def test_date_type_validator_invalid_year_digits(self):
-        validator = DateCheck()
-
-        mock_form = Mock()
-        mock_form.data = "2-12-20"
-        mock_form.year.data = "2"
-
-        mock_field = Mock()
-
-        with self.assertRaises(StopValidation) as ite:
-            validator(mock_form, mock_field)
-
-        self.assertEqual(error_messages["INVALID_DATE"], str(ite.exception))
-
-    def test_date_type_validator_invalid_month_digits(self):
-        validator = DateCheck()
-
-        mock_form = Mock()
-        mock_form.data = "2020--2-20"
-
-        mock_field = Mock()
-
-        with self.assertRaises(StopValidation) as ite:
-            validator(mock_form, mock_field)
-
-        self.assertEqual(error_messages["INVALID_DATE"], str(ite.exception))
-
-    def test_date_type_validator_invalid_day_digits(self):
-        validator = DateCheck()
-
-        mock_form = Mock()
-        mock_form.data = "2020-12--2"
-        mock_form.year.data = "2020"
-
-        mock_field = Mock()
-
-        with self.assertRaises(StopValidation) as ite:
-            validator(mock_form, mock_field)
-
-        self.assertEqual(error_messages["INVALID_DATE"], str(ite.exception))
-
-    def test_date_type_validator_invalid_leap_year(self):
-        validator = DateCheck()
-
-        # 2015 was not a leap year
-        mock_form = Mock()
-        mock_form.data = "2015-02-29"
-        mock_form.year.data = "2015"
-
-        mock_field = Mock()
-
-        with self.assertRaises(StopValidation) as ite:
-            validator(mock_form, mock_field)
-
-        self.assertEqual(error_messages["INVALID_DATE"], str(ite.exception))
-
-    @staticmethod
-    def test_date_type_validator_valid_leap_year():
-        validator = DateCheck()
-
-        # 2016 WAS a leap year
-        mock_form = Mock()
-        mock_form.data = "2016-02-29"
-        mock_form.year.data = "2016"
-
-        mock_field = Mock()
-        validator(mock_form, mock_field)
-
-    @staticmethod
-    def test_date_type_validator_valid_dates():
-        validator = DateCheck()
-
-        mock_form = Mock()
-        mock_form.data = "2016-01-29"
-        mock_form.year.data = "2016"
-
-        mock_field = Mock()
-        validator(mock_form, mock_field)
-
-        mock_form = Mock()
-        mock_form.data = "2016-12-01"
-        mock_form.year.data = "2016"
-
-        mock_field = Mock()
-        validator(mock_form, mock_field)
-
-        mock_form = Mock()
-        mock_form.data = "2016-03-03"
-        mock_form.year.data = "2016"
-
-        mock_field = Mock()
-        validator(mock_form, mock_field)
+@pytest.mark.parametrize(
+    "date",
+    [
+        "",
+        "2016-12-",
+        "2016--03",
+        "-12-03",
+        "2016-12-40",
+        "2016-13-20",
+        "20000-12-20",
+        "2015-02-29",  # 2015 was not a leap year
+    ],
+)
+def test_invalid_day_month_year(date_check, mock_form, mock_field, date):
+    mock_form.data = date
+
+    assert_invalid_date_error(date_check, mock_form, mock_field)
+
+
+@pytest.mark.parametrize(
+    "date",
+    [
+        "2016-",
+        "-12",
+        "2016-13",
+        "20000-12",
+    ],
+)
+def test_invalid_month_year(date_check, mock_form, mock_field, date):
+    mock_form.data = date
+    del mock_form.day
+
+    assert_invalid_date_error(date_check, mock_form, mock_field)
+
+
+def test_invalid_year(date_check, mock_form, mock_field):
+    del mock_form.day
+    del mock_form.month
+    mock_form.data = "20000"
+
+    assert_invalid_date_error(date_check, mock_form, mock_field)
+
+
+@pytest.mark.parametrize(
+    "date",
+    [
+        "2016-01-29",
+        "2016-02-29",  # 2016 was a leap year
+    ],
+)
+def test_valid_day_month_year(date_check, mock_form, mock_field, date):
+    mock_form.data = date
+
+    try:
+        date_check(mock_form, mock_field)
+    except StopValidation:
+        pytest.fail("Valid day month year raised StopValidation")
+
+
+def test_valid_month_year(date_check, mock_form, mock_field):
+    del mock_form.day
+    mock_form.data = "2016-12"
+
+    try:
+        date_check(mock_form, mock_field)
+    except StopValidation:
+        pytest.fail("Valid month year raised StopValidation")
+
+
+def test_valid_year(date_check, mock_form, mock_field):
+    del mock_form.day
+    del mock_form.month
+    mock_form.data = "2016"
+
+    try:
+        date_check(mock_form, mock_field)
+    except StopValidation:
+        pytest.fail("Valid year raised StopValidation")
+
+
+def assert_invalid_date_error(date_check, mock_form, mock_field):
+    with pytest.raises(StopValidation) as ite:
+        date_check(mock_form, mock_field)
+    assert error_messages["INVALID_DATE"] == str(ite.value)

--- a/tests/app/forms/validation/test_date_range_validator.py
+++ b/tests/app/forms/validation/test_date_range_validator.py
@@ -28,6 +28,7 @@ def test_invalid_date_range(
 
     with pytest.raises(ValidationError) as context:
         date_range_check(mock_form, mock_period_from, mock_period_to)
+
     assert error_messages["INVALID_DATE_RANGE"] == str(context.value)
 
 
@@ -81,43 +82,63 @@ def test_bespoke_message_playback(
     assert "Test 2 years, 1 month, 3 days" == str(context.value)
 
 
-def test_message_combinations(
-    get_date_range_check, mock_form, mock_period_from, mock_period_to
+@pytest.mark.parametrize(
+    "period_max, expected_result",
+    [
+        ({"years": 2, "months": 1, "days": 3}, "2 years, 1 month, 3 days"),
+        ({"months": 2, "days": 1}, "2 months, 1 day"),
+        ({"days": 3}, "3 days"),
+    ],
+)
+def test_date_range_period_max(
+    get_date_range_check,
+    mock_form,
+    mock_period_from,
+    mock_period_to,
+    period_max,
+    expected_result,
 ):
     mock_period_from.data = "2016-02-11"
     mock_period_to.data = "2018-03-19"
-    period_max = {"years": 2, "months": 1, "days": 3}
 
     date_range_check = get_date_range_check(period_max=period_max)
 
     with pytest.raises(ValidationError) as context:
         date_range_check(mock_form, mock_period_from, mock_period_to)
 
-    assert (
-        "Enter a reporting period less than or equal to 2 years, 1 month, 3 days"
-        == str(context.value)
-    )
-
-    period_max = {"months": 2, "days": 1}
-
-    date_range_check = get_date_range_check(period_max=period_max)
-
-    with pytest.raises(ValidationError) as context:
-        date_range_check(mock_form, mock_period_from, mock_period_to)
-
-    assert "Enter a reporting period less than or equal to 2 months, 1 day" == str(
+    assert f"Enter a reporting period less than or equal to {expected_result}" == str(
         context.value
     )
 
-    period_min = {"years": 3, "days": 2}
+
+@pytest.mark.parametrize(
+    "period_min, expected_result",
+    [
+        ({"years": 3, "months": 2}, "3 years, 2 months"),
+        ({"years": 3, "days": 2}, "3 years, 2 days"),
+        ({"years": 3}, "3 years"),
+        ({"months": 3}, "3 months"),
+    ],
+)
+def test_date_range_period_min(
+    get_date_range_check,
+    mock_form,
+    mock_period_from,
+    mock_period_to,
+    period_min,
+    expected_result,
+):
+    mock_period_from.data = "2016-02-11"
+    mock_period_to.data = "2016-03-19"
 
     date_range_check = get_date_range_check(period_min=period_min)
 
     with pytest.raises(ValidationError) as context:
         date_range_check(mock_form, mock_period_from, mock_period_to)
 
-    assert "Enter a reporting period greater than or equal to 3 years, 2 days" == str(
-        context.value
+    assert (
+        f"Enter a reporting period greater than or equal to {expected_result}"
+        == str(context.value)
     )
 
 

--- a/tests/app/forms/validation/test_date_required.py
+++ b/tests/app/forms/validation/test_date_required.py
@@ -1,101 +1,64 @@
-import unittest
-from unittest.mock import Mock
-
+import pytest
 from wtforms.validators import StopValidation
 
 from app.forms import error_messages
-from app.forms.validators import DateRequired
 
 
-class TestDateRequiredValidator(unittest.TestCase):
-    def test_date_required_empty(self):
-        validator = DateRequired()
+def test_day_month_year_required_empty(date_required, mock_form, mock_field):
+    mock_form.day.data = ""
+    mock_form.month.data = ""
+    mock_form.year.data = ""
 
-        mock_form = Mock()
-        mock_form.day.data = ""
-        mock_form.month.data = ""
-        mock_form.year.data = ""
+    assert_mandatory_date_error(date_required, mock_field, mock_form)
 
-        mock_field = Mock()
 
-        with self.assertRaises(StopValidation) as ite:
-            validator(mock_form, mock_field)
+def test_month_year_required_empty(date_required, mock_form, mock_field):
+    del mock_form.day
+    mock_form.month.data = ""
+    mock_form.year.data = ""
 
-        self.assertEqual(error_messages["MANDATORY_DATE"], str(ite.exception))
+    assert_mandatory_date_error(date_required, mock_field, mock_form)
 
-    def test_date_month_year_required_empty(self):
-        validator = DateRequired()
 
-        class TestMonthYearSpec:
-            month = None
-            year = None
+def test_year_required_empty(date_required, mock_form, mock_field):
+    del mock_form.day
+    del mock_form.month
+    mock_form.year.data = ""
 
-        mock_form = Mock(spec=TestMonthYearSpec)
-        mock_form.month.data = ""
-        mock_form.year.data = ""
-        mock_field = Mock()
+    assert_mandatory_date_error(date_required, mock_field, mock_form)
 
-        with self.assertRaises(StopValidation) as ite:
-            validator(mock_form, mock_field)
 
-        self.assertEqual(error_messages["MANDATORY_DATE"], str(ite.exception))
+def test_valid_day_month_year(date_required, mock_form, mock_field):
+    mock_form.day.data = "01"
+    mock_form.month.data = "01"
+    mock_form.year.data = "2015"
 
-    def test_date_year_required_empty(self):
-        validator = DateRequired()
+    try:
+        date_required(mock_form, mock_field)
+    except StopValidation:
+        pytest.fail("Valid day month year raised StopValidation")
 
-        class TestYearSpec:
-            year = None
 
-        mock_form = Mock(spec=TestYearSpec)
-        mock_form.year.data = ""
-        mock_field = Mock()
+def test_valid_month_year(date_required, mock_form, mock_field):
+    mock_form.month.data = "01"
+    mock_form.year.data = "2017"
 
-        with self.assertRaises(StopValidation) as ite:
-            validator(mock_form, mock_field)
+    try:
+        date_required(mock_form, mock_field)
+    except StopValidation:
+        pytest.fail("Valid month year raised StopValidation")
 
-        self.assertEqual(error_messages["MANDATORY_DATE"], str(ite.exception))
 
-    def test_valid_date(self):
+def test_valid_year(date_required, mock_form, mock_field):
+    mock_form.year.data = "2017"
 
-        validator = DateRequired()
+    try:
+        date_required(mock_form, mock_field)
+    except StopValidation:
+        pytest.fail("Valid year raised StopValidation")
 
-        mock_form = Mock()
-        mock_form.day.data = "01"
-        mock_form.month.data = "01"
-        mock_form.year.data = "2015"
 
-        mock_field = Mock()
-
-        try:
-            validator(mock_form, mock_field)
-        except StopValidation:
-            self.fail("Valid date raised StopValidation")
-
-    def test_valid_month_year(self):
-
-        validator = DateRequired()
-
-        mock_form = Mock()
-        mock_form.month.data = "01"
-        mock_form.year.data = "2017"
-
-        mock_field = Mock()
-
-        try:
-            validator(mock_form, mock_field)
-        except StopValidation:
-            self.fail("Valid date raised StopValidation")
-
-    def test_valid__year(self):
-
-        validator = DateRequired()
-
-        mock_form = Mock()
-        mock_form.year.data = "2017"
-
-        mock_field = Mock()
-
-        try:
-            validator(mock_form, mock_field)
-        except StopValidation:
-            self.fail("Valid date raised StopValidation")
+def assert_mandatory_date_error(date_required, mock_field, mock_form):
+    with pytest.raises(StopValidation) as ite:
+        date_required(mock_form, mock_field)
+    assert error_messages["MANDATORY_DATE"] == str(ite.value)


### PR DESCRIPTION
### What is the context of this PR?
This PR updates the tests for forms validation for DateCheck, DateRequired and DateRangeCheck to pytest. Extra tests have been added as coverage was missing from the original and some have been removed as I thought they weren't overly useful

### How to review 
Firstly check coverage of just these new tests now has line coverage for the correct parts in validators.py. I quite like updating scripts/run_tests_unit.sh  (i.e py.test ...... -k test_date_check_validator) and then looking at htmlcov/index.html in a browser to see coverage. (there are other ways of course)

Once that has been done check that everything has been updated to pytest correctly.


### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
