### PR TITLE
Add functional tests batch 4

### DIFF
--- a/tests/functional/spec/features/validation/sum/sum_equal_or_less_validation_against_total.spec.js
+++ b/tests/functional/spec/features/validation/sum/sum_equal_or_less_validation_against_total.spec.js
@@ -20,6 +20,19 @@ describe("Feature: Sum of grouped answers validation (equal or less than) agains
     });
   });
 
+  describe("Given I start a grouped answer validation survey and enter 12 into the total", () => {
+    it("When I continue and enter 3 in each breakdown field, Then I should be able to get to the summary", () => {
+      $(TotalAnswerPage.total()).setValue("12");
+      $(TotalAnswerPage.submit()).click();
+      $(BreakdownAnswerPage.breakdown1()).setValue("3");
+      $(BreakdownAnswerPage.breakdown2()).setValue("3");
+      $(BreakdownAnswerPage.breakdown3()).setValue("3");
+      $(BreakdownAnswerPage.breakdown4()).setValue("3");
+      $(BreakdownAnswerPage.submit()).click();
+      expect(browser.getUrl()).to.contain(SubmitPage.pageName);
+    });
+  });
+
   describe("Given I start a grouped answer validation survey and enter 5 into the total", () => {
     it("When I continue and enter 4 into breakdown 1 and leave the others empty, Then I should be able to get to the summary", () => {
       $(TotalAnswerPage.total()).setValue("5");

--- a/tests/functional/spec/features/validation/sum/sum_equal_or_less_validation_against_total.spec.js
+++ b/tests/functional/spec/features/validation/sum/sum_equal_or_less_validation_against_total.spec.js
@@ -4,7 +4,7 @@ import SubmitPage from "../../../../generated_pages/sum_less_validation_against_
 
 describe("Feature: Sum of grouped answers validation (equal or less than) against total", () => {
   beforeEach(() => {
-    browser.openQuestionnaire("test_sum_less_validation_against_total.json");
+    browser.openQuestionnaire("test_sum_equal_or_less_validation_against_total.json");
   });
 
   describe("Given I start a grouped answer validation survey and enter 12 into the total", () => {
@@ -34,15 +34,15 @@ describe("Feature: Sum of grouped answers validation (equal or less than) agains
   });
 
   describe("Given I start a grouped answer validation survey and enter 12 into the total", () => {
-    it("When I continue and enter 3 in each breakdown field, Then I should see a validation error", () => {
+    it("When I continue and enter 4 in each breakdown field, Then I should see a validation error", () => {
       $(TotalAnswerPage.total()).setValue("12");
       $(TotalAnswerPage.submit()).click();
-      $(BreakdownAnswerPage.breakdown1()).setValue("3");
-      $(BreakdownAnswerPage.breakdown2()).setValue("3");
-      $(BreakdownAnswerPage.breakdown3()).setValue("3");
-      $(BreakdownAnswerPage.breakdown4()).setValue("3");
+      $(BreakdownAnswerPage.breakdown1()).setValue("4");
+      $(BreakdownAnswerPage.breakdown2()).setValue("4");
+      $(BreakdownAnswerPage.breakdown3()).setValue("4");
+      $(BreakdownAnswerPage.breakdown4()).setValue("4");
       $(BreakdownAnswerPage.submit()).click();
-      expect($(BreakdownAnswerPage.errorNumber(1)).getText()).to.contain("Enter answers that add up to less than £12.00");
+      expect($(BreakdownAnswerPage.errorNumber(1)).getText()).to.contain("Enter answers that add up to or are less than 12");
     });
   });
 
@@ -55,7 +55,7 @@ describe("Feature: Sum of grouped answers validation (equal or less than) agains
       $(BreakdownAnswerPage.breakdown3()).setValue("3");
       $(BreakdownAnswerPage.breakdown4()).setValue("3");
       $(BreakdownAnswerPage.submit()).click();
-      expect($(BreakdownAnswerPage.errorNumber(1)).getText()).to.contain("Enter answers that add up to less than £5.00");
+      expect($(BreakdownAnswerPage.errorNumber(1)).getText()).to.contain("Enter answers that add up to or are less than 5");
     });
   });
 });

--- a/tests/functional/spec/theme_northernireland.spec.js
+++ b/tests/functional/spec/theme_northernireland.spec.js
@@ -9,13 +9,11 @@ describe("Theme Northern Ireland", () => {
 
     it("When I navigate to the radio page, Then I should see Northern Ireland theme content", () => {
       expect(browser.getUrl()).to.contain(RadioPage.pageName);
-      expect($("#ni-finance-logo-alt").isExisting()).to.equal(true);
       expect($("#ni-finance-logo-alt").getHTML()).to.contain("Northern Ireland Department of Finance logo");
     });
     it("When I navigate to the submit page, Then I should see Northern Ireland theme content", () => {
       $(SubmitPage.submit()).click();
       expect(browser.getUrl()).to.contain(SubmitPage.pageName);
-      expect($("#ni-finance-logo-alt").isExisting()).to.equal(true);
       expect($("#ni-finance-logo-alt").getHTML()).to.contain("Northern Ireland Department of Finance logo");
     });
   });

--- a/tests/functional/spec/theme_northernireland.spec.js
+++ b/tests/functional/spec/theme_northernireland.spec.js
@@ -1,5 +1,4 @@
 import RadioPage from "../generated_pages/theme_northernireland/radio.page";
-import SubmitPage from "../generated_pages/theme_northernireland/submit.page.js";
 
 describe("Theme Northern Ireland", () => {
   describe("Given I launch a Northern Ireland themed questionnaire", () => {
@@ -9,11 +8,6 @@ describe("Theme Northern Ireland", () => {
 
     it("When I navigate to the radio page, Then I should see Northern Ireland theme content", () => {
       expect(browser.getUrl()).to.contain(RadioPage.pageName);
-      expect($("#ni-finance-logo-alt").getHTML()).to.contain("Northern Ireland Department of Finance logo");
-    });
-    it("When I navigate to the submit page, Then I should see Northern Ireland theme content", () => {
-      $(SubmitPage.submit()).click();
-      expect(browser.getUrl()).to.contain(SubmitPage.pageName);
       expect($("#ni-finance-logo-alt").getHTML()).to.contain("Northern Ireland Department of Finance logo");
     });
   });

--- a/tests/functional/spec/theme_northernireland.spec.js
+++ b/tests/functional/spec/theme_northernireland.spec.js
@@ -1,0 +1,22 @@
+import RadioPage from "../generated_pages/theme_northernireland/radio.page";
+import SubmitPage from "../generated_pages/theme_northernireland/submit.page.js";
+
+describe("Theme Northern Ireland", () => {
+  describe("Given I launch a Northern Ireland themed questionnaire", () => {
+    before(() => {
+      browser.openQuestionnaire("test_theme_northernireland.json");
+    });
+
+    it("When I navigate to the radio page, Then I should see Northern Ireland theme content", () => {
+      expect(browser.getUrl()).to.contain(RadioPage.pageName);
+      expect($("#ni-finance-logo-alt").isExisting()).to.equal(true);
+      expect($("#ni-finance-logo-alt").getHTML()).to.contain("Northern Ireland Department of Finance logo");
+    });
+    it("When I navigate to the submit page, Then I should see Northern Ireland theme content", () => {
+      $(SubmitPage.submit()).click();
+      expect(browser.getUrl()).to.contain(SubmitPage.pageName);
+      expect($("#ni-finance-logo-alt").isExisting()).to.equal(true);
+      expect($("#ni-finance-logo-alt").getHTML()).to.contain("Northern Ireland Department of Finance logo");
+    });
+  });
+});


### PR DESCRIPTION
### What is the context of this PR?

This adds another batch of functional tests for schemas.

Functional tests already exist for:
- `test_submit_with_summary`
- `test_submit_with_summary_custom_submission_text`
- `test_theme_social`
- `test_view_submitted_response`

Test for `test_sum_equal_or_less_validation_against_total` already exists but needed fixing as it was referencing wrong schema and assertions were incorrect.

Only new test added is for `test_theme_northernireland`.


### How to review 
Check new test and the existing, fixed one.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
