### PR TITLE
Update pytest parametrized arguments to contain spaces

### DIFF
--- a/tests/app/forms/test_duration_form.py
+++ b/tests/app/forms/test_duration_form.py
@@ -45,7 +45,7 @@ def test_zero():
 
 
 @pytest.mark.parametrize(
-    "mandatory,years,months,valid,error",
+    "mandatory, years, months, valid, error",
     (
         (False, "5", "4", True, None),
         (True, "5", "4", True, None),

--- a/tests/app/forms/validation/test_mobile_number_validation.py
+++ b/tests/app/forms/validation/test_mobile_number_validation.py
@@ -6,7 +6,7 @@ from app.forms.validators import MobileNumberCheck, sanitise_mobile_number
 
 
 @pytest.mark.parametrize(
-    "unsanitized_number,expected",
+    "unsanitized_number, expected",
     (
         ("0.7.7.0.0.9.0.0.1.1.1.", "7700900111"),
         ("0447700\t900222", "7700900222"),

--- a/tests/app/forms/validation/test_mutually_exclusive_validator.py
+++ b/tests/app/forms/validation/test_mutually_exclusive_validator.py
@@ -6,7 +6,7 @@ from app.forms.validators import MutuallyExclusiveCheck, format_message_with_tit
 
 
 @pytest.mark.parametrize(
-    "answer_permutations,is_mandatory,is_only_checkboxes,error_type",
+    "answer_permutations, is_mandatory, is_only_checkboxes, error_type",
     (
         ([[], []], True, True, "MANDATORY_CHECKBOX"),
         ([None, []], True, True, "MANDATORY_CHECKBOX"),
@@ -39,7 +39,7 @@ def test_mutually_exclusive_mandatory_checkbox_raises_ValidationError(
 
 
 @pytest.mark.parametrize(
-    "answer_permutations,is_mandatory",
+    "answer_permutations, is_mandatory",
     (
         ([["British, Irish"], []], True),
         (["123", []], True),

--- a/tests/app/forms/validation/test_number_range_validator.py
+++ b/tests/app/forms/validation/test_number_range_validator.py
@@ -6,7 +6,7 @@ from app.forms.validators import NumberRange
 
 
 @pytest.mark.parametrize(
-    "minimum,maximum,value,min_excl,max_excl,error_type,error_dict",
+    "minimum, maximum, value, min_excl, max_excl, error_type, error_dict",
     (
         (0, None, -10, False, False, "NUMBER_TOO_SMALL", {"min": 0}),
         (
@@ -65,7 +65,7 @@ def test_number_range_validator_raises_ValidationError(
 
 
 @pytest.mark.parametrize(
-    "minimum,maximum,value",
+    "minimum, maximum, value",
     (
         (0, 10, 10),
         (0, 9999999999, 0),

--- a/tests/app/forms/validation/test_number_validator.py
+++ b/tests/app/forms/validation/test_number_validator.py
@@ -27,7 +27,7 @@ def test_number_validator_raises_StopValidation(
 
 
 @pytest.mark.parametrize(
-    "decimals,error",
+    "decimals, error",
     (
         (2, error_messages["INVALID_DECIMAL"] % {"max": 2}),
         (0, error_messages["INVALID_INTEGER"]),

--- a/tests/app/forms/validation/test_response_required.py
+++ b/tests/app/forms/validation/test_response_required.py
@@ -5,7 +5,7 @@ from app.forms.validators import ResponseRequired
 
 
 @pytest.mark.parametrize(
-    "message,raw_data",
+    "message, raw_data",
     (
         ("test_response_empty_invalid", [""]),
         ("test_response_blank_invalid", ["                           "]),
@@ -25,7 +25,7 @@ def test_response_invalid_raises_StopValidation(
 
 
 @pytest.mark.parametrize(
-    "message,raw_data,strip_whitespace",
+    "message, raw_data, strip_whitespace",
     (
         ("test_required_empty", ["Here is some valid input"], True),
         (

--- a/tests/app/forms/validation/test_single_date_range_validator.py
+++ b/tests/app/forms/validation/test_single_date_range_validator.py
@@ -7,7 +7,7 @@ from app.questionnaire.rules.utils import parse_datetime
 
 
 @pytest.mark.parametrize(
-    "validator,data,error_type,error_message",
+    "validator, data, error_type, error_message",
     (
         (
             SingleDatePeriodCheck(minimum_date=parse_datetime("2016-03-31")),

--- a/tests/app/forms/validation/test_sum_check_validator.py
+++ b/tests/app/forms/validation/test_sum_check_validator.py
@@ -6,7 +6,7 @@ from app.forms.validators import SumCheck, format_playback_value
 
 
 @pytest.mark.parametrize(
-    "conditions,calculation_total,target_total,error_type",
+    "conditions, calculation_total, target_total, error_type",
     (
         (["equals"], 10, 11.5, "TOTAL_SUM_NOT_EQUALS"),
         (["less than", "equals"], 20, 11.5, "TOTAL_SUM_NOT_LESS_THAN_OR_EQUALS"),

--- a/tests/app/helpers/test_template_helpers.py
+++ b/tests/app/helpers/test_template_helpers.py
@@ -196,7 +196,7 @@ def test_service_links_context(
 
 
 @pytest.mark.parametrize(
-    "survey_config,expected",
+    "survey_config, expected",
     [
         (
             SurveyConfig(),
@@ -227,7 +227,7 @@ def test_contact_us_url_context(
 
 
 @pytest.mark.parametrize(
-    "survey_config,expected",
+    "survey_config, expected",
     [
         (SurveyConfig(), "Save and sign out"),
         (CensusSurveyConfig(), "Save and complete later"),
@@ -248,7 +248,7 @@ def test_sign_out_button_text_context(
 
 
 @pytest.mark.parametrize(
-    "survey_config,expected",
+    "survey_config, expected",
     [
         (SurveyConfig(), "https://surveys.ons.gov.uk/cookies/"),
         (
@@ -296,7 +296,7 @@ def test_account_service_my_account_url_context(
 
 
 @pytest.mark.parametrize(
-    "survey_config,expected",
+    "survey_config, expected",
     [
         (SurveyConfig(), None),
         (
@@ -313,7 +313,7 @@ def test_account_service_my_todo_url_context(
 
 
 @pytest.mark.parametrize(
-    "survey_config,expected",
+    "survey_config, expected",
     [
         (SurveyConfig(), None),
         (
@@ -339,7 +339,7 @@ def test_account_service_log_out_url_context(
 
 
 @pytest.mark.parametrize(
-    "theme,language,expected",
+    "theme, language, expected",
     [
         ("default", "en", SurveyConfig),
         ("default", "cy", SurveyConfig),
@@ -443,7 +443,7 @@ def test_context_set_from_app_config(app):
 
 
 @pytest.mark.parametrize(
-    "theme,language,expected",
+    "theme, language, expected",
     [
         ("default", "en", None),
         ("business", "en", None),
@@ -468,7 +468,7 @@ def test_correct_theme_in_context(app: Flask, theme: str, language: str, expecte
 
 
 @pytest.mark.parametrize(
-    "theme,language,expected",
+    "theme, language, expected",
     [
         ("default", "en", "ONS Business Surveys"),
         ("business", "en", "ONS Business Surveys"),
@@ -495,7 +495,7 @@ def test_correct_survey_title_in_context(
 
 
 @pytest.mark.parametrize(
-    "theme,language,expected",
+    "theme, language, expected",
     [
         ("default", "en", []),
         ("business", "en", []),

--- a/tests/app/questionnaire/rules/test_operation_helper.py
+++ b/tests/app/questionnaire/rules/test_operation_helper.py
@@ -13,7 +13,7 @@ def test_string_to_datetime(operation_helper):
 
 
 @pytest.mark.parametrize(
-    "answer_id,value,expected",
+    "answer_id, value, expected",
     [
         (
             "mandatory-radio-answer",

--- a/tests/app/questionnaire/test_date_rules.py
+++ b/tests/app/questionnaire/test_date_rules.py
@@ -8,7 +8,7 @@ from app.questionnaire.when_rules import evaluate_date_rule, evaluate_goto
 
 
 @pytest.mark.parametrize(
-    "date,condition,comparison,expected",
+    "date, condition, comparison, expected",
     (
         (
             datetime.now(tz=timezone.utc).strftime("%Y-%m-%d"),

--- a/tests/app/questionnaire/test_dynamic_answer_options.py
+++ b/tests/app/questionnaire/test_dynamic_answer_options.py
@@ -78,7 +78,7 @@ def test_dynamic_answer_options(rule_evaluator, value_source_resolver):
 
 
 @pytest.mark.parametrize(
-    "checkbox_answer,expected_output",
+    "checkbox_answer, expected_output",
     [
         (
             ["Body"],

--- a/tests/app/questionnaire/test_path_finder.py
+++ b/tests/app/questionnaire/test_path_finder.py
@@ -255,7 +255,7 @@ def test_routing_path_with_conditional_value_not_in_metadata(answer_store, list_
 
 
 @pytest.mark.parametrize(
-    "schema,expected_routing_path_ids",
+    "schema, expected_routing_path_ids",
     (
         ("test_new_skip_condition_block", ["do-you-want-to-skip"]),
         ("test_skip_condition_block", ["do-you-want-to-skip", "a-non-skipped-block"]),

--- a/tests/app/questionnaire/test_placeholder_transforms.py
+++ b/tests/app/questionnaire/test_placeholder_transforms.py
@@ -6,7 +6,7 @@ from app.questionnaire.placeholder_transforms import PlaceholderTransforms
 
 
 @pytest.mark.parametrize(
-    "number,currency,expected",
+    "number, currency, expected",
     (
         ("11", "GBP", "£11.00"),
         ("11.99", "GBP", "£11.99"),
@@ -20,7 +20,7 @@ def test_format_currency(number, currency, expected, transformer):
 
 
 @pytest.mark.parametrize(
-    "number,expected",
+    "number, expected",
     (
         (123, "123"),
         ("123.4", "123.4"),
@@ -56,7 +56,7 @@ def test_format_list(transformer):
 
 
 @pytest.mark.parametrize(
-    "name,expected",
+    "name, expected",
     (
         ("Alice Aardvark", "Alice Aardvark’s"),
         ("Dave Dixon Davies", "Dave Dixon Davies’"),
@@ -69,7 +69,7 @@ def test_format_possessive(name, expected, transformer):
 
 
 @pytest.mark.parametrize(
-    "name,expected",
+    "name, expected",
     (
         ("Alice Aardvark", "Alice Aardvark"),
         ("Dave Dixon Davies", "Dave Dixon Davies"),
@@ -82,7 +82,7 @@ def test_format_possessive_non_english_does_nothing(name, expected, transformer)
 
 
 @pytest.mark.parametrize(
-    "date_start,date_end,expected",
+    "date_start, date_end, expected",
     (
         ("2016-06-10", "2019-06-10", "3 years"),
         ("2018-06-10", "2019-06-10", "1 year"),
@@ -108,7 +108,7 @@ def test_calculate_difference(date_start, date_end, expected):
 
 
 @pytest.mark.parametrize(
-    "token,expected",
+    "token, expected",
     (
         ("", "MilkEggsFlourWater"),
         (" ", "Milk Eggs Flour Water"),
@@ -121,7 +121,7 @@ def test_concatenate_list(token, expected, transformer):
 
 
 @pytest.mark.parametrize(
-    "first,second,expected",
+    "first, second, expected",
     (
         (1, 2, 3),
         (-2, -1, -3),
@@ -134,7 +134,7 @@ def test_add_int(first, second, expected, transformer):
 
 
 @pytest.mark.parametrize(
-    "first,second,expected",
+    "first, second, expected",
     (
         ("1.5", "2.5", "4"),
         ("-2.5", "-1.1", "-3.6"),
@@ -147,7 +147,7 @@ def test_add_decimal(first, second, expected, transformer):
 
 
 @pytest.mark.parametrize(
-    "language,number_to_format,determiner,expected",
+    "language, number_to_format, determiner, expected",
     (
         ("en", 1, "a_or_an", "a 1st"),
         ("en", 2, "a_or_an", "a 2nd"),
@@ -274,7 +274,7 @@ def test_list_has_items(transformer):
 
 
 @pytest.mark.parametrize(
-    "first,middle,last,include_middle_names,expected",
+    "first, middle, last, include_middle_names, expected",
     (
         ("Joe", None, "Bloggs", True, "Joe Bloggs"),
         ("Joe", None, "Bloggs", True, "Joe Bloggs"),
@@ -292,7 +292,7 @@ def test_format_name(first, middle, last, include_middle_names, expected, transf
 
 
 @pytest.mark.parametrize(
-    "address,subject,reference,expected",
+    "address, subject, reference, expected",
     (
         (
             "test@email.com",
@@ -333,7 +333,7 @@ def test_telephone_number_link(transformer):
 
 
 @pytest.mark.parametrize(
-    "item_list,expected",
+    "item_list, expected",
     (
         (["Alice Aardvark", "Bob Berty Brown", "Dave Dixon Davies"], 3),
         ([], 0),
@@ -345,7 +345,7 @@ def test_list_item_count(item_list, expected, transformer):
 
 
 @pytest.mark.parametrize(
-    "ref_date,weeks_prior,day_range,first_day_of_week,expected",
+    "ref_date, weeks_prior, day_range, first_day_of_week, expected",
     [
         # All weekdays as reference date
         ("2021-09-26", -1, 7, "MONDAY", ("2021-09-13", "2021-09-19")),
@@ -415,7 +415,7 @@ def test_date_range_bounds_kwarg_default_monday(transformer):
 
 
 @pytest.mark.parametrize(
-    "date_range,expected",
+    "date_range, expected",
     [
         (
             ("2021-09-01", "2021-09-15"),
@@ -441,7 +441,7 @@ def test_format_date_range(transformer, date_range, expected):
 
 
 @pytest.mark.parametrize(
-    "answer_id,value,expected",
+    "answer_id, value, expected",
     [
         (
             "mandatory-radio-answer",

--- a/tests/app/questionnaire/test_plural_forms.py
+++ b/tests/app/questionnaire/test_plural_forms.py
@@ -4,7 +4,7 @@ from app.questionnaire.plural_forms import DEFAULT_LANGUAGE_CODE, get_plural_for
 
 
 @pytest.mark.parametrize(
-    "count,language,expected",
+    "count, language, expected",
     (
         (1, DEFAULT_LANGUAGE_CODE, "one"),
         (0, DEFAULT_LANGUAGE_CODE, "other"),

--- a/tests/app/questionnaire/test_questionnaire_store_updater.py
+++ b/tests/app/questionnaire/test_questionnaire_store_updater.py
@@ -411,7 +411,7 @@ def get_answer_dependencies(for_list=None):
 
 
 @pytest.mark.parametrize(
-    "answer_id,answer_updated,answer_dependencies,expected_output",
+    "answer_id, answer_updated, answer_dependencies, expected_output",
     [
         (
             "total-employees-answer",

--- a/tests/app/questionnaire/test_when_rules.py
+++ b/tests/app/questionnaire/test_when_rules.py
@@ -15,7 +15,7 @@ from app.questionnaire.when_rules import (
 
 
 @pytest.mark.parametrize(
-    "when_rule,answers,expected",
+    "when_rule, answers, expected",
     (
         ({"value": "singleAnswer", "condition": "contains"}, ["singleAnswer"], True),
         (
@@ -100,7 +100,7 @@ def test_evaluate_rule(when_rule, answers, expected):
 
 
 @pytest.mark.parametrize(
-    "goto,answers,metadata,expected",
+    "goto, answers, metadata, expected",
     (
         (
             {
@@ -338,7 +338,7 @@ def test_go_to(
 
 
 @pytest.mark.parametrize(
-    "skip_conditions,answers,expected",
+    "skip_conditions, answers, expected",
     (
         (
             [
@@ -433,7 +433,7 @@ def test_skip_conditions(
 
 
 @pytest.mark.parametrize(
-    "when_rules,answers,expected",
+    "when_rules, answers, expected",
     (([{"id": "my_answers", "condition": "not set"}], {}, True),),
 )
 def test_evaluate_not_set_when_rules_should_return_true(
@@ -462,7 +462,7 @@ def test_evaluate_not_set_when_rules_should_return_true(
 
 
 @pytest.mark.parametrize(
-    "lhs_answer,comparison,rhs_answer,expected",
+    "lhs_answer, comparison, rhs_answer, expected",
     (
         ("medium", "equals", "medium", True),
         ("medium", "equals", "low", False),
@@ -523,7 +523,7 @@ def test_when_rule_comparing_answer_values(
 
 
 @pytest.mark.parametrize(
-    "list_item_id,expected",
+    "list_item_id, expected",
     (
         ("abc123", True),
         ("123abc", False),
@@ -579,7 +579,7 @@ def test_evaluate_when_rule_raises_if_bad_when_condition(
 
 
 @pytest.mark.parametrize(
-    "when_rules,expected",
+    "when_rules, expected",
     (
         ([{"list": "people", "condition": "less than", "value": 2}], True),
         ([{"list": "people", "condition": "equals", "value": 1}], True),
@@ -608,7 +608,7 @@ def test_evaluate_when_rule_with_list_rules(
 
 
 @pytest.mark.parametrize(
-    "routing_path,is_on_answer_path,expected",
+    "routing_path, is_on_answer_path, expected",
     (
         (
             RoutingPath(
@@ -716,7 +716,7 @@ def test_routing_ignores_answers_not_on_path(
 
 
 @pytest.mark.parametrize(
-    "when_rule_comparison_id,expected",
+    "when_rule_comparison_id, expected",
     (
         (
             "list_item_id",

--- a/tests/app/schema_loader/test_schema_loader.py
+++ b/tests/app/schema_loader/test_schema_loader.py
@@ -5,7 +5,7 @@ from app.utilities.schema import load_schema_from_name
 
 @pytest.mark.usefixtures("app")
 @pytest.mark.parametrize(
-    "schema_name,language_code",
+    "schema_name, language_code",
     (
         ("test_checkbox", None),
         ("test_dates", None),

--- a/tests/app/storage/test_encrypted_questionnaire_storage.py
+++ b/tests/app/storage/test_encrypted_questionnaire_storage.py
@@ -9,7 +9,7 @@ from tests.app.conftest import RESPONSE_EXPIRY
 
 @pytest.mark.usefixtures("app")
 @pytest.mark.parametrize(
-    "user_id,user_ik,pepper",
+    "user_id, user_ik, pepper",
     (
         (None, "key", "pepper"),
         ("1", None, "pepper"),

--- a/tests/app/storage/test_storage_encryption.py
+++ b/tests/app/storage/test_storage_encryption.py
@@ -5,7 +5,7 @@ from app.utilities.json import json_loads
 
 
 @pytest.mark.parametrize(
-    "user_id,user_ik,pepper",
+    "user_id, user_ik, pepper",
     (
         (None, "key", "pepper"),
         ("1", None, "pepper"),
@@ -18,7 +18,7 @@ def test_encrypted_storage_missing_required_args(user_id, user_ik, pepper):
 
 
 @pytest.mark.parametrize(
-    "storage1,storage2,storage3",
+    "storage1, storage2, storage3",
     (
         (
             ("user1", "user_ik_1", "pepper"),

--- a/tests/app/utilities/test_strings.py
+++ b/tests/app/utilities/test_strings.py
@@ -4,7 +4,7 @@ from app.utilities import strings
 
 
 @pytest.mark.parametrize(
-    "input_str,bytes_str",
+    "input_str, bytes_str",
     (
         ("abc", b"abc"),
         (b"def", b"def"),
@@ -17,7 +17,7 @@ def test_to_bytes(input_str, bytes_str):
 
 
 @pytest.mark.parametrize(
-    "input_str,bytes_str",
+    "input_str, bytes_str",
     (
         ("hij", "hij"),
         (b"klm", "klm"),


### PR DESCRIPTION
### What is the context of this PR?
This updates pytest parametrized arguments to contain spaces for readability (eq. `mandatory, years, months, valid, error` instead of `mandatory,years,months,valid,error`).

### How to review 
Check that all arguments are correctly formatted.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
