### PR TITLE
Add type hints to helpers

### DIFF
--- a/app/authentication/jti_claim_storage.py
+++ b/app/authentication/jti_claim_storage.py
@@ -4,7 +4,7 @@ from flask import current_app
 from structlog import get_logger
 
 from app.data_models.app_models import UsedJtiClaim
-from app.helpers.uuid_helper import is_valid_uuid
+from app.helpers.uuid_helper import is_valid_uuid4
 from app.storage.errors import ItemAlreadyExistsError
 
 logger = get_logger()
@@ -30,7 +30,7 @@ def use_jti_claim(jti_claim: str, expires_at: datetime) -> None:
     """
     if jti_claim is None:
         raise ValueError
-    if not is_valid_uuid(jti_claim):
+    if not is_valid_uuid4(jti_claim):
         logger.info("jti claim is invalid", jti_claim=jti_claim)
         raise TypeError
 

--- a/app/globals.py
+++ b/app/globals.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta, timezone
-from typing import Any, Mapping, Union
+from typing import Any, Mapping, Optional, Union
 
 from flask import current_app, g
 from flask import session as cookie_session
@@ -32,7 +32,7 @@ def get_questionnaire_store(user_id: str, user_ik: str) -> QuestionnaireStore:
     return store
 
 
-def get_session_store() -> Union[SessionStore, None]:
+def get_session_store() -> Optional[SessionStore]:
     if USER_IK not in cookie_session or EQ_SESSION_ID not in cookie_session:
         return None
 

--- a/app/helpers/address_lookup_api_helper.py
+++ b/app/helpers/address_lookup_api_helper.py
@@ -6,13 +6,13 @@ from jwcrypto import jwk, jwt
 from jwcrypto.common import base64url_encode
 
 
-def get_jwk_from_secret(secret):
+def get_jwk_from_secret(secret: str) -> jwk.JWK:
     return jwk.JWK(kty="oct", k=base64url_encode(secret.encode("utf-8")))
 
 
-def get_address_lookup_api_auth_token():
+def get_address_lookup_api_auth_token() -> str:
     if current_app.config["ADDRESS_LOOKUP_API_AUTH_ENABLED"]:
-        secret = current_app.eq["secret_store"].get_secret_by_name(
+        secret = current_app.eq["secret_store"].get_secret_by_name(  # type: ignore
             "ADDRESS_LOOKUP_API_AUTH_TOKEN_SECRET"
         )
         session_timeout = current_app.config["EQ_SESSION_TIMEOUT_SECONDS"]
@@ -31,5 +31,6 @@ def get_address_lookup_api_auth_token():
         )
         key = get_jwk_from_secret(secret)
         token.make_signed_token(key)
+        serialised_token: str = token.serialize()
 
-        return token.serialize()
+        return serialised_token

--- a/app/helpers/header_helpers.py
+++ b/app/helpers/header_helpers.py
@@ -1,6 +1,13 @@
-def get_span_and_trace(headers):
+from typing import Union
+
+from werkzeug.datastructures import EnvironHeaders
+
+
+def get_span_and_trace(
+    headers: EnvironHeaders,
+) -> Union[tuple[None, None], tuple[str, str]]:
     try:
-        trace, span = headers.get("X-Cloud-Trace-Context").split("/")
+        trace, span = headers.get("X-Cloud-Trace-Context").split("/")  # type: ignore
     except (ValueError, AttributeError):
         return None, None
 

--- a/app/helpers/language_helper.py
+++ b/app/helpers/language_helper.py
@@ -13,15 +13,13 @@ LANGUAGE_TEXT = {
 }
 
 
-def handle_language():
+def handle_language() -> None:
     session_store = get_session_store()
-    if session_store:
-        launch_language = (
-            session_store.session_data.launch_language_code or DEFAULT_LANGUAGE_CODE
-        )
+    if session_store and (session_data := session_store.session_data):
+        launch_language = session_data.launch_language_code or DEFAULT_LANGUAGE_CODE
         # pylint: disable=assigning-non-slot
         g.allowed_languages = get_allowed_languages(
-            session_store.session_data.schema_name, launch_language
+            session_data.schema_name, launch_language
         )
         request_language = request.args.get("language_code")
         if request_language and request_language in g.allowed_languages:

--- a/app/helpers/schema_helpers.py
+++ b/app/helpers/schema_helpers.py
@@ -1,10 +1,13 @@
 from functools import wraps
+from typing import Any, Callable
+
+from werkzeug.exceptions import Unauthorized
 
 from app.globals import get_session_store
 from app.utilities.schema import load_schema_from_session_data
 
 
-def with_schema(function):
+def with_schema(function: Callable) -> Any:
     """Adds the survey schema as the first argument to the function being wrapped.
     Use on flask request handlers or methods called by flask request handlers.
 
@@ -19,8 +22,12 @@ def with_schema(function):
     """
 
     @wraps(function)
-    def wrapped_function(*args, **kwargs):
-        session_data = get_session_store().session_data
+    def wrapped_function(*args: Any, **kwargs: Any) -> Any:
+        session_store = get_session_store()
+        if not session_store:
+            raise Unauthorized
+
+        session_data = session_store.session_data
         schema = load_schema_from_session_data(session_data)
         return function(schema, *args, **kwargs)
 

--- a/app/helpers/session_helpers.py
+++ b/app/helpers/session_helpers.py
@@ -1,18 +1,19 @@
 from functools import wraps
+from typing import Any, Callable, Mapping
 
 from flask_login import current_user
 
 from app.globals import get_questionnaire_store, get_session_store
 
 
-def with_questionnaire_store(function):
+def with_questionnaire_store(function: Callable) -> Any:
     """Adds the `questionnaire_store` as an argument, where the `current_user` is defined.
     Use on flask request handlers or methods called by flask request handlers.
 
     May error unless there is a `current_user`."""
 
     @wraps(function)
-    def wrapped_function(*args, **kwargs):
+    def wrapped_function(*args: tuple, **kwargs: Mapping) -> Any:
         questionnaire_store = get_questionnaire_store(
             current_user.user_id, current_user.user_ik
         )
@@ -21,13 +22,13 @@ def with_questionnaire_store(function):
     return wrapped_function
 
 
-def with_session_store(function):
+def with_session_store(function: Callable) -> Any:
     """Adds the `session_store` as an argument.
     Use on flask request handlers or methods called by flask request handlers.
     """
 
     @wraps(function)
-    def wrapped_function(*args, **kwargs):
+    def wrapped_function(*args: Any, **kwargs: Any) -> Any:
         session_store = get_session_store()
         return function(session_store, *args, **kwargs)
 

--- a/app/helpers/session_helpers.py
+++ b/app/helpers/session_helpers.py
@@ -1,5 +1,5 @@
 from functools import wraps
-from typing import Any, Callable, Mapping
+from typing import Any, Callable
 
 from flask_login import current_user
 

--- a/app/helpers/session_helpers.py
+++ b/app/helpers/session_helpers.py
@@ -13,7 +13,7 @@ def with_questionnaire_store(function: Callable) -> Any:
     May error unless there is a `current_user`."""
 
     @wraps(function)
-    def wrapped_function(*args: tuple, **kwargs: Mapping) -> Any:
+    def wrapped_function(*args: Any, **kwargs: Any) -> Any:
         questionnaire_store = get_questionnaire_store(
             current_user.user_id, current_user.user_ik
         )

--- a/app/helpers/url_safe_serializer.py
+++ b/app/helpers/url_safe_serializer.py
@@ -5,5 +5,5 @@ from itsdangerous import URLSafeSerializer
 from app.settings import EQ_SESSION_ID
 
 
-def url_safe_serializer():
+def url_safe_serializer() -> URLSafeSerializer:
     return URLSafeSerializer(current_app.secret_key, salt=cookie_session[EQ_SESSION_ID])

--- a/app/helpers/uuid_helper.py
+++ b/app/helpers/uuid_helper.py
@@ -1,11 +1,9 @@
 from uuid import UUID
 
-DEFAULT_UUID_VERSION = 4
 
-
-def is_valid_uuid(uuid_string: str, version: int = DEFAULT_UUID_VERSION) -> bool:
+def is_valid_uuid4(uuid_string: str) -> bool:
     try:
-        UUID(uuid_string, version=version)
+        UUID(uuid_string, version=4)
     except ValueError:
         return False
     return True

--- a/app/helpers/uuid_helper.py
+++ b/app/helpers/uuid_helper.py
@@ -1,7 +1,9 @@
 from uuid import UUID
 
+DEFAULT_UUID_VERSION = 4
 
-def is_valid_uuid(uuid_string: str, version: int = 4) -> bool:
+
+def is_valid_uuid(uuid_string: str, version: int = DEFAULT_UUID_VERSION) -> bool:
     try:
         UUID(uuid_string, version=version)
     except ValueError:

--- a/app/helpers/uuid_helper.py
+++ b/app/helpers/uuid_helper.py
@@ -1,7 +1,7 @@
 from uuid import UUID
 
 
-def is_valid_uuid(uuid_string, version=4):
+def is_valid_uuid(uuid_string: str, version: int = 4) -> bool:
     try:
         UUID(uuid_string, version=version)
     except ValueError:

--- a/mypy.ini
+++ b/mypy.ini
@@ -11,7 +11,7 @@ disallow_untyped_defs = True
 warn_return_any = True
 no_implicit_optional = True
 
-[mypy-app.helpers.template_helpers]
+[mypy-app.helpers.*]
 disallow_untyped_defs = True
 warn_return_any = True
 no_implicit_optional = True

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -1,3 +1,5 @@
+# pylint: disable=redefined-outer-name
+
 from datetime import datetime, timedelta, timezone
 
 import fakeredis
@@ -70,15 +72,17 @@ def expires_at():
 
 
 @pytest.fixture(name="session_store")
-def fixture_session_store():
-    return SessionStore("user_ik", "pepper", "eq_session_id")
+def fixture_session_store(session_data):
+    session_store = SessionStore("user_ik", "pepper", "eq_session_id")
+    session_store.session_data = session_data
+    return session_store
 
 
 @pytest.fixture
 def session_data():
     return SessionData(
         tx_id="tx_id",
-        schema_name="some_schema_name",
+        schema_name="test_checkbox",
         period_str="period_str",
         language_code=None,
         launch_language_code=None,

--- a/tests/app/data_model/test_fulfilment_request.py
+++ b/tests/app/data_model/test_fulfilment_request.py
@@ -4,7 +4,7 @@ from typing import Mapping
 from freezegun import freeze_time
 
 from app.data_models import FulfilmentRequest
-from app.helpers.uuid_helper import is_valid_uuid
+from app.helpers.uuid_helper import is_valid_uuid4
 from app.utilities.json import json_loads
 
 time_to_freeze = datetime.now(timezone.utc).replace(second=0, microsecond=0)
@@ -23,7 +23,7 @@ def test_fulfilment_request_message():
     json_message = json_loads(fulfilment_request.message)
 
     transaction_id = json_message["event"].pop("transactionId")
-    assert is_valid_uuid(transaction_id, version=4) is True
+    assert is_valid_uuid4(transaction_id) is True
 
     expected_json_message = {
         "event": {

--- a/tests/app/helpers/conftest.py
+++ b/tests/app/helpers/conftest.py
@@ -1,3 +1,5 @@
+# pylint: disable=redefined-outer-name
+
 from datetime import datetime, timezone
 
 import pytest

--- a/tests/app/helpers/conftest.py
+++ b/tests/app/helpers/conftest.py
@@ -1,5 +1,9 @@
+from datetime import datetime, timezone
+
+import pytest
 from pytest import fixture
 
+from app.data_models import SessionData, SessionStore
 from app.helpers.template_helpers import ContextHelper
 
 
@@ -192,3 +196,28 @@ def expected_footer_nisra_theme():
             "alt": "NISRA - Northern Ireland Statistics and Research Agency",
         },
     }
+
+
+@pytest.fixture()
+def session_data():
+    return SessionData(
+        tx_id="123",
+        schema_name="test_checkbox",
+        display_address="68 Abingdon Road, Goathill",
+        period_str=None,
+        language_code="cy",
+        launch_language_code="en",
+        survey_url=None,
+        ru_name=None,
+        ru_ref=None,
+        submitted_at=datetime.now(timezone.utc).isoformat(),
+        response_id="321",
+        case_id="789",
+    )
+
+
+@pytest.fixture()
+def session_store(session_data):
+    store = SessionStore("user_ik", "pepper", "eq_session_id")
+    store.session_data = session_data
+    return store

--- a/tests/app/helpers/conftest.py
+++ b/tests/app/helpers/conftest.py
@@ -1,11 +1,5 @@
-# pylint: disable=redefined-outer-name
-
-from datetime import datetime, timezone
-
-import pytest
 from pytest import fixture
 
-from app.data_models import SessionData, SessionStore
 from app.helpers.template_helpers import ContextHelper
 
 
@@ -198,28 +192,3 @@ def expected_footer_nisra_theme():
             "alt": "NISRA - Northern Ireland Statistics and Research Agency",
         },
     }
-
-
-@pytest.fixture()
-def session_data():
-    return SessionData(
-        tx_id="123",
-        schema_name="test_checkbox",
-        display_address="68 Abingdon Road, Goathill",
-        period_str=None,
-        language_code="cy",
-        launch_language_code="en",
-        survey_url=None,
-        ru_name=None,
-        ru_ref=None,
-        submitted_at=datetime.now(timezone.utc).isoformat(),
-        response_id="321",
-        case_id="789",
-    )
-
-
-@pytest.fixture()
-def session_store(session_data):
-    store = SessionStore("user_ik", "pepper", "eq_session_id")
-    store.session_data = session_data
-    return store

--- a/tests/app/helpers/test_address_lookup_api_helper.py
+++ b/tests/app/helpers/test_address_lookup_api_helper.py
@@ -6,7 +6,7 @@ from jwcrypto import jwt
 
 from app.helpers import get_address_lookup_api_auth_token
 from app.helpers.address_lookup_api_helper import get_jwk_from_secret
-from app.helpers.uuid_helper import is_valid_uuid
+from app.helpers.uuid_helper import is_valid_uuid4
 from app.utilities.json import json_loads
 
 TIME_TO_FREEZE = datetime.now(timezone.utc).replace(second=0, microsecond=0)
@@ -32,4 +32,4 @@ def test_get_address_lookup_api_auth_token(app: Flask):
 
         assert claims["iss"] == "eq"
         assert claims["exp"] == expiry_time
-        assert is_valid_uuid(claims["jti"])
+        assert is_valid_uuid4(claims["jti"])

--- a/tests/app/helpers/test_schema_helper.py
+++ b/tests/app/helpers/test_schema_helper.py
@@ -1,0 +1,29 @@
+import pytest
+from werkzeug.exceptions import Unauthorized
+
+from app.helpers.schema_helpers import with_schema
+from app.questionnaire import QuestionnaireSchema
+
+
+@pytest.mark.usefixtures("app")
+def test_questionnaire_schema_passed_into_function(mocker, session_store):
+    mocker.patch(
+        "app.helpers.schema_helpers.get_session_store",
+        return_value=session_store,
+    )
+
+    mock_callable = mocker.Mock()
+    func = with_schema(mock_callable)
+
+    func()
+
+    assert isinstance(mock_callable.call_args.args[0], QuestionnaireSchema)
+
+
+@pytest.mark.usefixtures("app")
+def test_no_session_store_raises_unauthorised_exception(mocker):
+    mock_callable = mocker.Mock()
+    func = with_schema(mock_callable)
+
+    with pytest.raises(Unauthorized):
+        assert func()

--- a/tests/app/libs/test_utils.py
+++ b/tests/app/libs/test_utils.py
@@ -1,9 +1,9 @@
-from app.helpers.uuid_helper import is_valid_uuid
+from app.helpers.uuid_helper import is_valid_uuid4
 from app.libs.utils import convert_tx_id
 
 
 def test_convert_tx_id():
     tx_id_to_convert = "bc26d5ef-8475-4710-ac82-753a0a150708"
 
-    assert is_valid_uuid(tx_id_to_convert)
+    assert is_valid_uuid4(tx_id_to_convert)
     assert convert_tx_id(tx_id_to_convert) == "BC26 - D5EF - 8475 - 4710"

--- a/tests/app/views/handlers/test_individual_response_fulfilment_request.py
+++ b/tests/app/views/handlers/test_individual_response_fulfilment_request.py
@@ -5,7 +5,7 @@ import pytest
 from freezegun import freeze_time
 
 from app.forms.validators import sanitise_mobile_number
-from app.helpers.uuid_helper import is_valid_uuid
+from app.helpers.uuid_helper import is_valid_uuid4
 from app.utilities.json import json_loads
 from app.views.handlers.individual_response import (
     GB_ENG_REGION_CODE,
@@ -59,8 +59,8 @@ def validate_uuids_in_payload(payload):
     individual_case_id = payload["fulfilmentRequest"].pop("individualCaseId")
     case_id = payload["fulfilmentRequest"].pop("caseId")
 
-    assert is_valid_uuid(individual_case_id, version=4) is True
-    assert is_valid_uuid(case_id, version=4) is True
+    assert is_valid_uuid4(individual_case_id) is True
+    assert is_valid_uuid4(case_id) is True
 
 
 @freeze_time(datetime.now(tz=timezone.utc).isoformat())


### PR DESCRIPTION
### What is the context of this PR?
Added type hints to the helpers module.

### How to review 
Ensure the type annotations are accurate.

Note: Decorator type hints return `Any` due to a lack of support by the language. It has been improved in Py 3.10, therefore, we can properly type check decorators once we are on Py 3.10 using [ParamSpec]( https://peps.python.org/pep-0612/).

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
