### PR TITLE
Answer dependencies for min and max validation

### DIFF
--- a/app/questionnaire/questionnaire_schema.py
+++ b/app/questionnaire/questionnaire_schema.py
@@ -249,9 +249,9 @@ class QuestionnaireSchema:  # pylint: disable=too-many-public-methods
                             )
 
     def _update_answer_dependencies_for_calculated_summary(
-        self, answer_ids: list[str], block_id: str
+        self, calculated_summary_answer_ids: list[str], block_id: str
     ) -> None:
-        for answer_id in answer_ids:
+        for answer_id in calculated_summary_answer_ids:
             self._answer_dependencies_map[answer_id] |= {
                 self._get_answer_dependent_for_block_id(block_id)
             }
@@ -275,10 +275,9 @@ class QuestionnaireSchema:  # pylint: disable=too-many-public-methods
         self, answer: Mapping, block_id: str
     ) -> None:
         for key in ["minimum", "maximum"]:
-            if answer.get(key) and isinstance(answer[key]["value"], dict):
-                self._update_answer_dependencies_for_value_source(
-                    answer[key]["value"], block_id
-                )
+            value = answer.get(key, {}).get("value")
+            if isinstance(value, dict):
+                self._update_answer_dependencies_for_value_source(value, block_id)
 
     def _update_answer_dependencies_for_value_source(
         self, value_source: dict, block_id: str

--- a/app/questionnaire/questionnaire_schema.py
+++ b/app/questionnaire/questionnaire_schema.py
@@ -280,7 +280,7 @@ class QuestionnaireSchema:  # pylint: disable=too-many-public-methods
                 self._update_answer_dependencies_for_value_source(value, block_id)
 
     def _update_answer_dependencies_for_value_source(
-        self, value_source: dict, block_id: str
+        self, value_source: Mapping, block_id: str
     ) -> None:
         if value_source["source"] == "answers":
             self._answer_dependencies_map[value_source["identifier"]] |= {

--- a/app/questionnaire/questionnaire_schema.py
+++ b/app/questionnaire/questionnaire_schema.py
@@ -229,7 +229,7 @@ class QuestionnaireSchema:  # pylint: disable=too-many-public-methods
     def _populate_answer_dependencies(self) -> None:
         for block in self.get_blocks():
             if block["type"] == "CalculatedSummary":
-                self._update_answer_dependencies_for_answers(
+                self._update_answer_dependencies_for_calculated_summary(
                     block["calculation"]["answers_to_calculate"], block["id"]
                 )
                 continue
@@ -238,16 +238,23 @@ class QuestionnaireSchema:  # pylint: disable=too-many-public-methods
                     self._update_answer_dependencies_for_calculations(
                         question["calculations"],
                     )
+                    continue
 
-    def _get_answer_dependent_for_block_id(self, block_id: str) -> AnswerDependent:
-        section_id: str = self.get_section_id_for_block_id(block_id)  # type: ignore
-        for_list = self.get_repeating_list_for_section(section_id)
+                for answer in question.get("answers", []):
+                    self._update_answer_dependencies_for_min_max(answer, block["id"])
+                    for option in answer.get("options", []):
+                        if "detail_answer" in option:
+                            self._update_answer_dependencies_for_min_max(
+                                option["detail_answer"], block["id"]
+                            )
 
-        return AnswerDependent(
-            block_id=block_id,
-            section_id=section_id,
-            for_list=for_list,
-        )
+    def _update_answer_dependencies_for_calculated_summary(
+        self, answer_ids: list[str], block_id: str
+    ) -> None:
+        for answer_id in answer_ids:
+            self._answer_dependencies_map[answer_id] |= {
+                self._get_answer_dependent_for_block_id(block_id)
+            }
 
     def _update_answer_dependencies_for_calculations(
         self,
@@ -264,13 +271,32 @@ class QuestionnaireSchema:  # pylint: disable=too-many-public-methods
             }
             self._answer_dependencies_map[source_answer_id] |= dependents
 
-    def _update_answer_dependencies_for_answers(
-        self, answer_ids: list[str], block_id: str
+    def _update_answer_dependencies_for_min_max(
+        self, answer: Mapping, block_id: str
     ) -> None:
-        for answer_id in answer_ids:
-            self._answer_dependencies_map[answer_id] |= {
-                self._get_answer_dependent_for_block_id(block_id)
+        for key in ["minimum", "maximum"]:
+            if answer.get(key) and isinstance(answer[key]["value"], dict):
+                self._update_answer_dependencies_for_value_source(
+                    answer[key]["value"], block_id
+                )
+
+    def _update_answer_dependencies_for_value_source(
+        self, value_source: dict, block_id: str
+    ) -> None:
+        if value_source["source"] == "answers":
+            self._answer_dependencies_map[value_source["identifier"]] |= {
+                self._get_answer_dependent_for_block_id(block_id)  # type: ignore
             }
+
+    def _get_answer_dependent_for_block_id(self, block_id: str) -> AnswerDependent:
+        section_id: str = self.get_section_id_for_block_id(block_id)  # type: ignore
+        for_list = self.get_repeating_list_for_section(section_id)
+
+        return AnswerDependent(
+            block_id=block_id,
+            section_id=section_id,
+            for_list=for_list,
+        )
 
     def _get_flattened_questions(self) -> list[ImmutableDict[str, Any]]:
         return [

--- a/schemas/test/en/test_numbers.json
+++ b/schemas/test/en/test_numbers.json
@@ -290,6 +290,67 @@
                                 "title": "Please enter test values (none mandatory)",
                                 "type": "General"
                             }
+                        },
+                        {
+                            "type": "Question",
+                            "id": "detail-answer-block",
+                            "question": {
+                                "answers": [
+                                    {
+                                        "id": "detail-answer",
+                                        "label": {
+                                            "text": "Less or equal than {maximum}",
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "maximum",
+                                                    "transforms": [
+                                                        {
+                                                            "transform": "format_number",
+                                                            "arguments": {
+                                                                "number": {
+                                                                    "source": "answers",
+                                                                    "identifier": "set-maximum"
+                                                                }
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "mandatory": true,
+                                        "options": [
+                                            {
+                                                "label": "1",
+                                                "value": "1"
+                                            },
+                                            {
+                                                "label": "2",
+                                                "value": "2"
+                                            },
+                                            {
+                                                "label": "Other",
+                                                "value": "Other",
+                                                "detail_answer": {
+                                                    "mandatory": false,
+                                                    "id": "other-answer",
+                                                    "label": "Please specify other",
+                                                    "type": "Number",
+                                                    "maximum": {
+                                                        "value": {
+                                                            "source": "answers",
+                                                            "identifier": "set-maximum"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ],
+                                        "type": "Radio"
+                                    }
+                                ],
+                                "id": "detail-answer-question",
+                                "title": "Please enter test values for detail answer",
+                                "type": "General"
+                            }
                         }
                     ],
                     "id": "test"

--- a/schemas/test/en/test_numbers.json
+++ b/schemas/test/en/test_numbers.json
@@ -298,25 +298,6 @@
                                 "answers": [
                                     {
                                         "id": "detail-answer",
-                                        "label": {
-                                            "text": "Less or equal than {maximum}",
-                                            "placeholders": [
-                                                {
-                                                    "placeholder": "maximum",
-                                                    "transforms": [
-                                                        {
-                                                            "transform": "format_number",
-                                                            "arguments": {
-                                                                "number": {
-                                                                    "source": "answers",
-                                                                    "identifier": "set-maximum"
-                                                                }
-                                                            }
-                                                        }
-                                                    ]
-                                                }
-                                            ]
-                                        },
                                         "mandatory": true,
                                         "options": [
                                             {
@@ -344,11 +325,29 @@
                                                 }
                                             }
                                         ],
-                                        "type": "Radio"
+                                        "type": "Checkbox"
                                     }
                                 ],
                                 "id": "detail-answer-question",
-                                "title": "Please enter test values for detail answer",
+                                "title": {
+                                    "text": "Please enter test values for detail answer Less or equal than {maximum}",
+                                    "placeholders": [
+                                        {
+                                            "placeholder": "maximum",
+                                            "transforms": [
+                                                {
+                                                    "transform": "format_number",
+                                                    "arguments": {
+                                                        "number": {
+                                                            "source": "answers",
+                                                            "identifier": "set-maximum"
+                                                        }
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
                                 "type": "General"
                             }
                         }

--- a/tests/app/questionnaire/conftest.py
+++ b/tests/app/questionnaire/conftest.py
@@ -1157,3 +1157,8 @@ def calculated_question_with_dependent_sections_schema_repeating():
 @pytest.fixture
 def calculated_summary_schema():
     return load_schema_from_name("test_calculated_summary")
+
+
+@pytest.fixture
+def numbers_schema():
+    return load_schema_from_name("test_numbers")

--- a/tests/app/questionnaire/test_questionnaire_schema.py
+++ b/tests/app/questionnaire/test_questionnaire_schema.py
@@ -561,3 +561,32 @@ def test_answer_dependencies_for_calculated_summary(
     }
 
     assert schema.answer_dependencies == expected_dependencies
+
+
+def test_answer_dependencies_for_min_max(numbers_schema):
+    schema = numbers_schema
+
+    assert schema.answer_dependencies == {
+        "set-minimum": {
+            AnswerDependent(
+                section_id="default-section",
+                block_id="test-min-max-block",
+                for_list=None,
+                answer_id=None,
+            )
+        },
+        "set-maximum": {
+            AnswerDependent(
+                section_id="default-section",
+                block_id="detail-answer-block",
+                for_list=None,
+                answer_id=None,
+            ),
+            AnswerDependent(
+                section_id="default-section",
+                block_id="test-min-max-block",
+                for_list=None,
+                answer_id=None,
+            ),
+        },
+    }

--- a/tests/functional/spec/numbers.spec.js
+++ b/tests/functional/spec/numbers.spec.js
@@ -66,7 +66,7 @@ describe("Number validation", () => {
       expect(browser.getUrl()).to.contain(SubmitPage.pageName);
     });
 
-    it("When I edit and change a question which has dependent answer, Then I must re-answer if required and re-submit before I can return to the summary", () => {
+    it("When I edit and change the maximum value, Then I must re-validate and submit any dependent answers before I can return to the summary", () => {
       $(SubmitPage.setMaximumEdit()).click();
       $(SetMinMax.setMaximum()).setValue("1019");
       $(SetMinMax.submit()).click();
@@ -77,6 +77,20 @@ describe("Number validation", () => {
 
       $(DetailAnswer.otherDetail()).setValue("1019");
       $(DetailAnswer.submit()).click();
+
+      expect(browser.getUrl()).to.contain(SubmitPage.pageName);
+    });
+
+    it("When I edit and change the minimum value, Then I must re-validate and submit any dependent answers again before I can return to the summary", () => {
+      $(SubmitPage.setMinimumEdit()).click();
+      $(SetMinMax.setMinimum()).setValue("11");
+      $(SetMinMax.submit()).click();
+      $(TestMinMax.submit()).click();
+
+      expect($(TestMinMax.errorNumber(1)).getText()).to.contain("Enter an answer more than 11");
+
+      $(TestMinMax.testRangeExclusive()).setValue("12");
+      $(TestMinMax.submit()).click();
 
       expect(browser.getUrl()).to.contain(SubmitPage.pageName);
     });

--- a/tests/functional/spec/numbers.spec.js
+++ b/tests/functional/spec/numbers.spec.js
@@ -1,62 +1,85 @@
 import SetMinMax from "../generated_pages/numbers/set-min-max-block.page.js";
 import TestMinMax from "../generated_pages/numbers/test-min-max-block.page.js";
+import DetailAnswer from "../generated_pages/numbers/detail-answer-block.page";
 import SubmitPage from "../generated_pages/numbers/submit.page";
 
-describe("NumericRange", () => {
-  const numberSchema = "test_numbers.json";
-
-  beforeEach(() => {
-    browser.openQuestionnaire(numberSchema);
+describe("Number validation", () => {
+  before(() => {
+    browser.openQuestionnaire("test_numbers.json");
   });
+  describe("Given I am completing the test numbers questionnaire,", () => {
 
-  it("Answer labels should have descriptions displayed", () => {
-    expect($(SetMinMax.setMinimumLabelDescription()).getText()).to.contain("This is a description of the minimum value");
-    expect($(SetMinMax.setMaximumLabelDescription()).getText()).to.contain("This is a description of the maximum value");
-  });
+    it("When I am on the set minimum and maximum page, Then each field has a label", () => {
+      expect($(SetMinMax.setMinimumLabelDescription()).getText()).to.contain("This is a description of the minimum value");
+      expect($(SetMinMax.setMaximumLabelDescription()).getText()).to.contain("This is a description of the maximum value");
+    });
 
-  it("Given a max and min set, a user should be able to complete the survey obeying those ranges", () => {
-    $(SetMinMax.setMinimum()).setValue("10");
-    $(SetMinMax.setMaximum()).setValue("1020");
-    $(SetMinMax.submit()).click();
-    $(TestMinMax.testRange()).setValue("10");
-    $(TestMinMax.testMin()).setValue("123");
-    $(TestMinMax.testMax()).setValue("456");
-    $(TestMinMax.testPercent()).setValue("100");
-    $(TestMinMax.submit()).click();
-    expect(browser.getUrl()).to.contain(SubmitPage.pageName);
-  });
+    it("When I enter values outside of the set range, Then the correct error messages are displayed", () => {
+      $(SetMinMax.setMinimum()).setValue("10");
+      $(SetMinMax.setMaximum()).setValue("1020");
+      $(SetMinMax.submit()).click();
 
-  it("Given values outside of the allowed range then the correct error messages are displayed", () => {
-    $(SetMinMax.setMinimum()).setValue("10");
-    $(SetMinMax.setMaximum()).setValue("1020");
-    $(SetMinMax.submit()).click();
-    $(TestMinMax.testRange()).setValue("9");
-    $(TestMinMax.testRangeExclusive()).setValue("10");
-    $(TestMinMax.testMin()).setValue("0");
-    $(TestMinMax.testMax()).setValue("12345");
-    $(TestMinMax.testMinExclusive()).setValue("123");
-    $(TestMinMax.testMaxExclusive()).setValue("12345");
-    $(TestMinMax.testPercent()).setValue("101");
-    $(TestMinMax.testDecimal()).setValue("5.4");
-    $(TestMinMax.submit()).click();
-    expect($(TestMinMax.errorNumber(1)).getText()).to.contain("Enter an answer more than or equal to 10");
-    expect($(TestMinMax.errorNumber(2)).getText()).to.contain("Enter an answer more than 10");
-    expect($(TestMinMax.errorNumber(3)).getText()).to.contain("Enter an answer more than or equal to 123");
-    expect($(TestMinMax.errorNumber(4)).getText()).to.contain("Enter an answer less than or equal to 1,234");
-    expect($(TestMinMax.errorNumber(5)).getText()).to.contain("Enter an answer more than 123");
-    expect($(TestMinMax.errorNumber(6)).getText()).to.contain("Enter an answer less than 1,234");
-    expect($(TestMinMax.errorNumber(7)).getText()).to.contain("Enter an answer less than or equal to 100");
-    expect($(TestMinMax.errorNumber(8)).getText()).to.contain("Enter an answer more than or equal to £10.00");
-  });
+      $(TestMinMax.testRange()).setValue("9");
+      $(TestMinMax.testRangeExclusive()).setValue("10");
+      $(TestMinMax.testMin()).setValue("0");
+      $(TestMinMax.testMax()).setValue("12345");
+      $(TestMinMax.testMinExclusive()).setValue("123");
+      $(TestMinMax.testMaxExclusive()).setValue("12345");
+      $(TestMinMax.testPercent()).setValue("101");
+      $(TestMinMax.testDecimal()).setValue("5.4");
+      $(TestMinMax.submit()).click();
 
-  it("Given values outside of the allowed decimal places then the correct error messages are displayed", () => {
-    $(SetMinMax.setMinimum()).setValue("10");
-    $(SetMinMax.setMaximum()).setValue("1020");
-    $(SetMinMax.submit()).click();
-    $(TestMinMax.testRange()).setValue("12.344");
-    $(TestMinMax.testDecimal()).setValue("11.234");
-    $(TestMinMax.submit()).click();
-    expect($(TestMinMax.errorNumber(1)).getText()).to.contain("Enter a number rounded to 2 decimal places");
-    expect($(TestMinMax.errorNumber(2)).getText()).to.contain("Enter a number rounded to 2 decimal places");
+      expect($(TestMinMax.errorNumber(1)).getText()).to.contain("Enter an answer more than or equal to 10");
+      expect($(TestMinMax.errorNumber(2)).getText()).to.contain("Enter an answer more than 10");
+      expect($(TestMinMax.errorNumber(3)).getText()).to.contain("Enter an answer more than or equal to 123");
+      expect($(TestMinMax.errorNumber(4)).getText()).to.contain("Enter an answer less than or equal to 1,234");
+      expect($(TestMinMax.errorNumber(5)).getText()).to.contain("Enter an answer more than 123");
+      expect($(TestMinMax.errorNumber(6)).getText()).to.contain("Enter an answer less than 1,234");
+      expect($(TestMinMax.errorNumber(7)).getText()).to.contain("Enter an answer less than or equal to 100");
+      expect($(TestMinMax.errorNumber(8)).getText()).to.contain("Enter an answer more than or equal to £10.00");
+    });
+
+    it("When I enter values inside the set range but provide too many decimal places, Then the correct error messages are displayed", () => {
+      $(TestMinMax.testRange()).setValue("1020");
+      $(TestMinMax.testRangeExclusive()).setValue("11");
+      $(TestMinMax.testMin()).setValue("123");
+      $(TestMinMax.testMax()).setValue("1019");
+      $(TestMinMax.testMinExclusive()).setValue("124");
+      $(TestMinMax.testMaxExclusive()).setValue("1233");
+      $(TestMinMax.testPercent()).setValue("100");
+      $(TestMinMax.testRange()).setValue("12.344");
+      $(TestMinMax.testDecimal()).setValue("11.234");
+      $(TestMinMax.submit()).click();
+
+      expect($(TestMinMax.errorNumber(1)).getText()).to.contain("Enter a number rounded to 2 decimal places");
+      expect($(TestMinMax.errorNumber(2)).getText()).to.contain("Enter a number rounded to 2 decimal places");
+    });
+
+    it("When I enter values inside the set range, Then I should be able to submit the survey", () => {
+      $(TestMinMax.testRange()).setValue("12");
+      $(TestMinMax.testDecimal()).setValue("11.23");
+      $(TestMinMax.testPercent()).setValue("99");
+      $(TestMinMax.submit()).click();
+      $(DetailAnswer.other()).click();
+      $(DetailAnswer.otherDetail()).setValue("1020");
+      $(DetailAnswer.submit()).click();
+
+      expect(browser.getUrl()).to.contain(SubmitPage.pageName);
+    });
+
+    it("When I edit and change a question which has dependent answer, Then I must re-answer if required and re-submit before I can return to the summary", () => {
+      $(SubmitPage.setMaximumEdit()).click();
+      $(SetMinMax.setMaximum()).setValue("1019");
+      $(SetMinMax.submit()).click();
+      $(TestMinMax.submit()).click();
+      $(DetailAnswer.submit()).click();
+
+      expect($(DetailAnswer.errorNumber(1)).getText()).to.contain("Enter an answer less than or equal to 1,019");
+
+      $(DetailAnswer.otherDetail()).setValue("1019");
+      $(DetailAnswer.submit()).click();
+
+      expect(browser.getUrl()).to.contain(SubmitPage.pageName);
+    });
   });
 });

--- a/tests/functional/spec/numbers.spec.js
+++ b/tests/functional/spec/numbers.spec.js
@@ -8,7 +8,6 @@ describe("Number validation", () => {
     browser.openQuestionnaire("test_numbers.json");
   });
   describe("Given I am completing the test numbers questionnaire,", () => {
-
     it("When I am on the set minimum and maximum page, Then each field has a label", () => {
       expect($(SetMinMax.setMinimumLabelDescription()).getText()).to.contain("This is a description of the minimum value");
       expect($(SetMinMax.setMaximumLabelDescription()).getText()).to.contain("This is a description of the maximum value");

--- a/tests/functional/spec/save_sign_out.spec.js
+++ b/tests/functional/spec/save_sign_out.spec.js
@@ -1,5 +1,6 @@
 import SetMinMax from "../generated_pages/numbers/set-min-max-block.page.js";
 import TestMinMax from "../generated_pages/numbers/test-min-max-block.page.js";
+import DetailAnswer from "../generated_pages/numbers/detail-answer-block.page";
 import SubmitPage from "../generated_pages/numbers/submit.page";
 import IntroductionPage from "../generated_pages/introduction/introduction.page";
 import IntroInterstitialPage from "../generated_pages/introduction/general-business-information-completed.page";
@@ -41,6 +42,8 @@ describe("Save sign out / Exit", () => {
     $(TestMinMax.testMax()).setValue("1000");
     $(TestMinMax.testPercent()).setValue("100");
     $(TestMinMax.submit()).click();
+    $(DetailAnswer.answer1()).click();
+    $(DetailAnswer.submit()).click();
 
     $(SubmitPage.submit()).click();
     expect(browser.getUrl()).to.contain("thank-you");


### PR DESCRIPTION
### What is the context of this PR?
This PR adds answer dependencies for min and max validation

### How to review 
Using test_numbers.json, complete the survey then go back and change set min/max (first block). Make sure you have to confirm/validate any answers again that have dependencies before going back to summary, the best one to change is max as it has dependencies on the other 2 blocks in the questionnaire

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
