### PR TITLE
Fix save and continue button spacing

### DIFF
--- a/templates/layouts/_questionnaire.html
+++ b/templates/layouts/_questionnaire.html
@@ -25,7 +25,6 @@
           onsButton({
               "submitType": "timer",
               "text": continue_button_text | default(_("Save and continue")),
-              "classes": "ons-u-mt-xl",
               "attributes": {
                   "data-qa": "btn-submit"
               }

--- a/templates/partials/email-form.html
+++ b/templates/partials/email-form.html
@@ -26,9 +26,9 @@
     "description": _("This will not be stored and only used once to send your confirmation")
   },
   "attributes": {
-  "data-qa": "input-text",
+    "data-qa": "input-text",
   },
-  "error": error
+    "error": error
   }
 %}
 
@@ -38,7 +38,7 @@
   onsButton({
     "text": _("Send confirmation"),
     "submitType": 'timer',
-    "classes": "ons-u-mt-s ons-u-mb-xl",
+    "classes": "ons-u-mt-s",
     "attributes": {
       "data-qa": "btn-submit"
     }

--- a/tests/functional/spec/features/validation/date_validation/date-combined-yyyy.spec.js
+++ b/tests/functional/spec/features/validation/date_validation/date-combined-yyyy.spec.js
@@ -8,7 +8,7 @@ describe("Feature: Combined question level and single validation for MM-YYYY dat
 
   describe("Period Validation", () => {
     describe("Given I enter dates", () => {
-      it("When I enter a single dates that are too early/late, Then I should see single validation errors", () => {
+      it("When I enter dates that are too early and too late, Then I should see two validation errors", () => {
         $(DateRangePage.dateRangeFromYear()).setValue(2015);
         $(DateRangePage.dateRangeToYear()).setValue(2021);
         $(DateRangePage.submit()).click();

--- a/tests/functional/spec/features/validation/date_validation/date-combined-yyyy.spec.js
+++ b/tests/functional/spec/features/validation/date_validation/date-combined-yyyy.spec.js
@@ -9,7 +9,7 @@ describe("Feature: Combined question level and single validation for MM-YYYY dat
   describe("Period Validation", () => {
     describe("Given I enter dates", () => {
       it("When I enter a single dates that are too early/late, Then I should see single validation errors", () => {
-        $(DateRangePage.dateRangeFromYear()).setValue(2014);
+        $(DateRangePage.dateRangeFromYear()).setValue(2015);
         $(DateRangePage.dateRangeToYear()).setValue(2021);
         $(DateRangePage.submit()).click();
         expect($(DateRangePage.errorNumber(1)).getText()).to.contain("Enter a date after 2015");
@@ -17,8 +17,8 @@ describe("Feature: Combined question level and single validation for MM-YYYY dat
       });
 
       it("When I enter a range too large, Then I should see a range validation error", () => {
-        $(DateRangePage.dateRangeFromYear()).setValue(2015);
-        $(DateRangePage.dateRangeToYear()).setValue(2019);
+        $(DateRangePage.dateRangeFromYear()).setValue(2016);
+        $(DateRangePage.dateRangeToYear()).setValue(2020);
         $(DateRangePage.submit()).click();
         expect($(DateRangePage.errorNumber(1)).getText()).to.contain("Enter a reporting period less than or equal to 3 years");
       });

--- a/tests/functional/spec/features/validation/date_validation/date-combined-yyyy.spec.js
+++ b/tests/functional/spec/features/validation/date_validation/date-combined-yyyy.spec.js
@@ -8,17 +8,17 @@ describe("Feature: Combined question level and single validation for MM-YYYY dat
 
   describe("Period Validation", () => {
     describe("Given I enter dates", () => {
-      it("When I enter a single dates that are too early/late, Then I should see a single validation errors", () => {
-        $(DateRangePage.dateRangeFromYear()).setValue(2015);
+      it("When I enter a single dates that are too early/late, Then I should see single validation errors", () => {
+        $(DateRangePage.dateRangeFromYear()).setValue(2014);
         $(DateRangePage.dateRangeToYear()).setValue(2021);
         $(DateRangePage.submit()).click();
-        expect($(DateRangePage.errorNumber(1)).getText()).to.contain("Enter a date after 2015");
+        expect($(DateRangePage.errorNumber(1)).getText()).to.contain("Enter a date after 2014");
         expect($(DateRangePage.errorNumber(2)).getText()).to.contain("Enter a date before 2021");
       });
 
       it("When I enter a range too large, Then I should see a range validation error", () => {
-        $(DateRangePage.dateRangeFromYear()).setValue(2016);
-        $(DateRangePage.dateRangeToYear()).setValue(2020);
+        $(DateRangePage.dateRangeFromYear()).setValue(2015);
+        $(DateRangePage.dateRangeToYear()).setValue(2019);
         $(DateRangePage.submit()).click();
         expect($(DateRangePage.errorNumber(1)).getText()).to.contain("Enter a reporting period less than or equal to 3 years");
       });

--- a/tests/functional/spec/features/validation/date_validation/date-combined-yyyy.spec.js
+++ b/tests/functional/spec/features/validation/date_validation/date-combined-yyyy.spec.js
@@ -12,7 +12,7 @@ describe("Feature: Combined question level and single validation for MM-YYYY dat
         $(DateRangePage.dateRangeFromYear()).setValue(2014);
         $(DateRangePage.dateRangeToYear()).setValue(2021);
         $(DateRangePage.submit()).click();
-        expect($(DateRangePage.errorNumber(1)).getText()).to.contain("Enter a date after 2014");
+        expect($(DateRangePage.errorNumber(1)).getText()).to.contain("Enter a date after 2015");
         expect($(DateRangePage.errorNumber(2)).getText()).to.contain("Enter a date before 2021");
       });
 

--- a/tests/functional/wdio.conf.js
+++ b/tests/functional/wdio.conf.js
@@ -58,7 +58,7 @@ exports.config = {
       "goog:chromeOptions": {
         args: [
           process.env.EQ_RUN_FUNCTIONAL_TESTS_HEADLESS ? "--headless" : "--start-maximized",
-          "--window-size=1280,1100",
+          "--window-size=3840,2160",
           "--no-sandbox",
           "--disable-gpu",
           "--disable-extensions",


### PR DESCRIPTION
### What is the context of this PR?
Fixes issue with save and continue button that has too big a margin top on it.

Also removes a `ons-u-mb-xl` that is not needed too.

This PR also updates the wdio config to make the resolution 4k. This is because updating this bit by bit has caused issues in the tests. Updating in to a 4k resolution should stop anymore issues

### How to review 
- Check a few schemas in master and on this branch to see the button is now spaced correctly (`test_numbers`, `test_dates` are two good ones)
- Check `test_confirmation_email` see the gap underneath the button is reduced

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
