### PR TITLE
Fix info panel style on calculated summaries

### DIFF
--- a/templates/calculatedsummary.html
+++ b/templates/calculatedsummary.html
@@ -8,8 +8,7 @@
   <h1 data-qa="calculated-summary-title">{{content.summary.title}}</h1>
 
   {% call onsPanel({
-      "type": "success",
-      "classes": "print__hidden ons-u-mb-l"
+      "classes": "ons-u-mb-l"
     }) %}
     <p>{{ _("Please review your answers and confirm these are correct") }}.</p>
   {% endcall %}

--- a/templates/calculatedsummary.html
+++ b/templates/calculatedsummary.html
@@ -10,7 +10,7 @@
   {% call onsPanel({
       "classes": "ons-u-mb-l"
     }) %}
-    <p>{{ _("Please review your answers and confirm these are correct") }}.</p>
+    <p>{{ _("Please review your answers and confirm these are correct") }}</p>
   {% endcall %}
 
   <div class="ons-u-mb-m">


### PR DESCRIPTION
### What is the context of this PR?
The calculated summary is currently using a success panel style (green) for what should be an information panel (blue), have extra padding at the beginning of the text and have a class (`print__hidden`) that isn't being used. Also removes the full stop as this is not needed when the panel only has one line.

This PR will fix these issues

### How to review 
- Test calculated summaries and see that the panel is now blue and the text doesn't have the extra padding at the beginning

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
