### PR TITLE
Fix IE11 countdown panel bug

### DIFF
--- a/app/views/contexts/thank_you_context.py
+++ b/app/views/contexts/thank_you_context.py
@@ -54,7 +54,9 @@ def build_view_submitted_response_context(schema, submitted_at):
         expired = has_view_submitted_response_expired(submitted_at)
         view_submitted_response.update(
             expired=expired,
-            expires_at=get_view_submitted_response_expiration_time(submitted_at),
+            expires_at=get_view_submitted_response_expiration_time(
+                submitted_at
+            ).isoformat(),
         )
         if not expired:
             view_submitted_response["url"] = url_for(


### PR DESCRIPTION
### What is the context of this PR?
There is currently a bug with countdown panels not showing the countdown on IE11. This is because the time being passed to the panel from runner is not in ISO format which IE11 seems to be struggling with. This PR will convert the time being passed to the panel to ISO format.

### How to review 
- Tests pass
- Panel still works as it should when used in the `test_view_submitted_response` schema

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
