### PR TITLE
Utilise correct cookie banner url

### DIFF
--- a/app/translations/messages.pot
+++ b/app/translations/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-03-29 09:47+0100\n"
+"POT-Creation-Date: 2022-04-20 14:02+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -380,7 +380,7 @@ msgstr ""
 msgid "Crown copyright and database rights 2020 OS 100019153."
 msgstr ""
 
-#: app/survey_config/survey_config.py:43
+#: app/survey_config/survey_config.py:42
 msgid "Save and exit survey"
 msgstr ""
 
@@ -711,11 +711,11 @@ msgstr ""
 msgid "View Submitted Response"
 msgstr ""
 
-#: templates/calculatedsummary.html:14
+#: templates/calculatedsummary.html:13
 msgid "Please review your answers and confirm these are correct"
 msgstr ""
 
-#: templates/calculatedsummary.html:25
+#: templates/calculatedsummary.html:24
 msgid "Yes, I confirm these are correct"
 msgstr ""
 
@@ -1129,8 +1129,8 @@ msgstr ""
 #: templates/layouts/_base.html:72
 msgid ""
 "We use <a href='{cookie_settings_url}'>cookies to collect information</a>"
-" about how you use census.gov.uk. We use this information to make the "
-"website work as well as possible and improve our services."
+" about how you use surveys.ons.gov.uk. We use this information to make "
+"the website work as well as possible and improve our services."
 msgstr ""
 
 #: templates/layouts/_base.html:73
@@ -1180,7 +1180,7 @@ msgstr ""
 msgid "Continue survey"
 msgstr ""
 
-#: templates/layouts/_questionnaire.html:38
+#: templates/layouts/_questionnaire.html:37
 msgid "Choose another section and return to this later"
 msgstr ""
 

--- a/templates/layouts/_base.html
+++ b/templates/layouts/_base.html
@@ -69,7 +69,7 @@
       onsCookiesBanner({
         "secondaryButtonUrl": cookie_settings_url,
         "statementTitle": _('Tell us whether you accept cookies'),
-        "statementText": _("We use <a href='{cookie_settings_url}'>cookies to collect information</a> about how you use census.gov.uk. We use this information to make the website work as well as possible and improve our services.").format(cookie_settings_url=cookie_settings_url),
+        "statementText": _("We use <a href='{cookie_settings_url}'>cookies to collect information</a> about how you use surveys.ons.gov.uk. We use this information to make the website work as well as possible and improve our services.").format(cookie_settings_url=cookie_settings_url),
         "confirmationText": _("You’ve accepted all cookies. You can <a href='{cookie_settings_url}'>change your cookie preferences</a> at any time.").format(cookie_settings_url=cookie_settings_url),
         "primaryButtonText": _('Accept all cookies'),
         "secondaryButtonText": _('Set cookie preferences'),


### PR DESCRIPTION
### What is the context of this PR?
This removes old census cookie banner url and replaces it with a RAS one, requirement described on [this Trello card](https://trello.com/c/7roDKuo1).

### How to review 
Visually check schema's cookie banner after launching.

### Checklist

* [x] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
