### PR TITLE
Fix labels for autogenerated release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,10 +2,10 @@ changelog:
   categories:
     - title: ⚠️ Breaking Changes
       labels:
-        - Breaking Changes
+        - Breaking Change
     - title: New Features
       labels:
-        - New Features
+        - New Feature
     - title: Enhancements
       labels:
         - Enhancement


### PR DESCRIPTION
### What is the context of this PR?
Currently we use inappropriate plural versions of pull request labels, this PR fixes the issue.

### How to review 
Autogenerate release notes on your fork after merging some labelled PRs.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
