### PR TITLE
Make calculated summary return_to conditional

### DIFF
--- a/app/views/contexts/calculated_summary_context.py
+++ b/app/views/contexts/calculated_summary_context.py
@@ -16,6 +16,17 @@ from app.views.contexts.summary.group import Group
 
 
 class CalculatedSummaryContext(Context):
+    def get_return_to(self, section_id: str):
+        # :TODO: Add support for returning to the calculated summary that was used
+        has_section_summary = bool(self._schema.get_summary_for_section(section_id))
+        if has_section_summary:
+            return "section-summary"
+
+        if not self._schema.is_flow_hub:
+            return "final-summary"
+
+        return None
+
     def build_groups_for_section(self, section):
         routing_path = self._router.routing_path(section["id"])
 
@@ -32,7 +43,7 @@ class CalculatedSummaryContext(Context):
                 self._schema,
                 location,
                 self._language,
-                return_to="final-summary",
+                return_to=self.get_return_to(section["id"]),
             ).serialize()
             for group in section["groups"]
         ]

--- a/app/views/contexts/summary/answer.py
+++ b/app/views/contexts/summary/answer.py
@@ -45,6 +45,6 @@ class Answer:
             block_id=block_id,
             list_item_id=list_item_id,
             return_to=return_to,
-            return_to_answer_id=self.id,
+            return_to_answer_id=self.id if return_to else None,
             _anchor=self.id,
         )

--- a/app/views/contexts/summary/question.py
+++ b/app/views/contexts/summary/question.py
@@ -60,7 +60,7 @@ class Question:
                 block_id=block_id,
                 list_item_id=self.list_item_id,
                 return_to=return_to,
-                return_to_answer_id=answer_id,
+                return_to_answer_id=answer_id if return_to else None,
                 _anchor=answer_id,
             )
 

--- a/tests/app/views/contexts/summary/test_answer.py
+++ b/tests/app/views/contexts/summary/test_answer.py
@@ -4,14 +4,18 @@ from app.views.contexts.summary.answer import Answer
 
 
 @pytest.mark.usefixtures("app")
-def test_create_answer():
+@pytest.mark.parametrize(
+    "return_to",
+    ["section-summary", None],
+)
+def test_create_answer(return_to):
     answer = Answer(
         answer_schema={"id": "answer-id", "label": "Answer Label", "type": "date"},
         answer_value="An answer",
         block_id="house-type",
         list_name="answer-list",
         list_item_id="answer-item-id",
-        return_to="section-summary",
+        return_to=return_to,
     )
 
     assert answer.id == "answer-id"
@@ -19,9 +23,12 @@ def test_create_answer():
     assert answer.value == "An answer"
     assert answer.type == "date"
 
+    query_string = (
+        "?return_to=section-summary&return_to_answer_id=answer-id" if return_to else ""
+    )
     assert (
         answer.link
-        == "/questionnaire/answer-list/answer-item-id/house-type/?return_to=section-summary&return_to_answer_id=answer-id#answer-id"
+        == f"/questionnaire/answer-list/answer-item-id/house-type/{query_string}#answer-id"
     )
 
 

--- a/tests/app/views/contexts/test_calculated_summary_context.py
+++ b/tests/app/views/contexts/test_calculated_summary_context.py
@@ -108,322 +108,43 @@ def test_build_view_context_for_currency_calculated_summary(
     )
     assert context_summary["calculated_question"]["answers"][0]["value"] == value
 
-
-@pytest.mark.usefixtures("app")
-def test_context_for_section_list_summary(people_answer_store):
-    schema = load_schema_from_name("test_list_collector_section_summary")
-
-    summary_context = SectionSummaryContext(
-        language=DEFAULT_LANGUAGE_CODE,
-        schema=schema,
-        answer_store=people_answer_store,
-        list_store=ListStore(
-            [
-                {"items": ["PlwgoG", "UHPLbX"], "name": "people"},
-                {"items": ["gTrlio"], "name": "visitors"},
-            ]
-        ),
-        progress_store=ProgressStore(),
-        metadata={"display_address": "70 Abingdon Road, Goathill"},
-        response_metadata={},
-        current_location=Location(section_id="section"),
-        routing_path=RoutingPath(
-            [
-                "primary-person-list-collector",
-                "list-collector",
-                "visitor-list-collector",
-            ],
-            section_id="section",
-        ),
-    )
-    context = summary_context()
-    expected = {
-        "summary": {
-            "answers_are_editable": True,
-            "collapsible": False,
-            "custom_summary": [
-                {
-                    "add_link": "/questionnaire/people/add-person/?return_to=section-summary",
-                    "add_link_text": "Add someone to this household",
-                    "empty_list_text": "There are no householders",
-                    "list": {
-                        "editable": True,
-                        "list_items": [
-                            {
-                                "edit_link": "/questionnaire/people/PlwgoG/edit-person/?return_to=section-summary",
-                                "item_title": "Toni Morrison",
-                                "primary_person": False,
-                                "remove_link": "/questionnaire/people/PlwgoG/remove-person/?return_to=section-summary",
-                                "list_item_id": "PlwgoG",
-                            },
-                            {
-                                "edit_link": "/questionnaire/people/UHPLbX/edit-person/?return_to=section-summary",
-                                "item_title": "Barry Pheloung",
-                                "primary_person": False,
-                                "remove_link": "/questionnaire/people/UHPLbX/remove-person/?return_to=section-summary",
-                                "list_item_id": "UHPLbX",
-                            },
-                        ],
-                    },
-                    "list_name": "people",
-                    "title": "Household members staying overnight on 13 October 2019 at 70 Abingdon Road, Goathill",
-                    "type": "List",
-                },
-                {
-                    "add_link": "/questionnaire/visitors/add-visitor/?return_to=section-summary",
-                    "add_link_text": "Add another visitor to this household",
-                    "empty_list_text": "There are no visitors",
-                    "list": {
-                        "editable": True,
-                        "list_items": [
-                            {
-                                "edit_link": "/questionnaire/visitors/gTrlio/edit-visitor-person/?return_to=section-summary",
-                                "item_title": "",
-                                "primary_person": False,
-                                "remove_link": "/questionnaire/visitors/gTrlio/remove-visitor/?return_to=section-summary",
-                                "list_item_id": "gTrlio",
-                            }
-                        ],
-                    },
-                    "list_name": "visitors",
-                    "title": "Visitors staying overnight on 13 October 2019 at 70 Abingdon Road, Goathill",
-                    "type": "List",
-                },
-            ],
-            "page_title": "People who live here and overnight visitors",
-            "summary_type": "SectionSummary",
-            "title": "People who live here and overnight visitors",
-        }
-    }
-
-    assert context == expected
+    answer_change_link = context_summary["groups"][0]["blocks"][0]["question"][
+        "answers"
+    ][0]["link"]
+    assert "return_to=final-summary" in answer_change_link
 
 
-@pytest.mark.usefixtures("app")
-def test_context_for_driving_question_summary_empty_list():
-    schema = load_schema_from_name("test_list_collector_driving_question")
+@pytest.mark.parametrize(
+    "has_section_summary",
+    ([True, False]),
+)
+@pytest.mark.parametrize(
+    "is_hub_enabled",
+    ([True, False]),
+)
+def test_get_return_to(
+    has_section_summary,
+    is_hub_enabled,
+    mocker,
+):
+    schema = mocker.MagicMock()
+    schema.is_flow_hub = is_hub_enabled
+    schema.get_summary_for_section = mocker.Mock(return_value=has_section_summary)
 
-    summary_context = SectionSummaryContext(
-        DEFAULT_LANGUAGE_CODE,
+    calculated_summary_context = CalculatedSummaryContext(
+        "en",
         schema,
-        AnswerStore([{"answer_id": "anyone-usually-live-at-answer", "value": "No"}]),
-        ListStore(),
-        ProgressStore(),
+        answer_store=mocker.MagicMock(),
+        list_store=mocker.MagicMock(),
+        progress_store=mocker.MagicMock(),
         metadata={},
         response_metadata={},
-        current_location=Location(section_id="section"),
-        routing_path=RoutingPath(["anyone-usually-live-at"], section_id="section"),
     )
 
-    context = summary_context()
-    expected = {
-        "summary": {
-            "answers_are_editable": True,
-            "collapsible": False,
-            "custom_summary": [
-                {
-                    "add_link": "/questionnaire/anyone-usually-live-at/?return_to=section-summary",
-                    "add_link_text": "Add someone to this household",
-                    "empty_list_text": "There are no householders",
-                    "list": {"editable": False, "list_items": []},
-                    "list_name": "people",
-                    "title": "Household members",
-                    "type": "List",
-                }
-            ],
-            "page_title": "List Collector Driving Question Summary",
-            "summary_type": "SectionSummary",
-            "title": "List Collector Driving Question Summary",
-        }
-    }
-
-    assert context == expected
-
-
-@pytest.mark.usefixtures("app")
-def test_context_for_driving_question_summary():
-    schema = load_schema_from_name("test_list_collector_driving_question")
-
-    summary_context = SectionSummaryContext(
-        DEFAULT_LANGUAGE_CODE,
-        schema,
-        AnswerStore(
-            [
-                {"answer_id": "anyone-usually-live-at-answer", "value": "Yes"},
-                {"answer_id": "first-name", "value": "Toni", "list_item_id": "PlwgoG"},
-                {
-                    "answer_id": "last-name",
-                    "value": "Morrison",
-                    "list_item_id": "PlwgoG",
-                },
-            ]
-        ),
-        ListStore([{"items": ["PlwgoG"], "name": "people"}]),
-        ProgressStore(),
-        metadata={},
-        response_metadata={},
-        current_location=Location(section_id="section"),
-        routing_path=RoutingPath(
-            ["anyone-usually-live-at", "anyone-else-live-at"], section_id="section"
-        ),
-    )
-
-    context = summary_context()
-
-    expected = {
-        "summary": {
-            "answers_are_editable": True,
-            "collapsible": False,
-            "custom_summary": [
-                {
-                    "add_link": "/questionnaire/people/add-person/?return_to=section-summary",
-                    "add_link_text": "Add someone to this household",
-                    "empty_list_text": "There are no householders",
-                    "list": {
-                        "editable": True,
-                        "list_items": [
-                            {
-                                "item_title": "Toni Morrison",
-                                "primary_person": False,
-                                "edit_link": "/questionnaire/people/PlwgoG/edit-person/?return_to=section-summary",
-                                "remove_link": "/questionnaire/people/PlwgoG/remove-person/?return_to=section-summary",
-                                "list_item_id": "PlwgoG",
-                            }
-                        ],
-                    },
-                    "list_name": "people",
-                    "title": "Household members",
-                    "type": "List",
-                }
-            ],
-            "page_title": "List Collector Driving Question Summary",
-            "summary_type": "SectionSummary",
-            "title": "List Collector Driving Question Summary",
-        }
-    }
-
-    assert context == expected
-
-
-@pytest.mark.usefixtures("app")
-def test_titles_for_repeating_section_summary(people_answer_store, mocker):
-    schema = load_schema_from_name("test_repeating_sections_with_hub_and_spoke")
-
-    section_summary_context = SectionSummaryContext(
-        DEFAULT_LANGUAGE_CODE,
-        schema,
-        people_answer_store,
-        ListStore(
-            [
-                {"items": ["PlwgoG", "UHPLbX"], "name": "people"},
-                {"items": ["gTrlio"], "name": "visitors"},
-            ]
-        ),
-        ProgressStore(),
-        metadata={},
-        response_metadata={},
-        current_location=Location(
-            section_id="personal-details-section",
-            list_name="people",
-            list_item_id="PlwgoG",
-        ),
-        routing_path=mocker.MagicMock(),
-    )
-
-    context = section_summary_context()
-
-    assert context["summary"]["title"] == "Toni Morrison"
-
-    section_summary_context = SectionSummaryContext(
-        DEFAULT_LANGUAGE_CODE,
-        schema,
-        people_answer_store,
-        ListStore(
-            [
-                {"items": ["PlwgoG", "UHPLbX"], "name": "people"},
-                {"items": ["gTrlio"], "name": "visitors"},
-            ]
-        ),
-        ProgressStore(),
-        metadata={},
-        response_metadata={},
-        current_location=Location(
-            block_id="personal-summary",
-            section_id="personal-details-section",
-            list_name="people",
-            list_item_id="UHPLbX",
-        ),
-        routing_path=mocker.MagicMock(),
-    )
-
-    context = section_summary_context()
-    assert context["summary"]["title"] == "Barry Pheloung"
-
-
-@pytest.mark.usefixtures("app")
-def test_primary_only_links_for_section_summary(people_answer_store):
-    schema = load_schema_from_name("test_list_collector_section_summary")
-
-    summary_context = SectionSummaryContext(
-        language=DEFAULT_LANGUAGE_CODE,
-        schema=schema,
-        answer_store=people_answer_store,
-        list_store=ListStore(
-            [{"items": ["PlwgoG"], "name": "people", "primary_person": "PlwgoG"}]
-        ),
-        progress_store=ProgressStore(),
-        metadata={"display_address": "70 Abingdon Road, Goathill"},
-        response_metadata={},
-        current_location=Location(section_id="section"),
-        routing_path=RoutingPath(
-            [
-                "primary-person-list-collector",
-                "list-collector",
-                "visitor-list-collector",
-            ],
-            section_id="section",
-        ),
-    )
-    context = summary_context()
-
-    list_items = context["summary"]["custom_summary"][0]["list"]["list_items"]
-
-    assert "/add-or-edit-primary-person/" in list_items[0]["edit_link"]
-
-
-@pytest.mark.usefixtures("app")
-def test_primary_links_for_section_summary(people_answer_store):
-    schema = load_schema_from_name("test_list_collector_section_summary")
-
-    summary_context = SectionSummaryContext(
-        language=DEFAULT_LANGUAGE_CODE,
-        schema=schema,
-        answer_store=people_answer_store,
-        list_store=ListStore(
-            [
-                {
-                    "items": ["PlwgoG", "fg0sPd"],
-                    "name": "people",
-                    "primary_person": "PlwgoG",
-                }
-            ]
-        ),
-        progress_store=ProgressStore(),
-        metadata={"display_address": "70 Abingdon Road, Goathill"},
-        response_metadata={},
-        current_location=Location(section_id="section"),
-        routing_path=RoutingPath(
-            [
-                "primary-person-list-collector",
-                "list-collector",
-                "visitor-list-collector",
-            ],
-            section_id="section",
-        ),
-    )
-    context = summary_context()
-
-    list_items = context["summary"]["custom_summary"][0]["list"]["list_items"]
-
-    assert "/edit-person/" in list_items[0]["edit_link"]
-    assert "/edit-person/" in list_items[1]["edit_link"]
+    return_to = calculated_summary_context.get_return_to("some-section")
+    if has_section_summary:
+        assert return_to == "section-summary"
+    elif not is_hub_enabled:
+        assert return_to == "final-summary"
+    else:
+        assert return_to is None

--- a/tests/app/views/contexts/test_calculated_summary_context.py
+++ b/tests/app/views/contexts/test_calculated_summary_context.py
@@ -1,14 +1,7 @@
 import pytest
 
-from app.data_models.answer_store import AnswerStore
-from app.data_models.list_store import ListStore
-from app.data_models.progress_store import ProgressStore
 from app.questionnaire.location import Location
-from app.questionnaire.questionnaire_schema import DEFAULT_LANGUAGE_CODE
-from app.questionnaire.routing_path import RoutingPath
-from app.utilities.schema import load_schema_from_name
 from app.views.contexts.calculated_summary_context import CalculatedSummaryContext
-from app.views.contexts.section_summary_context import SectionSummaryContext
 from tests.app.views.contexts import assert_summary_context
 
 


### PR DESCRIPTION
### What is the context of this PR?
- Made the `return_to` query string from the change link for Calculated summaries conditional on section summary/hub flow. We currently do not support jumping straight back to a calculated summary. Support for jumping straight back to a calculated summary will be implemented separately.
- Also removed tests in `test_calculated_summary_context.py` that were duplicated from `test_section_summary_context.py`

***Note: This is a temporary solution***

### How to review 
Ensure the change links on a calculated summary depend on the whether you have a section summary and or if hub is enabled.

- if section summary is enabled for the section you are on, then return to should be `section-summary`
- if section summary is disabled and hub is disabled, then return to should be `final-summary`
- otherwise, return to should be `None`. (This would go to the first block in the section since, hub without section summary would go to the first block anyway when you click (View answers))

Test the journeys do not result in 404s.
Test the following journey on master vs this branch.
- Launch construction
- Complete all sections
- From the hub, click View answer to the `Infrastructure` section. You should now be on the section summary.
- Click `Previous` to go to the Calculated summary.
- Click `Change` on one of the answers.
- Click `Save and continue` and you should see a 404 on master, but go to the section summary on this branch. 


### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
