### PR TITLE
Bug fix: Only include first 11 characters of ru_ref in help link

### DIFF
--- a/app/survey_config/business_config.py
+++ b/app/survey_config/business_config.py
@@ -61,7 +61,11 @@ class BusinessSurveyConfig(
         if self.schema and is_authenticated and ru_ref:
             request_data = {
                 "survey_ref": self.schema.json["survey_id"],
-                "ru_ref": ru_ref,
+                # This is a temporary fix to send upstream only the first 11 characters of the ru_ref.
+                # The ru_ref currently is concatenated with the check letter. Which upstream currently do not support.
+                # The first 11 characters represents the reporting unit reference.
+                # The 12th character is the check letter identifier.
+                "ru_ref": ru_ref[:11],
             }
             return f"{self.base_url}/surveys/surveys-help?{urlencode(request_data)}"
 

--- a/tests/app/helpers/test_template_helpers.py
+++ b/tests/app/helpers/test_template_helpers.py
@@ -158,6 +158,23 @@ def test_get_page_header_context_census_nisra(app: Flask):
             None,
         ),
         (
+            BusinessSurveyConfig(),
+            False,
+            {
+                "toggleServicesButton": {
+                    "text": "Menu",
+                    "ariaLabel": "Toggle services menu",
+                },
+                "itemsList": [
+                    {
+                        "title": "Help",
+                        "url": "https://surveys.ons.gov.uk/help",
+                        "id": "header-link-help",
+                    }
+                ],
+            },
+        ),
+        (
             BusinessSurveyConfig(schema=QuestionnaireSchema({"survey_id": "001"})),
             True,
             {
@@ -190,14 +207,15 @@ def test_service_links_context(
     app: Flask, mocker, survey_config, is_authenticated, expected
 ):
     with app.app_context():
-        current_user = mocker.patch(
-            "flask_login.utils._get_user", return_value=mocker.MagicMock()
-        )
-        mocker.patch(
-            "app.helpers.template_helpers.get_metadata",
-            return_value={"ru_ref": "63782964754U"},
-        )
-        current_user.is_authenticated = is_authenticated
+        mocked_current_user = mocker.Mock()
+        mocked_current_user.is_authenticated = is_authenticated
+        mocker.patch("flask_login.utils._get_user", return_value=mocked_current_user)
+
+        if is_authenticated:
+            mocker.patch(
+                "app.helpers.template_helpers.get_metadata",
+                return_value={"ru_ref": "63782964754U"},
+            )
 
         result = ContextHelper(
             language="en",

--- a/tests/app/helpers/test_template_helpers.py
+++ b/tests/app/helpers/test_template_helpers.py
@@ -4,6 +4,7 @@ import pytest
 from flask import Flask, current_app
 
 from app.helpers.template_helpers import ContextHelper, get_survey_config
+from app.questionnaire import QuestionnaireSchema
 from app.settings import ACCOUNT_SERVICE_BASE_URL
 from app.survey_config import (
     BusinessSurveyConfig,
@@ -157,7 +158,7 @@ def test_get_page_header_context_census_nisra(app: Flask):
             None,
         ),
         (
-            BusinessSurveyConfig(),
+            BusinessSurveyConfig(schema=QuestionnaireSchema({"survey_id": "001"})),
             True,
             {
                 "toggleServicesButton": {
@@ -167,7 +168,7 @@ def test_get_page_header_context_census_nisra(app: Flask):
                 "itemsList": [
                     {
                         "title": "Help",
-                        "url": "https://surveys.ons.gov.uk/help",
+                        "url": "https://surveys.ons.gov.uk/surveys/surveys-help?survey_ref=001&ru_ref=63782964754",
                         "id": "header-link-help",
                     },
                     {
@@ -191,6 +192,10 @@ def test_service_links_context(
     with app.app_context():
         current_user = mocker.patch(
             "flask_login.utils._get_user", return_value=mocker.MagicMock()
+        )
+        mocker.patch(
+            "app.helpers.template_helpers.get_metadata",
+            return_value={"ru_ref": "63782964754U"},
         )
         current_user.is_authenticated = is_authenticated
 

--- a/tests/integration/test_header_links.py
+++ b/tests/integration/test_header_links.py
@@ -32,7 +32,7 @@ class TestHeaderLinks(IntegrationTestCase):
         self.assertEqual(help_link.text, "Help")
         self.assertEqual(
             help_link["href"],
-            f"{ACCOUNT_SERVICE_URL}/surveys/surveys-help?survey_ref=001&ru_ref=123456789012A",
+            f"{ACCOUNT_SERVICE_URL}/surveys/surveys-help?survey_ref=001&ru_ref=12345678901",
         )
 
     def assert_help_link_exist_not_authenticated(self):


### PR DESCRIPTION
### What is the context of this PR?
- Temporary tactical solution to only send RAS the first 11 characters of the `ru_ref` when generating the help link. The first 11 characters are send because the reporting unit reference is always 11 characters.
- The `ru_ref` eQ gets from RAS actually includes `ru_ref` + `check_letter` but when using the help link, they do not expect the `check_letter` to be present. They will progress a more appropriate solution to their end in the future, but this is a temp fix to get the changes in preprod moving.

### How to review 
- Launch a schema and set the ru ref to your liking, and ensure that only the first 11 characters are used when generating the help link ru_ref query param.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
