### PR TITLE
Set page title for Calculated summary blocks

### DIFF
--- a/app/views/contexts/calculated_summary_context.py
+++ b/app/views/contexts/calculated_summary_context.py
@@ -185,7 +185,7 @@ class CalculatedSummaryContext(Context):
 
     @staticmethod
     def _get_calculated_question(calculation_question, formatted_total):
-        calculation_title = calculation_question.get("title")
+        calculation_title = calculation_question["title"]
 
         return {
             "title": calculation_title,

--- a/app/views/handlers/calculated_summary.py
+++ b/app/views/handlers/calculated_summary.py
@@ -13,6 +13,9 @@ class CalculatedSummary(Content):
             self._questionnaire_store.metadata,
             self._questionnaire_store.response_metadata,
         )
-        return calculated_summary_context.build_view_context_for_calculated_summary(
+        context = calculated_summary_context.build_view_context_for_calculated_summary(
             self._current_location
         )
+        self.page_title = context["summary"]["calculated_question"]["title"]
+
+        return context

--- a/tests/functional/spec/features/calculated_summary.spec.js
+++ b/tests/functional/spec/features/calculated_summary.spec.js
@@ -55,6 +55,10 @@ describe("Feature: Calculated Summary", () => {
       expect(browserUrl).to.contain(CurrencyTotalPlaybackPageWithFourth.pageName);
     });
 
+    it("Given I have completed all questions. When I am on the calculated summary, Then the page title should use the calculation's title", () => {
+      expect(browser.getTitle()).to.equal("Grand total of previous values - A test schema to demo Calculated Summary");
+    });
+
     it("Given I complete every question, When I get to the currency summary, Then I should see the correct total", () => {
       // Totals and titles should be shown
       expect($(CurrencyTotalPlaybackPageWithFourth.calculatedSummaryTitle()).getText()).to.contain(

--- a/tests/functional/spec/features/calculated_summary.spec.js
+++ b/tests/functional/spec/features/calculated_summary.spec.js
@@ -55,7 +55,7 @@ describe("Feature: Calculated Summary", () => {
       expect(browserUrl).to.contain(CurrencyTotalPlaybackPageWithFourth.pageName);
     });
 
-    it("Given I have completed all questions. When I am on the calculated summary, Then the page title should use the calculation's title", () => {
+    it("Given I have completed all questions, When I am on the calculated summary, Then the page title should use the calculation's title", () => {
       expect(browser.getTitle()).to.equal("Grand total of previous values - A test schema to demo Calculated Summary");
     });
 


### PR DESCRIPTION
### What is the context of this PR?
Page title was not being set for Calculated summary blocks.

### How to review 
Ensure the page title is set appropriately. The title for calculated summary should be `{calculated_summary_title} - {survey_title}`. Ensure the title does not display `None`.

- Test using any schema with a calculated summary.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
