### PR TITLE
Bug fix: Support for in-flight sessions that use survey_url

### DIFF
--- a/app/data_models/session_data.py
+++ b/app/data_models/session_data.py
@@ -9,7 +9,6 @@ class SessionData:
         period_str: Optional[str],
         language_code: Optional[str],
         launch_language_code: Optional[str],
-        schema_url: Optional[str],
         ru_name: Optional[str],
         ru_ref: Optional[str],
         response_id: Optional[str],
@@ -21,6 +20,8 @@ class SessionData:
         display_address: Optional[str] = None,
         confirmation_email_count: int = 0,
         feedback_count: int = 0,
+        schema_url: Optional[str] = None,
+        survey_url: Optional[str] = None,  # pylint: disable=unused-argument
         **_: Any,
     ):  # pylint: disable=too-many-locals
         self.tx_id = tx_id
@@ -28,7 +29,6 @@ class SessionData:
         self.period_str = period_str
         self.language_code = language_code
         self.launch_language_code = launch_language_code
-        self.schema_url = schema_url
         self.ru_name = ru_name
         self.ru_ref = ru_ref
         self.response_id = response_id
@@ -40,3 +40,9 @@ class SessionData:
         self.display_address = display_address
         self.confirmation_email_count = confirmation_email_count
         self.feedback_count = feedback_count
+        self.schema_url = schema_url
+
+        # :TODO: Remove once `schema_url` has been rolled out successfully.
+        # This is only to support a rollback in the event `schema_url` deploy is not successful.
+        # Survey URL will not be used to load surveys.
+        self.survey_url = None

--- a/tests/app/data_model/test_session_data.py
+++ b/tests/app/data_model/test_session_data.py
@@ -1,0 +1,45 @@
+from app.data_models import SessionData
+
+
+def test_session_data_default_properties():
+    try:
+        session_data = SessionData(
+            tx_id="123",
+            schema_name="some_schema_name",
+            period_str=None,
+            language_code="cy",
+            launch_language_code="en",
+            ru_name=None,
+            ru_ref=None,
+            response_id="321",
+            case_id="789",
+        )
+    except TypeError:
+        assert False, "Error occurred when creating session data"
+
+    assert session_data.case_ref is None
+    assert session_data.account_service_base_url is None
+    assert session_data.account_service_log_out_url is None
+    assert session_data.trad_as is None
+    assert session_data.display_address is None
+    assert session_data.confirmation_email_count == 0
+    assert session_data.feedback_count == 0
+    assert session_data.schema_url is None
+    assert session_data.survey_url is None
+
+
+def test_session_data_survey_url_always_set_to_none():
+    session_data = SessionData(
+        tx_id="123",
+        schema_name="some_schema_name",
+        period_str=None,
+        language_code="cy",
+        launch_language_code="en",
+        ru_name=None,
+        ru_ref=None,
+        response_id="321",
+        case_id="789",
+        survey_url="some-url",
+    )
+
+    assert session_data.survey_url is None

--- a/tests/app/data_model/test_session_data.py
+++ b/tests/app/data_model/test_session_data.py
@@ -1,3 +1,5 @@
+import pytest
+
 from app.data_models import SessionData
 
 
@@ -15,7 +17,7 @@ def test_session_data_default_properties():
             case_id="789",
         )
     except TypeError:
-        assert False, "Error occurred when creating session data"
+        return pytest.fail("An error occurred when creating session data")
 
     assert session_data.case_ref is None
     assert session_data.account_service_base_url is None


### PR DESCRIPTION
### What is the context of this PR?
Recently `schema_url` was introduced in favour of `survey_url`, however that breaks in-flight sessions for users that currently made use of `survey_url`.

- This PR adds supports so that in-flight session does not error when rolling out the `schema_url` change. 
- Although `survey_url` is now supported for in-flight sessions, the literal value for `survey_url` has been dropped. RAS does not use `survey_url` for any live surveys.
- With this change `SessionData` accepts a `schema_url` or `survey_url` on initialisation. This was simply to allows us to roll back this change in the event this errored in prod. Once `schema_url` has been rolled out successfully, `survey_url` will be removed in a subsequent PR.

### How to review 
1. Check out to v3.107.1 and launch a survey
2. Check out to this branch and try to continue the survey.
3.  Check out back to v3.107.1 and try complete and submit the survey
4. Ensure none of these steps result in an error.

When comparing these steps above between v3.107.1 and v4.0.0, it should result in errors.

Has any scenario been missed which would result in an error?.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
