### PR TITLE
Add calculated summary section dependencies

### DIFF
--- a/app/questionnaire/questionnaire_schema.py
+++ b/app/questionnaire/questionnaire_schema.py
@@ -843,14 +843,19 @@ class QuestionnaireSchema:  # pylint: disable=too-many-public-methods
             if not isinstance(rule, Mapping):
                 continue
 
-            answer_id = None
+            answer_id_list: list = []
+            identifier: str = rule.get("identifier", "")
 
             if "id" in rule:
-                answer_id = rule["id"]
+                answer_id_list.append(rule["id"])
             elif rule.get("source") == "answers":
-                answer_id = rule.get("identifier")
+                answer_id_list.append(identifier)
+            elif rule.get("source") == "calculated_summary":
+                calculated_summary_block = self.get_block(identifier)
+                calculated_summary_answer_ids = calculated_summary_block["calculation"]["answers_to_calculate"]  # type: ignore
+                answer_id_list.extend(iter(calculated_summary_answer_ids))
 
-            if answer_id:
+            for answer_id in answer_id_list:
                 block = self.get_block_for_answer_id(answer_id)  # type: ignore
                 section_id = self.get_section_id_for_block_id(block["id"])  # type: ignore
 

--- a/schemas/test/en/test_new_routing_section_dependencies_calculated_summary.json
+++ b/schemas/test/en/test_new_routing_section_dependencies_calculated_summary.json
@@ -1,0 +1,279 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "language": "en",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.3",
+    "survey_id": "001",
+    "title": "Routing and Skipping Section Dependencies based on Calculated Summary",
+    "theme": "default",
+    "description": "A questionnaire to test routing and skipping rules, when the rule references a different section to its current section",
+    "metadata": [
+        {
+            "name": "user_id",
+            "type": "string"
+        },
+        {
+            "name": "period_id",
+            "type": "string"
+        },
+        {
+            "name": "ru_name",
+            "type": "string"
+        }
+    ],
+    "questionnaire_flow": {
+        "type": "Hub",
+        "options": {}
+    },
+    "sections": [
+        {
+            "title": "Calculated Summary Section",
+            "summary": { "show_on_completion": true },
+            "id": "calculated-summary-section",
+            "groups": [
+                {
+                    "blocks": [
+                        {
+                            "type": "Question",
+                            "id": "first-question-block",
+                            "question": {
+                                "id": "first-question",
+                                "title": "How much do you spend on the following items?",
+                                "type": "General",
+                                "answers": [
+                                    {
+                                        "id": "milk-answer",
+                                        "label": "Milk",
+                                        "mandatory": true,
+                                        "type": "Currency",
+                                        "currency": "GBP",
+                                        "decimal_places": 2
+                                    },
+                                    {
+                                        "id": "eggs-answer",
+                                        "label": "Eggs",
+                                        "mandatory": true,
+                                        "type": "Currency",
+                                        "currency": "GBP",
+                                        "decimal_places": 2
+                                    },
+                                    {
+                                        "id": "bread-answer",
+                                        "label": "Bread",
+                                        "mandatory": true,
+                                        "type": "Currency",
+                                        "currency": "GBP",
+                                        "decimal_places": 2
+                                    },
+                                    {
+                                        "id": "cheese-answer",
+                                        "label": "Cheese",
+                                        "mandatory": true,
+                                        "type": "Currency",
+                                        "currency": "GBP",
+                                        "decimal_places": 2
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "type": "CalculatedSummary",
+                            "id": "currency-total-playback",
+                            "title": "We calculate the total of currency values entered to be %(total)s. Is this correct?",
+                            "calculation": {
+                                "calculation_type": "sum",
+                                "answers_to_calculate": ["milk-answer", "eggs-answer", "bread-answer", "cheese-answer"],
+                                "title": "Grand total of previous values"
+                            }
+                        }
+                    ],
+                    "id": "calculated-summary-group"
+                }
+            ]
+        },
+        {
+            "title": "Dependent question Section",
+            "summary": { "show_on_completion": true },
+            "id": "dependent-question-section",
+            "groups": [
+                {
+                    "blocks": [
+                        {
+                            "skip_conditions": {
+                                "when": {
+                                    ">=": [
+                                        {
+                                            "source": "calculated_summary",
+                                            "identifier": "currency-total-playback"
+                                        },
+                                        10
+                                    ]
+                                }
+                            },
+                            "type": "Question",
+                            "id": "fruit",
+                            "question": {
+                                "answers": [
+                                    {
+                                        "id": "fruit-answer",
+                                        "mandatory": false,
+                                        "options": [
+                                            {
+                                                "label": "Yes",
+                                                "value": "Yes"
+                                            },
+                                            {
+                                                "label": "No",
+                                                "value": "No"
+                                            }
+                                        ],
+                                        "type": "Radio"
+                                    }
+                                ],
+                                "id": "fruit-question",
+                                "title": "Do you like eating fruit",
+                                "type": "General"
+                            }
+                        },
+                        {
+                            "routing_rules": [
+                                {
+                                    "block": "second-question-block",
+                                    "when": {
+                                        ">=": [
+                                            {
+                                                "source": "calculated_summary",
+                                                "identifier": "currency-total-playback"
+                                            },
+                                            100
+                                        ]
+                                    }
+                                },
+                                {
+                                    "section": "End"
+                                }
+                            ],
+                            "type": "Question",
+                            "id": "vegetables",
+                            "question": {
+                                "answers": [
+                                    {
+                                        "id": "vegetables-answer",
+                                        "mandatory": false,
+                                        "options": [
+                                            {
+                                                "label": "Yes",
+                                                "value": "Yes"
+                                            },
+                                            {
+                                                "label": "No",
+                                                "value": "No"
+                                            }
+                                        ],
+                                        "type": "Radio"
+                                    }
+                                ],
+                                "id": "vegetables-question",
+                                "title": "Do you like eating vegetables",
+                                "type": "General"
+                            }
+                        },
+                        {
+                            "type": "Question",
+                            "id": "second-question-block",
+                            "question": {
+                                "id": "second-question",
+                                "title": "How much do you spend on the following items?",
+                                "type": "General",
+                                "answers": [
+                                    {
+                                        "id": "apples-answer",
+                                        "label": "Apples",
+                                        "mandatory": true,
+                                        "type": "Currency",
+                                        "currency": "GBP",
+                                        "decimal_places": 2
+                                    },
+                                    {
+                                        "id": "bananas-answer",
+                                        "label": "Bananas",
+                                        "mandatory": true,
+                                        "type": "Currency",
+                                        "currency": "GBP",
+                                        "decimal_places": 2
+                                    },
+                                    {
+                                        "id": "oranges-answer",
+                                        "label": "Oranges",
+                                        "mandatory": true,
+                                        "type": "Currency",
+                                        "currency": "GBP",
+                                        "decimal_places": 2
+                                    },
+                                    {
+                                        "id": "lemons-answer",
+                                        "label": "Lemons",
+                                        "mandatory": true,
+                                        "type": "Currency",
+                                        "currency": "GBP",
+                                        "decimal_places": 2
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "id": "dependent-question-group"
+                }
+            ]
+        },
+        {
+            "enabled": {
+                "when": {
+                    "==": [
+                        100,
+                        {
+                            "source": "calculated_summary",
+                            "identifier": "currency-total-playback"
+                        }
+                    ]
+                }
+            },
+            "title": "Dependent Enabled Section",
+            "summary": { "show_on_completion": true },
+            "id": "dependent-enabled-section",
+            "groups": [
+                {
+                    "blocks": [
+                        {
+                            "type": "Question",
+                            "id": "desserts",
+                            "question": {
+                                "answers": [
+                                    {
+                                        "id": "desserts-answer",
+                                        "mandatory": false,
+                                        "options": [
+                                            {
+                                                "label": "Yes",
+                                                "value": "Yes"
+                                            },
+                                            {
+                                                "label": "No",
+                                                "value": "No"
+                                            }
+                                        ],
+                                        "type": "Radio"
+                                    }
+                                ],
+                                "id": "vegetables-question",
+                                "title": "Do you like eating desserts",
+                                "type": "General"
+                            }
+                        }
+                    ],
+                    "id": "dependent-enabled-section-group"
+                }
+            ]
+        }
+    ]
+}

--- a/tests/functional/spec/routing_and_skipping_section_dependencies_calculated_summary.spec.js
+++ b/tests/functional/spec/routing_and_skipping_section_dependencies_calculated_summary.spec.js
@@ -1,0 +1,123 @@
+import CalculatedSummarySectionSummaryPage from "../generated_pages/new_routing_section_dependencies_calculated_summary/calculated-summary-section-summary.page";
+import CurrencyTotalPlaybackPage from "../generated_pages/new_routing_section_dependencies_calculated_summary/currency-total-playback.page";
+import DependentQuestionSectionSummaryPage from "../generated_pages/new_routing_section_dependencies_calculated_summary/dependent-question-section-summary.page";
+import FirstQuestionBlockPage from "../generated_pages/new_routing_section_dependencies_calculated_summary/first-question-block.page";
+import FruitPage from "../generated_pages/new_routing_section_dependencies_calculated_summary/fruit.page";
+import SecondQuestionBlockPage from "../generated_pages/new_routing_section_dependencies_calculated_summary/second-question-block.page";
+import VegetablesPage from "../generated_pages/new_routing_section_dependencies_calculated_summary/vegetables.page";
+
+import HubPage from "../base_pages/hub.page";
+
+describe("Routing and skipping section dependencies based on calculated summaries", () => {
+  describe("Given the section dependencies based on a calculated summary questionnaire", () => {
+    beforeEach("Load the survey", () => {
+      browser.openQuestionnaire("test_new_routing_section_dependencies_calculated_summary.json");
+    });
+
+    it("When the calculated summary total has not been set, Then the dependent section should not be enabled", () => {
+      expect($(HubPage.summaryRowLink("calculated-summary-section")).isExisting()).to.be.true;
+      expect($(HubPage.summaryRowLink("dependent-question-section")).isExisting()).to.be.true;
+      expect($(HubPage.summaryRowLink("dependent-enabled-section")).isExisting()).to.be.false;
+    });
+
+    it("When the calculated summary total is equal to £100, Then the dependent section should be enabled", () => {
+      $(HubPage.summaryRowLink("calculated-summary-section")).click();
+      $(FirstQuestionBlockPage.milk()).setValue(25);
+      $(FirstQuestionBlockPage.eggs()).setValue(25);
+      $(FirstQuestionBlockPage.bread()).setValue(25);
+      $(FirstQuestionBlockPage.cheese()).setValue(25);
+      $(FirstQuestionBlockPage.submit()).click();
+      $(CurrencyTotalPlaybackPage.submit()).click();
+      $(CalculatedSummarySectionSummaryPage.submit()).click();
+
+      expect($(HubPage.summaryRowLink("calculated-summary-section")).isExisting()).to.be.true;
+      expect($(HubPage.summaryRowLink("dependent-question-section")).isExisting()).to.be.true;
+      expect($(HubPage.summaryRowLink("dependent-enabled-section")).isExisting()).to.be.true;
+    });
+
+    it("When a question in another section has a skip condition dependency on a calculated summary total, and the skip condition is not met (total less than £10), then the dependent question should be displayed", () => {
+      $(HubPage.summaryRowLink("calculated-summary-section")).click();
+      $(FirstQuestionBlockPage.milk()).setValue(1);
+      $(FirstQuestionBlockPage.eggs()).setValue(1);
+      $(FirstQuestionBlockPage.bread()).setValue(1);
+      $(FirstQuestionBlockPage.cheese()).setValue(1);
+      $(FirstQuestionBlockPage.submit()).click();
+      $(CurrencyTotalPlaybackPage.submit()).click();
+      $(CalculatedSummarySectionSummaryPage.submit()).click();
+
+      $(HubPage.summaryRowLink("dependent-question-section")).click();
+      expect(browser.getUrl()).to.contain(FruitPage.pageName);
+    });
+
+    it("When a question in another section has a skip condition dependency on a calculated summary total, and the skip condition is met (total greater than £10), then the dependent question should not be displayed", () => {
+      $(HubPage.summaryRowLink("calculated-summary-section")).click();
+      $(FirstQuestionBlockPage.milk()).setValue(5);
+      $(FirstQuestionBlockPage.eggs()).setValue(5);
+      $(FirstQuestionBlockPage.bread()).setValue(5);
+      $(FirstQuestionBlockPage.cheese()).setValue(5);
+      $(FirstQuestionBlockPage.submit()).click();
+      $(CurrencyTotalPlaybackPage.submit()).click();
+      $(CalculatedSummarySectionSummaryPage.submit()).click();
+
+      $(HubPage.summaryRowLink("dependent-question-section")).click();
+      expect(browser.getUrl()).to.contain(VegetablesPage.pageName);
+    });
+
+    it("When a question in another section has a routing rule dependency on a calculated summary total, and the calculated summary total is greater than £100, then we should be routed to the second question block", () => {
+      $(HubPage.summaryRowLink("calculated-summary-section")).click();
+      $(FirstQuestionBlockPage.milk()).setValue(30);
+      $(FirstQuestionBlockPage.eggs()).setValue(30);
+      $(FirstQuestionBlockPage.bread()).setValue(30);
+      $(FirstQuestionBlockPage.cheese()).setValue(30);
+      $(FirstQuestionBlockPage.submit()).click();
+      $(CurrencyTotalPlaybackPage.submit()).click();
+      $(CalculatedSummarySectionSummaryPage.submit()).click();
+
+      $(HubPage.summaryRowLink("dependent-question-section")).click();
+      $(VegetablesPage.yes()).click();
+      $(VegetablesPage.submit()).click();
+      expect(browser.getUrl()).to.contain(SecondQuestionBlockPage.pageName);
+    });
+
+    it("When a question in another section has a routing rule dependency on a calculated summary total, and the calculated summary total is less than £100, then we should be routed to the section summary", () => {
+      $(HubPage.summaryRowLink("calculated-summary-section")).click();
+      $(FirstQuestionBlockPage.milk()).setValue(20);
+      $(FirstQuestionBlockPage.eggs()).setValue(20);
+      $(FirstQuestionBlockPage.bread()).setValue(20);
+      $(FirstQuestionBlockPage.cheese()).setValue(20);
+      $(FirstQuestionBlockPage.submit()).click();
+      $(CurrencyTotalPlaybackPage.submit()).click();
+      $(CalculatedSummarySectionSummaryPage.submit()).click();
+
+      $(HubPage.summaryRowLink("dependent-question-section")).click();
+      $(VegetablesPage.yes()).click();
+      $(VegetablesPage.submit()).click();
+      expect(browser.getUrl()).to.contain(DependentQuestionSectionSummaryPage.pageName);
+    });
+
+    it("When a question in another section has a dependency on a calculated summary total, and both sections are complete, and I go back and edit the calculated summary total, then the dependent section status should be in progress", () => {
+      $(HubPage.summaryRowLink("calculated-summary-section")).click();
+      $(FirstQuestionBlockPage.milk()).setValue(20);
+      $(FirstQuestionBlockPage.eggs()).setValue(20);
+      $(FirstQuestionBlockPage.bread()).setValue(20);
+      $(FirstQuestionBlockPage.cheese()).setValue(20);
+      $(FirstQuestionBlockPage.submit()).click();
+      $(CurrencyTotalPlaybackPage.submit()).click();
+      $(CalculatedSummarySectionSummaryPage.submit()).click();
+
+      $(HubPage.summaryRowLink("dependent-question-section")).click();
+      $(VegetablesPage.yes()).click();
+      $(VegetablesPage.submit()).click();
+      $(DependentQuestionSectionSummaryPage.submit()).click();
+      expect($(HubPage.summaryRowState("dependent-question-section")).getText()).to.equal("Completed");
+
+      $(HubPage.summaryRowLink("calculated-summary-section")).click();
+      $(CurrencyTotalPlaybackPage.milkAnswerEdit()).click();
+      $(FirstQuestionBlockPage.milk()).setValue(100);
+      $(FirstQuestionBlockPage.submit()).click();
+      $(CurrencyTotalPlaybackPage.submit()).click();
+      $(CalculatedSummarySectionSummaryPage.submit()).click();
+      expect($(HubPage.summaryRowState("dependent-question-section")).getText()).to.equal("Partially completed");
+    });
+  });
+});


### PR DESCRIPTION
### What is the context of this PR?

Adds support so that `section enabled`, `routing_rules` and `skip_conditions` dependencies can be based on a `calculated_summary` total from another section.

### How to review 

Use the  new `test_new_routing_section_dependencies_calculated_summary.json` schema to test this change.

Follow the tests outlined in the newly added functional test. Has anything been missed?

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
