### PR TITLE
Fix detail answer value bug in convert_payload_0_0_1

### DIFF
--- a/app/submitter/convert_payload_0_0_1.py
+++ b/app/submitter/convert_payload_0_0_1.py
@@ -127,6 +127,7 @@ def _get_checkbox_answer_data(
             if "detail_answer" in option:
                 detail_answer = answer_store.get_answer(option["detail_answer"]["id"])
                 if detail_answer:
+                    # Ignore mypy type because the answer type can be any non strings, but user_answer is expected to be a string.
                     user_answer = detail_answer.value  # type: ignore
 
             qcodes_and_values.append((option.get("q_code"), user_answer))

--- a/app/submitter/convert_payload_0_0_1.py
+++ b/app/submitter/convert_payload_0_0_1.py
@@ -126,10 +126,8 @@ def _get_checkbox_answer_data(
         if option:
             if "detail_answer" in option:
                 detail_answer = answer_store.get_answer(option["detail_answer"]["id"])
-                # if the user has selected an option with a detail answer we need to find the detail answer value it refers to.
-                # the detail answer maybe None and the value could be empty, in this case we just use the main value (e.g. other)
-                if detail_answer:
-                    user_answer = detail_answer.value or user_answer  # type: ignore
+                if detail_answer and detail_answer.value:
+                    user_answer = detail_answer.value  # type: ignore
 
             qcodes_and_values.append((option.get("q_code"), user_answer))
 

--- a/app/submitter/convert_payload_0_0_1.py
+++ b/app/submitter/convert_payload_0_0_1.py
@@ -126,7 +126,7 @@ def _get_checkbox_answer_data(
         if option:
             if "detail_answer" in option:
                 detail_answer = answer_store.get_answer(option["detail_answer"]["id"])
-                if detail_answer and detail_answer.value:
+                if detail_answer:
                     user_answer = detail_answer.value  # type: ignore
 
             qcodes_and_values.append((option.get("q_code"), user_answer))

--- a/app/submitter/convert_payload_0_0_1.py
+++ b/app/submitter/convert_payload_0_0_1.py
@@ -127,8 +127,9 @@ def _get_checkbox_answer_data(
             if "detail_answer" in option:
                 detail_answer = answer_store.get_answer(option["detail_answer"]["id"])
                 # if the user has selected an option with a detail answer we need to find the detail answer value it refers to.
-                # the detail answer value can be empty, in this case we just use the main value (e.g. other)
-                user_answer = detail_answer.value or user_answer  # type: ignore
+                # the detail answer maybe None and the value could be empty, in this case we just use the main value (e.g. other)
+                if detail_answer:
+                    user_answer = detail_answer.value or user_answer  # type: ignore
 
             qcodes_and_values.append((option.get("q_code"), user_answer))
 

--- a/tests/app/submitter/test_convert_payload_0_0_1.py
+++ b/tests/app/submitter/test_convert_payload_0_0_1.py
@@ -337,6 +337,67 @@ def test_converter_checkboxes_with_q_codes_and_empty_other_value(
     assert answer_object["data"]["4"] == "Other"
 
 
+def test_converter_checkboxes_with_missing_detail_answer_value_in_answer_store(
+    fake_questionnaire_store,
+):
+    full_routing_path = [RoutingPath(["crisps"], section_id="food", list_item_id=None)]
+
+    fake_questionnaire_store.answer_store = AnswerStore(
+        [
+            Answer("crisps-answer", ["Ready salted", "Other"]).to_dict(),
+        ]
+    )
+
+    question = {
+        "id": "crisps-question",
+        "type": "General",
+        "answers": [
+            {
+                "id": "crisps-answer",
+                "type": "Checkbox",
+                "options": [
+                    {"label": "Ready salted", "value": "Ready salted", "q_code": "1"},
+                    {"label": "Sweet chilli", "value": "Sweet chilli", "q_code": "2"},
+                    {
+                        "label": "Cheese and onion",
+                        "value": "Cheese and onion",
+                        "q_code": "3",
+                    },
+                    {
+                        "label": "Other",
+                        "q_code": "4",
+                        "description": "Choose any other flavour",
+                        "value": "Other",
+                        "detail_answer": {
+                            "mandatory": False,
+                            "id": "other-answer-mandatory",
+                            "label": "Please specify other",
+                            "type": "TextField",
+                        },
+                    },
+                ],
+            }
+        ],
+    }
+
+    questionnaire = make_schema(
+        "0.0.1", "section-1", "favourite-food", "crisps", question
+    )
+
+    # When
+    answer_object = convert_answers(
+        QuestionnaireSchema(questionnaire),
+        fake_questionnaire_store,
+        full_routing_path,
+        SUBMITTED_AT,
+    )
+
+    # Then
+    assert len(answer_object["data"]) == 2
+    assert answer_object["data"]["1"] == "Ready salted"
+    assert answer_object["data"]["4"] == "Other"
+
+
 def test_converter_checkboxes_with_missing_q_codes_uses_answer_q_code(
     fake_questionnaire_store,
 ):

--- a/tests/app/submitter/test_convert_payload_0_0_1.py
+++ b/tests/app/submitter/test_convert_payload_0_0_1.py
@@ -275,68 +275,6 @@ def test_converter_checkboxes_with_q_codes_and_other_value(fake_questionnaire_st
     assert answer_object["data"]["4"] == "Bacon"
 
 
-def test_converter_checkboxes_with_q_codes_and_empty_other_value(
-    fake_questionnaire_store,
-):
-    full_routing_path = [RoutingPath(["crisps"], section_id="food", list_item_id=None)]
-
-    fake_questionnaire_store.answer_store = AnswerStore(
-        [
-            Answer("crisps-answer", ["Ready salted", "Other"]).to_dict(),
-            Answer("other-answer-mandatory", "").to_dict(),
-        ]
-    )
-
-    question = {
-        "id": "crisps-question",
-        "type": "General",
-        "answers": [
-            {
-                "id": "crisps-answer",
-                "type": "Checkbox",
-                "options": [
-                    {"label": "Ready salted", "value": "Ready salted", "q_code": "1"},
-                    {"label": "Sweet chilli", "value": "Sweet chilli", "q_code": "2"},
-                    {
-                        "label": "Cheese and onion",
-                        "value": "Cheese and onion",
-                        "q_code": "3",
-                    },
-                    {
-                        "label": "Other",
-                        "q_code": "4",
-                        "description": "Choose any other flavour",
-                        "value": "Other",
-                        "detail_answer": {
-                            "mandatory": True,
-                            "id": "other-answer-mandatory",
-                            "label": "Please specify other",
-                            "type": "TextField",
-                        },
-                    },
-                ],
-            }
-        ],
-    }
-
-    questionnaire = make_schema(
-        "0.0.1", "section-1", "favourite-food", "crisps", question
-    )
-
-    # When
-    answer_object = convert_answers(
-        QuestionnaireSchema(questionnaire),
-        fake_questionnaire_store,
-        full_routing_path,
-        SUBMITTED_AT,
-    )
-
-    # Then
-    assert len(answer_object["data"]) == 2
-    assert answer_object["data"]["1"] == "Ready salted"
-    assert answer_object["data"]["4"] == "Other"
-
-
 def test_converter_checkboxes_with_missing_detail_answer_value_in_answer_store(
     fake_questionnaire_store,
 ):


### PR DESCRIPTION
### What is the context of this PR?

Identified a bug on submission in our `covert_payload_0_0_1.py` while testing the BICS survey. When a user selected a detail answer field but did not set an answer, we were getting a 500 error as `detail_answer.value` could not be resolved as the value the `detail_answer` was  a `None` type.

Added a check to ensure that the `detail_answer` was not a None type before getting the value.

### How to review 

Check all tests pass.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
