### PR TITLE
Bug fix: Support radio detail answer for data version 0.0.1

### DIFF
--- a/app/forms/questionnaire_form.py
+++ b/app/forms/questionnaire_form.py
@@ -147,7 +147,9 @@ class QuestionnaireForm(FlaskForm):
 
         return False
 
-    def validate_mutually_exclusive_question(self, question: QuestionSchemaType) -> bool:
+    def validate_mutually_exclusive_question(
+        self, question: QuestionSchemaType
+    ) -> bool:
         is_mandatory: bool = question["mandatory"]
         messages = (
             question["validation"].get("messages") if "validation" in question else None

--- a/app/forms/questionnaire_form.py
+++ b/app/forms/questionnaire_form.py
@@ -16,7 +16,7 @@ from app.data_models import AnswerStore, AnswerValueTypes, ListStore
 from app.forms import error_messages
 from app.forms.field_handlers import DateHandler, FieldHandler, get_field_handler
 from app.forms.validators import DateRangeCheck, MutuallyExclusiveCheck, SumCheck
-from app.questionnaire import Location, QuestionnaireSchema, QuestionSchema
+from app.questionnaire import Location, QuestionnaireSchema, QuestionSchemaType
 from app.questionnaire.relationship_location import RelationshipLocation
 from app.questionnaire.rules.rule_evaluator import RuleEvaluator
 from app.questionnaire.value_source_resolver import ValueSourceResolver
@@ -37,7 +37,7 @@ class QuestionnaireForm(FlaskForm):
     def __init__(
         self,
         schema: QuestionnaireSchema,
-        question_schema: QuestionSchema,
+        question_schema: QuestionSchemaType,
         answer_store: AnswerStore,
         list_store: ListStore,
         metadata: Mapping[str, Any],
@@ -92,7 +92,7 @@ class QuestionnaireForm(FlaskForm):
             and valid_mutually_exclusive_form
         )
 
-    def validate_date_range_question(self, question: QuestionSchema) -> bool:
+    def validate_date_range_question(self, question: QuestionSchemaType) -> bool:
         date_from = question["answers"][0]
         date_to = question["answers"][1]
         if self._has_min_and_max_single_dates(date_from, date_to):
@@ -130,7 +130,7 @@ class QuestionnaireForm(FlaskForm):
 
         return True
 
-    def validate_calculated_question(self, question: QuestionSchema) -> bool:
+    def validate_calculated_question(self, question: QuestionSchemaType) -> bool:
         for calculation in question["calculations"]:
             result = self._get_target_total_and_currency(calculation, question)
             if result:
@@ -147,7 +147,7 @@ class QuestionnaireForm(FlaskForm):
 
         return False
 
-    def validate_mutually_exclusive_question(self, question: QuestionSchema) -> bool:
+    def validate_mutually_exclusive_question(self, question: QuestionSchemaType) -> bool:
         is_mandatory: bool = question["mandatory"]
         messages = (
             question["validation"].get("messages") if "validation" in question else None
@@ -173,7 +173,7 @@ class QuestionnaireForm(FlaskForm):
     def _get_target_total_and_currency(
         self,
         calculation: Calculation,
-        question: QuestionSchema,
+        question: QuestionSchemaType,
     ) -> Optional[tuple[Union[Calculation, AnswerValueTypes], Optional[str]]]:
 
         calculation_value: Union[Calculation, AnswerValueTypes]
@@ -249,7 +249,7 @@ class QuestionnaireForm(FlaskForm):
     def _validate_calculated_question(
         self,
         calculation: Calculation,
-        question: QuestionSchema,
+        question: QuestionSchemaType,
         target_total: Any,
         currency: Optional[str],
     ) -> bool:
@@ -427,7 +427,7 @@ def _option_value_in_data(
 
 
 def get_answer_fields(
-    question: QuestionSchema,
+    question: QuestionSchemaType,
     data: Union[None, MultiDict[str, Any], Mapping[str, Any]],
     schema: QuestionnaireSchema,
     answer_store: AnswerStore,
@@ -526,7 +526,7 @@ def _get_error_id(id_: str) -> str:
 
 
 def _clear_detail_answer_field(
-    form_data: MultiDict, question_schema: QuestionSchema
+    form_data: MultiDict, question_schema: QuestionSchemaType
 ) -> MultiDict[str, Any]:
     """
     Clears the detail answer field if the parent option is not selected
@@ -544,7 +544,7 @@ def _clear_detail_answer_field(
 
 def generate_form(
     schema: QuestionnaireSchema,
-    question_schema: QuestionSchema,
+    question_schema: QuestionSchemaType,
     answer_store: AnswerStore,
     list_store: ListStore,
     metadata: Mapping[str, Any],

--- a/app/questionnaire/__init__.py
+++ b/app/questionnaire/__init__.py
@@ -1,4 +1,4 @@
 from .location import Location
-from .questionnaire_schema import QuestionnaireSchema, QuestionSchema
+from .questionnaire_schema import QuestionnaireSchema, QuestionSchemaType
 
-__all__ = ["QuestionnaireSchema", "Location", "QuestionSchema"]
+__all__ = ["QuestionnaireSchema", "Location", "QuestionSchemaType"]

--- a/app/questionnaire/questionnaire_schema.py
+++ b/app/questionnaire/questionnaire_schema.py
@@ -643,16 +643,22 @@ class QuestionnaireSchema:  # pylint: disable=too-many-public-methods
             return None
 
     @classmethod
-    def get_answer_ids_for_question(cls, question: Mapping) -> list[str]:
-        answer_ids: list[str] = []
+    def get_answers_for_question_by_id(
+        cls, question: Mapping[str, Any]
+    ) -> dict[str, dict[str, Any]]:
+        answers: dict[str, dict[str, Any]] = {}
 
-        for answer in question.get("answers", []):
-            answer_ids.append(answer["id"])
-            for option in answer.get("options", []):
+        for answer in question.get("answers", {}):
+            answers[answer["id"]] = answer
+            for option in answer.get("options", {}):
                 if "detail_answer" in option:
-                    answer_ids.append(option["detail_answer"]["id"])
+                    answers[option["detail_answer"]["id"]] = option["detail_answer"]
 
-        return answer_ids
+        return answers
+
+    @classmethod
+    def get_answer_ids_for_question(cls, question: Mapping[str, Any]) -> list[str]:
+        return list(cls.get_answers_for_question_by_id(question).keys())
 
     def get_first_answer_id_for_block(self, block_id: str) -> str:
         answer_ids = self.get_answer_ids_for_block(block_id)

--- a/app/questionnaire/questionnaire_schema.py
+++ b/app/questionnaire/questionnaire_schema.py
@@ -22,7 +22,7 @@ LIST_COLLECTOR_CHILDREN = [
 
 RELATIONSHIP_CHILDREN = ["UnrelatedQuestion"]
 
-QuestionSchema = Mapping[str, Any]
+QuestionSchemaType = Mapping[str, Any]
 
 
 class InvalidSchemaConfigurationException(Exception):
@@ -644,7 +644,7 @@ class QuestionnaireSchema:  # pylint: disable=too-many-public-methods
 
     @classmethod
     def get_answers_for_question_by_id(
-        cls, question: Mapping[str, Any]
+        cls, question: QuestionSchemaType
     ) -> dict[str, dict[str, Any]]:
         answers: dict[str, dict[str, Any]] = {}
 
@@ -657,7 +657,7 @@ class QuestionnaireSchema:  # pylint: disable=too-many-public-methods
         return answers
 
     @classmethod
-    def get_answer_ids_for_question(cls, question: Mapping[str, Any]) -> list[str]:
+    def get_answer_ids_for_question(cls, question: QuestionSchemaType) -> list[str]:
         return list(cls.get_answers_for_question_by_id(question).keys())
 
     def get_first_answer_id_for_block(self, block_id: str) -> str:

--- a/app/submitter/convert_payload_0_0_1.py
+++ b/app/submitter/convert_payload_0_0_1.py
@@ -62,9 +62,12 @@ def convert_answers_to_payload_0_0_1(
                     list_store,
                     current_location=current_location,
                 )
-                for answer in question["answers"]:
-                    if answer["id"] == answer_in_block.answer_id:
+                for answer_id, answer in schema.get_answers_for_question_by_id(
+                    question
+                ).items():
+                    if answer_id == answer_in_block.answer_id:
                         answer_schema = answer
+                        break
 
                 value = answer_in_block.value
 

--- a/app/views/handlers/confirm_email.py
+++ b/app/views/handlers/confirm_email.py
@@ -17,7 +17,7 @@ from app.data_models import (
 )
 from app.forms.questionnaire_form import generate_form
 from app.helpers import url_safe_serializer
-from app.questionnaire import QuestionnaireSchema, QuestionSchema
+from app.questionnaire import QuestionnaireSchema, QuestionSchemaType
 from app.settings import (
     EQ_SUBMISSION_CONFIRMATION_CLOUD_FUNCTION_NAME,
     EQ_SUBMISSION_CONFIRMATION_QUEUE,
@@ -81,7 +81,7 @@ class ConfirmEmail:
         )
 
     @cached_property
-    def question_schema(self) -> QuestionSchema:
+    def question_schema(self) -> QuestionSchemaType:
         return {
             "type": "General",
             "id": "confirm-email",

--- a/schemas/test/en/test_checkbox.json
+++ b/schemas/test/en/test_checkbox.json
@@ -2,7 +2,7 @@
     "mime_type": "application/json/ons/eq",
     "language": "en",
     "schema_version": "0.0.1",
-    "data_version": "0.0.1",
+    "data_version": "0.0.3",
     "survey_id": "0",
     "title": "Other input fields",
     "theme": "default",

--- a/schemas/test/en/test_checkbox.json
+++ b/schemas/test/en/test_checkbox.json
@@ -2,7 +2,7 @@
     "mime_type": "application/json/ons/eq",
     "language": "en",
     "schema_version": "0.0.1",
-    "data_version": "0.0.3",
+    "data_version": "0.0.1",
     "survey_id": "0",
     "title": "Other input fields",
     "theme": "default",

--- a/tests/app/submitter/test_convert_payload_0_0_1.py
+++ b/tests/app/submitter/test_convert_payload_0_0_1.py
@@ -441,7 +441,10 @@ def test_radio_answer(fake_questionnaire_store):
         RoutingPath(["radio-block"], section_id="section-1", list_item_id=None)
     ]
     fake_questionnaire_store.answer_store = AnswerStore(
-        [Answer("radio-answer", "Coffee").to_dict()]
+        [
+            Answer("radio-answer", "Coffee").to_dict(),
+            Answer("other-answer-mandatory", "Water").to_dict(),
+        ],
     )
 
     question = {
@@ -455,6 +458,17 @@ def test_radio_answer(fake_questionnaire_store):
                 "options": [
                     {"label": "Coffee", "value": "Coffee"},
                     {"label": "Tea", "value": "Tea"},
+                    {
+                        "label": "Other",
+                        "value": "Other",
+                        "detail_answer": {
+                            "mandatory": True,
+                            "id": "other-answer-mandatory",
+                            "label": "Please specify other",
+                            "type": "TextField",
+                            "q_code": "101",
+                        },
+                    },
                 ],
             }
         ],
@@ -472,8 +486,9 @@ def test_radio_answer(fake_questionnaire_store):
     )
 
     # Then
-    assert len(answer_object["data"]) == 1
+    assert len(answer_object["data"]) == 2
     assert answer_object["data"]["1"] == "Coffee"
+    assert answer_object["data"]["101"] == "Water"
 
 
 def test_number_answer(fake_questionnaire_store):


### PR DESCRIPTION
### What is the context of this PR?
Radio details answer was being ignored for data version 0.0.1. This PR ensure details answer for radios are in the downstream payload.

### How to review 
- Test with a schema that has a radio detail answer, i.e `covid_001`.
- Complete the first section
- For the "Exporting" section, for answers "Other" and enter a detail answer
- Once on the hub, try a submission via `/dump/submission` and ensure the `Other` value and it's user entered detail answers are in the payload.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
