### PR TITLE
Fix yarn typescript warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,8 +54,5 @@
         "wdio-chromedriver-service": "^7.2.8",
         "webdriverio": "^7.17.4"
     },
-    "prettier": {},
-    "dependencies": {
-        "typescript": "^4.7.4"
-    }
+    "prettier": {}
 }

--- a/package.json
+++ b/package.json
@@ -54,5 +54,8 @@
         "wdio-chromedriver-service": "^7.2.8",
         "webdriverio": "^7.17.4"
     },
-    "prettier": {}
+    "prettier": {},
+    "dependencies": {
+        "typescript": "^4.7.4"
+    }
 }

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
         "node-forge": "^1.2.1",
         "node-jose": "^2.1.0",
         "prettier": "^2.5.1",
+        "typescript": "^4.7.4",
         "uuid": "^8.3.2",
         "wdio-chromedriver-service": "^7.2.8",
         "webdriverio": "^7.17.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5028,6 +5028,11 @@ type-fest@^0.21.3:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
   integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
 
+typescript@^4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
+
 ua-parser-js@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-1.0.2.tgz#e2976c34dbfb30b15d2c300b2a53eac87c57a775"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5028,11 +5028,6 @@ type-fest@^0.21.3:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
   integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
 
-typescript@^4.7.4:
-  version "4.7.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
-  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
-
 ua-parser-js@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-1.0.2.tgz#e2976c34dbfb30b15d2c300b2a53eac87c57a775"


### PR DESCRIPTION
### What is the context of this PR?
When running `yarn` to update js dependancies this warning appears
![Screenshot 2022-08-16 at 10 31 50](https://user-images.githubusercontent.com/42928680/184847494-aac8cfc5-c34a-4392-b7ef-76a50b34edbc.png)

This PR will install typescript to remove this warning

### How to review 
Run `yarn` on master see warning
Run `yarn` on this branch see warning is gone

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
