### PR TITLE
Fix percentage symbol missing on input

### DIFF
--- a/templates/partials/answers/percentage.html
+++ b/templates/partials/answers/percentage.html
@@ -18,7 +18,8 @@
   },
   "suffix": {
     "id": answer.id ~ "-type",
-    "title": "%"
+    "title": "Percent",
+    "text": "%"
   },
   "dontWrap": true if mutuallyExclusive else false,
   "mutuallyExclusive": mutuallyExclusive,

--- a/tests/integration/components/test_render_percentage_widget.py
+++ b/tests/integration/components/test_render_percentage_widget.py
@@ -8,7 +8,7 @@ class TestRenderPercentageWidget(IntegrationTestCase):
         self.launchSurvey("test_percentage")
 
     def test_percentage_widget_has_icon(self):
-        self.assertInSelectorCSS("%", "abbr", {"class": "ons-input-type__type"})
+        self.assertInSelectorCSS(">%</abbr>", "abbr", {"class": "ons-input-type__type"})
 
     def test_entering_invalid_number_displays_error(self):
         self.post({"answer": "not a percentage"})


### PR DESCRIPTION
### What is the context of this PR?
Percentage symbol is missing from the suffix on `test_percentage` schema

![Screenshot 2022-09-16 at 15 04 47](https://user-images.githubusercontent.com/42928680/190660501-ef333f70-89a7-49e4-b9f1-f61b07bc8626.png)

### How to review 
Open the `test_percentage` schema and see that the percentage symbol suffix is displayed

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
