### PR TITLE
Fix button GA tracking

### DIFF
--- a/templates/layouts/configs/_save-sign-out-button.html
+++ b/templates/layouts/configs/_save-sign-out-button.html
@@ -6,10 +6,9 @@
             "text": sign_out_button_text,
             "url": sign_out_url,
             "attributes": {
-                "data-qa": "btn-save-sign-out",
-                "data-ga": "click",
+                "data-ga-label": "Save and sign out Button click",
                 "data-ga-category": "Navigation",
-                "data-ga-action": "Save and sign out click"
+                "data-ga-action": "Save and sign out"
             },
             "iconType": "exit",
             "iconPosition": "after"
@@ -20,10 +19,9 @@
             "text": _("Exit"),
             "url": sign_out_url,
             "attributes": {
-                "data-qa": "btn-exit",
-                "data-ga": "click",
+                "data-ga-label": "Exit Button click",
                 "data-ga-category": "Navigation",
-                "data-ga-action": "Exit click"
+                "data-ga-action": "Exit"
             },
             "iconType": "exit",
             "iconPosition": 'after'

--- a/templates/view-submitted-response.html
+++ b/templates/view-submitted-response.html
@@ -36,7 +36,9 @@
         "buttonStyle": "print",
         "variants": ['small', 'secondary'],
         "attributes": {
-          "data-qa": "btn-print"
+          "data-ga-category": "Print Button",
+          "data-ga-action": "Open Print Dialogue",
+          "data-ga-label": "Print Button click"
         }
       })
     }}
@@ -49,7 +51,9 @@
         "url": content.pdf_url,
         "removeDownloadAttribute": true,
         "attributes": {
-          "data-qa": "btn-pdf"
+          "data-ga-category": "PDF Button",
+          "data-ga-action": "Download PDF",
+          "data-ga-label": "PDF Button click"
         }
       })
     }}


### PR DESCRIPTION
### What is the context of this PR?
Fixes some issues with tracking of button clicks in Google Analytics and removes the setting of one attribute twice.
Buttons affected:
- Print button
- Download PDF button
- Save and sign out button
- Exit button

### How to review 
Check attributes are set for all buttons affected. The `test_view_submitted_response_schema` is good for this

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
