### PR TITLE
Fix session expired page links

### DIFF
--- a/app/routes/session.py
+++ b/app/routes/session.py
@@ -13,6 +13,7 @@ from app.authentication.authenticator import decrypt_token, store_session
 from app.authentication.jti_claim_storage import JtiTokenUsed, use_jti_claim
 from app.globals import get_session_store, get_session_timeout_in_seconds
 from app.helpers.template_helpers import get_survey_config, render_template
+from app.routes.errors import _render_error_page
 from app.utilities.metadata_parser import (
     validate_questionnaire_claims,
     validate_runner_claims,
@@ -118,7 +119,7 @@ def get_session_expired():
     if request.method == "GET":
         logout_user()
 
-    return render_template("errors/401")
+    return _render_error_page(200, template="401")
 
 
 @session_blueprint.route("/session-expiry", methods=["GET", "PATCH"])

--- a/tests/integration/routes/test_session.py
+++ b/tests/integration/routes/test_session.py
@@ -29,6 +29,13 @@ class TestSession(IntegrationTestCase):
     def test_session_expired(self):
         self.get("/session-expired")
         self.assertInBody("Sorry, you need to sign in again")
+        self.assertInBody(
+            '<p>If you are completing a business survey, you need to sign back in to <a href="https://surveys.ons.gov.uk/sign-in/logout">your account</a>.</p>'
+        )
+        self.assertInBody(
+            '<p>If you started your survey using an access code, you need to <a href="https://start.surveys.ons.gov.uk/sign-in/logout">re-enter your code</a>.'
+            "</p>"
+        )
 
     def test_session_jti_token_expired(self):
         self.launchSurvey(exp=time.time() - float(60))


### PR DESCRIPTION
### What is the context of this PR?
This fixes the way we render `session-expired` page that uses `401.html` template. The correct way is to use the `_render_error_page()` method for all error pages (that creates all the required vars) instead of ordinary `render_template()`.

### How to review 
Two new assertions added that check if required urls exists.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
