### PR TITLE
Remove case_ref from Social/Health schemas

### DIFF
--- a/schemas/test/en/test_theme_health.json
+++ b/schemas/test/en/test_theme_health.json
@@ -9,10 +9,6 @@
     "description": "A questionnaire to demo the health survey theme",
     "metadata": [
         {
-            "name": "case_ref",
-            "type": "string"
-        },
-        {
             "name": "questionnaire_id",
             "type": "string"
         }

--- a/schemas/test/en/test_theme_social.json
+++ b/schemas/test/en/test_theme_social.json
@@ -9,10 +9,6 @@
     "description": "A questionnaire to demo the social survey theme",
     "metadata": [
         {
-            "name": "case_ref",
-            "type": "string"
-        },
-        {
             "name": "questionnaire_id",
             "type": "string"
         }


### PR DESCRIPTION
### What is the context of this PR?
Removes case_ref from Social/Health schema as they are not required fields.