### PR TITLE
Rename questionnaire_id to qid

### DIFF
--- a/app/routes/session.py
+++ b/app/routes/session.py
@@ -71,11 +71,11 @@ def login():
             runner_claims["survey_metadata"]["data"] = questionnaire_claims
 
         ru_ref = questionnaire_claims.get("ru_ref")
-        questionnaire_id = questionnaire_claims.get("questionnaire_id")
+        qid = questionnaire_claims.get("qid")
         claims = runner_claims
     else:
         ru_ref = runner_claims["ru_ref"]
-        questionnaire_id = None
+        qid = None
         claims = {**runner_claims, **questionnaire_claims}
 
     tx_id = claims["tx_id"]
@@ -89,7 +89,7 @@ def login():
             "schema_name": metadata.schema_name,
             "schema_url": metadata.schema_url,
             "ru_ref": ru_ref,
-            "questionnaire_id": questionnaire_id,
+            "qid": qid,
         }.items()
         if value
     }

--- a/schemas/test/en/test_theme_health.json
+++ b/schemas/test/en/test_theme_health.json
@@ -13,7 +13,7 @@
             "type": "string"
         },
         {
-            "name": "questionnaire_id",
+            "name": "qid",
             "type": "string"
         }
     ],

--- a/schemas/test/en/test_theme_social.json
+++ b/schemas/test/en/test_theme_social.json
@@ -13,7 +13,7 @@
             "type": "string"
         },
         {
-            "name": "questionnaire_id",
+            "name": "qid",
             "type": "string"
         }
     ],

--- a/tests/app/parser/conftest.py
+++ b/tests/app/parser/conftest.py
@@ -119,13 +119,13 @@ def fake_metadata_full_v2_social():
     """
     fake_survey_metadata_claims = {
         "case_ref": "1000000000000001",
-        "questionnaire_id": "2000000000000002",
+        "qid": "2000000000000002",
     }
 
     metadata = fake_metadata_runner_v2()
 
     metadata["survey_metadata"]["data"] = fake_survey_metadata_claims
-    metadata["survey_metadata"]["receipting_keys"] = ["questionnaire_id"]
+    metadata["survey_metadata"]["receipting_keys"] = ["qid"]
 
     return metadata
 

--- a/tests/app/parser/test_metadata_parser.py
+++ b/tests/app/parser/test_metadata_parser.py
@@ -417,7 +417,7 @@ def test_valid_v2_social_claims():
 def test_invalid_v2_social_claims_missing_receipting_key_raises_error():
     metadata = get_metadata_social()
 
-    del metadata["survey_metadata"]["data"]["questionnaire_id"]
+    del metadata["survey_metadata"]["data"]["qid"]
 
     with pytest.raises(ValidationError):
         validate_runner_claims_v2(metadata)

--- a/tests/app/submitter/test_submitter.py
+++ b/tests/app/submitter/test_submitter.py
@@ -217,7 +217,7 @@ def test_gcs_submitter_adds_additional_keys_to_metadata_when_set(patch_gcs_clien
 
     # When
     gcs_submitter.send_message(
-        message={"test_data"}, tx_id="123", case_id="456", **{"questionnaire_id": "1"}
+        message={"test_data"}, tx_id="123", case_id="456", **{"qid": "1"}
     )
 
     # Then
@@ -227,7 +227,7 @@ def test_gcs_submitter_adds_additional_keys_to_metadata_when_set(patch_gcs_clien
     assert blob.metadata == {
         "tx_id": "123",
         "case_id": "456",
-        "questionnaire_id": "1",
+        "qid": "1",
     }
 
 
@@ -239,7 +239,7 @@ def test_gcs_feedback_submitter_adds_additional_keys_to_metadata_when_set(
     # When
     gcs_submitter.upload(
         payload=json_dumps({"some-data": "some-value"}),
-        metadata={"tx_id": "123", "case_id": "456", "questionnaire_id": "1"},
+        metadata={"tx_id": "123", "case_id": "456", "qid": "1"},
     )
 
     # Then
@@ -249,7 +249,7 @@ def test_gcs_feedback_submitter_adds_additional_keys_to_metadata_when_set(
     assert blob.metadata == {
         "tx_id": "123",
         "case_id": "456",
-        "questionnaire_id": "1",
+        "qid": "1",
     }
 
 

--- a/tests/app/views/handlers/test_feedback_upload.py
+++ b/tests/app/views/handlers/test_feedback_upload.py
@@ -177,10 +177,10 @@ def test_feedback_metadata():
 
 
 def test_feedback_metadata_with_receipting_keys():
-    receipting_keys = {"questionnaire_id": "1"}
+    receipting_keys = {"qid": "1"}
 
     feedback_metadata = FeedbackMetadata(case_id, tx_id, **receipting_keys)
 
-    expected_metadata = {"case_id": case_id, "tx_id": tx_id, "questionnaire_id": "1"}
+    expected_metadata = {"case_id": case_id, "tx_id": tx_id, "qid": "1"}
 
     assert feedback_metadata() == expected_metadata

--- a/tests/functional/jwt_helper.js
+++ b/tests/functional/jwt_helper.js
@@ -183,9 +183,9 @@ function getSurveyMetadata(theme, userId, displayAddress, periodId, periodStr) {
     surveyMetadata = {
       data: {
         case_ref: "1000000000000001",
-        questionnaire_id: "1000000000000001",
+        qid: "1000000000000001",
       },
-      receipting_keys: ["questionnaire_id"],
+      receipting_keys: ["qid"],
     };
   } else {
     surveyMetadata = {

--- a/tests/integration/create_token.py
+++ b/tests/integration/create_token.py
@@ -55,9 +55,9 @@ PAYLOAD_V2_SOCIAL = {
     "survey_metadata": {
         "data": {
             "case_ref": "1000000000000001",
-            "questionnaire_id": str(uuid4()),
+            "qid": str(uuid4()),
         },
-        "receipting_keys": ["questionnaire_id"],
+        "receipting_keys": ["qid"],
     },
     "collection_exercise_sid": "789",
     "response_id": "1234567890123456",
@@ -150,7 +150,7 @@ class TokenGenerator:
         payload_vars = self._get_payload_with_params(
             schema_name=schema_name, payload=PAYLOAD_V2_SOCIAL, **extra_payload
         )
-        del payload_vars["survey_metadata"]["data"]["questionnaire_id"]
+        del payload_vars["survey_metadata"]["data"]["qid"]
 
         return self.generate_token(payload_vars)
 


### PR DESCRIPTION
### What is the context of this PR?
The property `questionnaire_id` has been renamed to `qid` as part of https://github.com/ONSdigital/ons-schema-definitions/pull/71

### How to review 
Ensure all instances have been renamed.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
