### PR TITLE
Evaluate calculated summary is complete when returning to a calculated summary

### DIFF
--- a/app/questionnaire/router.py
+++ b/app/questionnaire/router.py
@@ -219,15 +219,20 @@ class Router:
         if not return_to:
             return None
 
-        if return_to == "calculated-summary":
-            if return_to_block_id in routing_path:
-                return url_for(
-                    "questionnaire.block",
-                    list_item_id=location.list_item_id,
-                    block_id=return_to_block_id,
-                    _anchor=return_to_answer_id,
-                )
-            return None
+        if (
+            return_to == "calculated-summary"
+            and return_to_block_id in routing_path
+            and self.can_access_location(
+                Location(block_id=return_to_block_id, section_id=location.section_id),
+                routing_path,
+            )
+        ):
+            return url_for(
+                "questionnaire.block",
+                list_item_id=location.list_item_id,
+                block_id=return_to_block_id,
+                _anchor=return_to_answer_id,
+            )
 
         if is_section_complete is None:
             is_section_complete = self._progress_store.is_section_complete(

--- a/app/questionnaire/router.py
+++ b/app/questionnaire/router.py
@@ -219,13 +219,13 @@ class Router:
         if not return_to:
             return None
 
-        if (
-            return_to == "calculated-summary"
-            and return_to_block_id in routing_path
-            and self.can_access_location(
-                Location(block_id=return_to_block_id, section_id=location.section_id),
-                routing_path,
-            )
+        if return_to == "calculated-summary" and self.can_access_location(
+            Location(
+                block_id=return_to_block_id,
+                section_id=location.section_id,
+                list_item_id=location.list_item_id,
+            ),
+            routing_path,
         ):
             return url_for(
                 "questionnaire.block",

--- a/schemas/test/en/test_calculated_summary_dependent_questions.json
+++ b/schemas/test/en/test_calculated_summary_dependent_questions.json
@@ -8,9 +8,7 @@
     "description": "A schema to showcase Calculated Summary with dependent questions.",
     "questionnaire_flow": {
         "type": "Linear",
-        "options": {
-
-        }
+        "options": {}
     },
     "sections": [
         {
@@ -142,10 +140,7 @@
                             "title": "We have calculated your total spend to be <em>%(total)s</em>. Is this correct?",
                             "calculation": {
                                 "calculation_type": "sum",
-                                "answers_to_calculate": [
-                                    "answer-1",
-                                    "answer-3"
-                                ],
+                                "answers_to_calculate": ["answer-1", "answer-3"],
                                 "title": "Total capital expenditure"
                             }
                         }

--- a/schemas/test/en/test_calculated_summary_dependent_questions.json
+++ b/schemas/test/en/test_calculated_summary_dependent_questions.json
@@ -1,0 +1,198 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "language": "en",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.3",
+    "survey_id": "0",
+    "title": "A test schema to demo Calculated Summary",
+    "description": "A schema to showcase Calculated Summary with dependent questions.",
+    "questionnaire_flow": {
+        "type": "Linear",
+        "options": {
+
+        }
+    },
+    "sections": [
+        {
+            "id": "default-section",
+            "title": "Section 1",
+            "summary": {
+                "show_on_completion": false,
+                "collapsible": false
+            },
+            "show_on_hub": true,
+            "groups": [
+                {
+                    "id": "group-1",
+                    "blocks": [
+                        {
+                            "id": "block-1",
+                            "type": "Question",
+                            "question": {
+                                "id": "question-1",
+                                "title": "How much did you spend on food?",
+                                "type": "General",
+                                "answers": [
+                                    {
+                                        "id": "answer-1",
+                                        "mandatory": true,
+                                        "type": "Currency",
+                                        "label": "Capital expenditure",
+                                        "description": "Enter the full value",
+                                        "minimum": {
+                                            "value": 0,
+                                            "exclusive": true
+                                        },
+                                        "decimal_places": 2,
+                                        "currency": "GBP"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "id": "block-2",
+                            "type": "Question",
+                            "question": {
+                                "id": "question-2",
+                                "title": "Of the money spent on food, how much did you spend on vegetables?",
+                                "type": "General",
+                                "answers": [
+                                    {
+                                        "id": "answer-2",
+                                        "mandatory": true,
+                                        "type": "Currency",
+                                        "label": "Capital expenditure",
+                                        "description": "Enter the full value",
+                                        "minimum": {
+                                            "value": 0,
+                                            "exclusive": true
+                                        },
+                                        "maximum": {
+                                            "value": {
+                                                "identifier": "answer-1",
+                                                "source": "answers"
+                                            },
+                                            "exclusive": false
+                                        },
+                                        "decimal_places": 2,
+                                        "currency": "GBP"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "id": "block-3",
+                            "type": "Question",
+                            "question": {
+                                "id": "question-3",
+                                "title": "How much did you spend on clothes?",
+                                "type": "General",
+                                "answers": [
+                                    {
+                                        "id": "answer-3",
+                                        "mandatory": true,
+                                        "type": "Currency",
+                                        "label": "Capital expenditure",
+                                        "description": "Enter the full value",
+                                        "minimum": {
+                                            "value": 0,
+                                            "exclusive": true
+                                        },
+                                        "decimal_places": 2,
+                                        "currency": "GBP"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "id": "block-4",
+                            "type": "Question",
+                            "question": {
+                                "id": "question-4",
+                                "title": "Of the money spent on clothes, how much did you spend on shoes?",
+                                "type": "General",
+                                "answers": [
+                                    {
+                                        "id": "answer-4",
+                                        "mandatory": true,
+                                        "type": "Currency",
+                                        "label": "Capital expenditure",
+                                        "description": "Enter the full value",
+                                        "minimum": {
+                                            "value": 0,
+                                            "exclusive": true
+                                        },
+                                        "maximum": {
+                                            "value": {
+                                                "identifier": "answer-3",
+                                                "source": "answers"
+                                            },
+                                            "exclusive": false
+                                        },
+                                        "decimal_places": 2,
+                                        "currency": "GBP"
+                                    }
+                                ]
+                            }
+                        },
+
+                        {
+                            "id": "calculated-summary-block",
+                            "type": "CalculatedSummary",
+                            "title": "We have calculated your total spend to be <em>%(total)s</em>. Is this correct?",
+                            "calculation": {
+                                "calculation_type": "sum",
+                                "answers_to_calculate": [
+                                    "answer-1",
+                                    "answer-3"
+                                ],
+                                "title": "Total capital expenditure"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "theme": "default",
+    "navigation": {
+        "visible": false
+    },
+    "metadata": [
+        {
+            "name": "user_id",
+            "type": "string"
+        },
+        {
+            "name": "period_id",
+            "type": "string"
+        },
+        {
+            "name": "ru_name",
+            "type": "string"
+        },
+        {
+            "name": "ru_ref",
+            "type": "string"
+        },
+        {
+            "name": "ref_p_start_date",
+            "type": "date"
+        },
+        {
+            "name": "ref_p_end_date",
+            "type": "date"
+        }
+    ],
+    "post_submission": {
+        "confirmation_email": true,
+        "feedback": true,
+        "view_response": true
+    },
+    "submission": {
+        "button": "Submit",
+        "title": "Check your answers and submit",
+        "warning": "You must submit this survey to complete it",
+        "guidance": "You will have the opportunity to view, save or print a copy of your answers after submitting this survey."
+    }
+}

--- a/schemas/test/en/test_calculated_summary_dependent_questions.json
+++ b/schemas/test/en/test_calculated_summary_dependent_questions.json
@@ -35,7 +35,7 @@
                                         "id": "answer-1",
                                         "mandatory": true,
                                         "type": "Currency",
-                                        "label": "Capital expenditure",
+                                        "label": "Money spent on food",
                                         "description": "Enter the full value",
                                         "minimum": {
                                             "value": 0,
@@ -59,7 +59,7 @@
                                         "id": "answer-2",
                                         "mandatory": true,
                                         "type": "Currency",
-                                        "label": "Capital expenditure",
+                                        "label": "Money spent on vegetables",
                                         "description": "Enter the full value",
                                         "minimum": {
                                             "value": 0,
@@ -90,7 +90,7 @@
                                         "id": "answer-3",
                                         "mandatory": true,
                                         "type": "Currency",
-                                        "label": "Capital expenditure",
+                                        "label": "Money spent on clothes",
                                         "description": "Enter the full value",
                                         "minimum": {
                                             "value": 0,
@@ -114,7 +114,7 @@
                                         "id": "answer-4",
                                         "mandatory": true,
                                         "type": "Currency",
-                                        "label": "Capital expenditure",
+                                        "label": "Money spent on shoes",
                                         "description": "Enter the full value",
                                         "minimum": {
                                             "value": 0,
@@ -150,9 +150,6 @@
         }
     ],
     "theme": "default",
-    "navigation": {
-        "visible": false
-    },
     "metadata": [
         {
             "name": "user_id",
@@ -165,29 +162,6 @@
         {
             "name": "ru_name",
             "type": "string"
-        },
-        {
-            "name": "ru_ref",
-            "type": "string"
-        },
-        {
-            "name": "ref_p_start_date",
-            "type": "date"
-        },
-        {
-            "name": "ref_p_end_date",
-            "type": "date"
         }
-    ],
-    "post_submission": {
-        "confirmation_email": true,
-        "feedback": true,
-        "view_response": true
-    },
-    "submission": {
-        "button": "Submit",
-        "title": "Check your answers and submit",
-        "warning": "You must submit this survey to complete it",
-        "guidance": "You will have the opportunity to view, save or print a copy of your answers after submitting this survey."
-    }
+    ]
 }

--- a/tests/app/questionnaire/test_router.py
+++ b/tests/app/questionnaire/test_router.py
@@ -511,13 +511,12 @@ class TestRouterNextLocation(RouterTestCase):
         self.schema = load_schema_from_name("test_calculated_summary")
 
         current_location = Location(
-            section_id="default-section", block_id="fifth-number-block"
+            section_id="default-section", block_id="second-number-block"
         )
 
         routing_path = RoutingPath(
             [
-                "fifth-number-block",
-                "sixth-number-block",
+                "second-number-block",
                 "currency-total-playback-skipped-fourth",
             ],
             section_id="default-section",
@@ -539,7 +538,50 @@ class TestRouterNextLocation(RouterTestCase):
             "questionnaire.block",
             list_item_id=expected_location.list_item_id,
             block_id=expected_location.block_id,
-            _anchor="first-number-answer",
+            return_to="calculated-summary",
+            return_to_answer_id="first-number-answer",
+            return_to_block_id="currency-total-playback-skipped-fourth",
+        )
+
+        assert expected_location_url == next_location_url
+
+    @pytest.mark.usefixtures("app")
+    def test_return_to_calculated_summary_with_dependent_questions(self):
+        self.schema = load_schema_from_name(
+            "test_calculated_summary_dependent_questions"
+        )
+
+        current_location = Location(section_id="default-section", block_id="block-3")
+
+        routing_path = RoutingPath(
+            [
+                "block-3",
+                "block-4",
+                "calculated-summary-block",
+            ],
+            section_id="default-section",
+        )
+
+        next_location_url = self.router.get_next_location_url(
+            current_location,
+            routing_path,
+            return_to_answer_id="answer-3",
+            return_to="calculated-summary",
+            return_to_block_id="calculated-summary-block",
+        )
+
+        expected_location = Location(
+            section_id="default-section",
+            block_id="block-4",
+        )
+
+        expected_location_url = url_for(
+            "questionnaire.block",
+            list_item_id=expected_location.list_item_id,
+            block_id=expected_location.block_id,
+            return_to="calculated-summary",
+            return_to_answer_id="answer-3",
+            return_to_block_id="calculated-summary-block",
         )
 
         assert expected_location_url == next_location_url
@@ -736,13 +778,11 @@ class TestRouterPreviousLocation(RouterTestCase):
         self.schema = load_schema_from_name("test_calculated_summary")
 
         current_location = Location(
-            section_id="default-section", block_id="fifth-number-block"
+            section_id="default-section", block_id="second-number-block"
         )
 
         routing_path = RoutingPath(
             [
-                "fifth-number-block",
-                "sixth-number-block",
                 "currency-total-playback-skipped-fourth",
             ],
             section_id="default-section",

--- a/tests/app/questionnaire/test_router.py
+++ b/tests/app/questionnaire/test_router.py
@@ -546,7 +546,7 @@ class TestRouterNextLocation(RouterTestCase):
         assert expected_location_url == next_location_url
 
     @pytest.mark.usefixtures("app")
-    def test_return_to_calculated_summary_with_dependent_questions(self):
+    def test_return_to_calculated_summary_not_on_allowable_path(self):
         self.schema = load_schema_from_name(
             "test_calculated_summary_dependent_questions"
         )


### PR DESCRIPTION
### What is the context of this PR?
Fixes a bug where users were seeing a 404 page when attempting to return to a calculated summary page. This was because we were attempting to return to the calculated summary page before visiting dependent questions.

Updated the logic so that we only return to the calculated summary page when all dependent questions are complete.

Added a test with a new `test_calculated_summary_dependent_questions` schema which emulates the journey that resulted in the bug.

Updated bug in journeys in the existing calculated summary tests.

### How to review 

Check that you see any dependent questions before returning to a calculated summary page, and that a `404` page is no longer displayed.

Use the `test_calculated_summary_dependent_questions`:
Complete all questions -> Use the change link on the second question on the calculated summary -> Update the value -> You should be taken to the dependent question before routing back to the calculated summary (previously saw a 404 error page)

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
