### PR TITLE
Add multilingual support to Social Survey Config

### DIFF
--- a/app/survey_config/social_survey_config.py
+++ b/app/survey_config/social_survey_config.py
@@ -3,6 +3,7 @@ from typing import Iterable, Mapping, MutableMapping, Optional
 
 from flask_babel import lazy_gettext
 
+from app.questionnaire.questionnaire_schema import DEFAULT_LANGUAGE_CODE
 from app.settings import ACCOUNT_SERVICE_BASE_URL_SOCIAL
 from app.survey_config.link import Link
 from app.survey_config.survey_config import SurveyConfig
@@ -29,8 +30,20 @@ class SocialSurveyConfig(
                 }
             ]
 
+        language_code = (
+            self.schema.language_code if self.schema else DEFAULT_LANGUAGE_CODE
+        )
+
         if not self.account_service_log_out_url:
-            self.account_service_log_out_url: str = f"{self.base_url}/sign-in/logout"
+            self.account_service_log_out_url: str = (
+                f"{self.base_url}/{language_code}/start/"
+            )
+
+        self.contact_us_url: str = f"{self.base_url}/{language_code}/contact-us/"
+        self.cookie_settings_url: str = f"{self.base_url}/{language_code}/cookies/"
+        self.privacy_and_data_protection_url: str = (
+            f"{self.base_url}/{language_code}/privacy-and-data-protection/"
+        )
 
     def get_footer_links(self, cookie_has_theme: bool) -> list[dict]:
         links = [Link(lazy_gettext("What we do"), self.what_we_do_url).__dict__]

--- a/tests/app/helpers/conftest.py
+++ b/tests/app/helpers/conftest.py
@@ -1,6 +1,7 @@
 from pytest import fixture
 
 from app.helpers.template_helpers import ContextHelper
+from app.questionnaire.questionnaire_schema import DEFAULT_LANGUAGE_CODE
 from app.settings import ACCOUNT_SERVICE_BASE_URL, ACCOUNT_SERVICE_BASE_URL_SOCIAL
 from app.survey_config.census_config import CY_BASE_URL, EN_BASE_URL
 
@@ -195,7 +196,7 @@ def expected_footer_social_theme():
                     },
                     {
                         "text": "Contact us",
-                        "url": f"{ACCOUNT_SERVICE_BASE_URL_SOCIAL}/contact-us/",
+                        "url": f"{ACCOUNT_SERVICE_BASE_URL_SOCIAL}/{DEFAULT_LANGUAGE_CODE}/contact-us/",
                         "target": "_blank",
                     },
                     {
@@ -211,12 +212,12 @@ def expected_footer_social_theme():
                 "itemsList": [
                     {
                         "text": "Cookies",
-                        "url": f"{ACCOUNT_SERVICE_BASE_URL_SOCIAL}/cookies/",
+                        "url": f"{ACCOUNT_SERVICE_BASE_URL_SOCIAL}/{DEFAULT_LANGUAGE_CODE}/cookies/",
                         "target": "_blank",
                     },
                     {
                         "text": "Privacy and data protection",
-                        "url": f"{ACCOUNT_SERVICE_BASE_URL_SOCIAL}/privacy-and-data-protection/",
+                        "url": f"{ACCOUNT_SERVICE_BASE_URL_SOCIAL}/{DEFAULT_LANGUAGE_CODE}/privacy-and-data-protection/",
                         "target": "_blank",
                     },
                 ]

--- a/tests/app/helpers/test_template_helpers.py
+++ b/tests/app/helpers/test_template_helpers.py
@@ -6,6 +6,7 @@ from flask import session as cookie_session
 
 from app.helpers.template_helpers import ContextHelper, get_survey_config
 from app.questionnaire import QuestionnaireSchema
+from app.questionnaire.questionnaire_schema import DEFAULT_LANGUAGE_CODE
 from app.settings import ACCOUNT_SERVICE_BASE_URL, ACCOUNT_SERVICE_BASE_URL_SOCIAL
 from app.survey_config import (
     BusinessSurveyConfig,
@@ -362,7 +363,7 @@ def test_service_links_context(
         ),
         (
             SocialSurveyConfig(),
-            f"{ACCOUNT_SERVICE_BASE_URL_SOCIAL}/contact-us/",
+            f"{ACCOUNT_SERVICE_BASE_URL_SOCIAL}/{DEFAULT_LANGUAGE_CODE}/contact-us/",
         ),
     ],
 )
@@ -418,7 +419,7 @@ def test_sign_out_button_text_context(
         (
             SocialSurveyConfig(),
             True,
-            f"{ACCOUNT_SERVICE_BASE_URL_SOCIAL}/cookies/",
+            f"{ACCOUNT_SERVICE_BASE_URL_SOCIAL}/{DEFAULT_LANGUAGE_CODE}/cookies/",
         ),
         (SurveyConfig(), False, None),
     ],
@@ -556,7 +557,7 @@ def test_account_service_my_todo_url_context(
         ),
         (
             SocialSurveyConfig(),
-            f"{ACCOUNT_SERVICE_BASE_URL_SOCIAL}/sign-in/logout",
+            f"{ACCOUNT_SERVICE_BASE_URL_SOCIAL}/{DEFAULT_LANGUAGE_CODE}/start/",
         ),
     ],
 )

--- a/tests/integration/routes/test_errors.py
+++ b/tests/integration/routes/test_errors.py
@@ -1,5 +1,6 @@
 from mock import Mock, patch
 
+from app.questionnaire.questionnaire_schema import DEFAULT_LANGUAGE_CODE
 from app.settings import ACCOUNT_SERVICE_BASE_URL, ACCOUNT_SERVICE_BASE_URL_SOCIAL
 from tests.integration.create_token import ACCOUNT_SERVICE_URL
 from tests.integration.integration_test_case import IntegrationTestCase
@@ -124,7 +125,7 @@ class TestErrors(IntegrationTestCase):  # pylint: disable=too-many-public-method
         cookie = self.getCookie()
         self.assertEqual(cookie.get("theme"), "social")
         self.assertInBody(
-            f'<p>To access this page you need to <a href="{SOCIAL_URL}/sign-in/logout">re-enter your access code</a>.</p>'
+            f'<p>To access this page you need to <a href="{SOCIAL_URL}/{DEFAULT_LANGUAGE_CODE}/start/">re-enter your access code</a>.</p>'
         )
 
     def test_401_no_cookie(self):
@@ -144,7 +145,8 @@ class TestErrors(IntegrationTestCase):  # pylint: disable=too-many-public-method
                 (
                     f'<p>If you are completing a business survey, you need to sign back in to <a href="{BUSINESS_URL}/sign-in/logout">your account</a>.</p>'
                 ),
-                f'<p>If you started your survey using an access code, you need to <a href="{SOCIAL_URL}/sign-in/logout">re-enter your code</a>.</p>',
+                f'<p>If you started your survey using an access code, you need to <a href="{SOCIAL_URL}/{DEFAULT_LANGUAGE_CODE}/start/">re-enter your code</a>.'
+                "</p>",
             ]
         )
 
@@ -177,7 +179,7 @@ class TestErrors(IntegrationTestCase):  # pylint: disable=too-many-public-method
         self.assertEqual(cookie.get("theme"), "social")
         self.assertStatusForbidden()
         self.assertInBody(
-            f'<p>For further help, please <a href="{SOCIAL_URL}/contact-us/">contact us</a>.</p>'
+            f'<p>For further help, please <a href="{SOCIAL_URL}/{DEFAULT_LANGUAGE_CODE}/contact-us/">contact us</a>.</p>'
         )
 
     def test_403_no_cookie(self):
@@ -196,7 +198,8 @@ class TestErrors(IntegrationTestCase):  # pylint: disable=too-many-public-method
                     f'<p>If you are completing a business survey and you need further help, please <a href="{BUSINESS_URL}/contact-us/">contact us</a>.</p>'
                 ),
                 (
-                    f'<p>If you started your survey using an access code and you need further help, please <a href="{SOCIAL_URL}/contact-us/">contact us</a>.</'
+                    f'<p>If you started your survey using an access code and you need further help, please <a href="{SOCIAL_URL}/{DEFAULT_LANGUAGE_CODE}/contac'
+                    f't-us/">contact us</a>.</'
                     "p>"
                 ),
             ]
@@ -231,7 +234,8 @@ class TestErrors(IntegrationTestCase):  # pylint: disable=too-many-public-method
         self.assertEqual(cookie.get("theme"), "social")
         self.assertStatusNotFound()
         self.assertInBody(
-            f'<p>If the web address is correct or you selected a link or button, <a href="{SOCIAL_URL}/contact-us/">contact us</a> for more help.</p>'
+            f'<p>If the web address is correct or you selected a link or button, <a href="{SOCIAL_URL}/{DEFAULT_LANGUAGE_CODE}/contact-us/">contact us</a> for '
+            "more help.</p>"
         )
 
     def test_404_no_cookie(self):
@@ -247,7 +251,7 @@ class TestErrors(IntegrationTestCase):  # pylint: disable=too-many-public-method
             [
                 "<p>If the web address is correct or you selected a link or button, please see the following help links.</p>",
                 f'<p>If you are completing a business survey, please <a href="{BUSINESS_URL}/contact-us/">contact us</a>.</p>',
-                f'<p>If you started your survey using an access code, please <a href="{SOCIAL_URL}/contact-us/">contact us</a>.</p>',
+                f'<p>If you started your survey using an access code, please <a href="{SOCIAL_URL}/{DEFAULT_LANGUAGE_CODE}/contact-us/">contact us</a>.</p>',
             ]
         )
 
@@ -265,7 +269,7 @@ class TestErrors(IntegrationTestCase):  # pylint: disable=too-many-public-method
             [
                 "<p>If the web address is correct or you selected a link or button, please see the following help links.</p>",
                 f'<p>If you are completing a business survey, please <a href="{BUSINESS_URL}/contact-us/">contact us</a>.</p>',
-                f'<p>If you started your survey using an access code, please <a href="{SOCIAL_URL}/contact-us/">contact us</a>.</p>',
+                f'<p>If you started your survey using an access code, please <a href="{SOCIAL_URL}/{DEFAULT_LANGUAGE_CODE}/contact-us/">contact us</a>.</p>',
             ]
         )
 
@@ -357,7 +361,7 @@ class TestErrors(IntegrationTestCase):  # pylint: disable=too-many-public-method
         # Then
         self.assertStatusCode(500)
         self.assertInBody(
-            f'<p>If this problem keeps happening, please <a href="{SOCIAL_URL}/contact-us/">contact us</a> for help.</p>'
+            f'<p>If this problem keeps happening, please <a href="{SOCIAL_URL}/{DEFAULT_LANGUAGE_CODE}/contact-us/">contact us</a> for help.</p>'
         )
 
     def test_submission_failed_theme_census_cookie_exists(self):

--- a/tests/integration/routes/test_session.py
+++ b/tests/integration/routes/test_session.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta, timezone
 
 from freezegun import freeze_time
 
+from app.questionnaire.questionnaire_schema import DEFAULT_LANGUAGE_CODE
 from app.utilities.json import json_loads
 from tests.integration.integration_test_case import IntegrationTestCase
 
@@ -33,8 +34,8 @@ class TestSession(IntegrationTestCase):
             '<p>If you are completing a business survey, you need to sign back in to <a href="https://surveys.ons.gov.uk/sign-in/logout">your account</a>.</p>'
         )
         self.assertInBody(
-            '<p>If you started your survey using an access code, you need to <a href="https://start.surveys.ons.gov.uk/sign-in/logout">re-enter your code</a>.'
-            "</p>"
+            f'<p>If you started your survey using an access code, you need to <a href="https://start.surveys.ons.gov.uk/{DEFAULT_LANGUAGE_CODE}/start/">re-ente'
+            "r your code</a>.</p>"
         )
 
     def test_session_jti_token_expired(self):


### PR DESCRIPTION
### What is the context of this PR?
This adds support the language-specific URLs for the Social survey config (it only applies to this class).

ULRs changed:
 - `{base_url}/{language_code}/start/`
  - `{base_url}/{language_code}/privacy-and-data-protection/`
  - `{base_url}/{language_code}/contact-us/`
  - `{base_url}/{language_code}/cookies/`

### How to review 
Old tests have been reworked, check if they assert/run as required.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
