### PR TITLE
Bug: Placeholders referencing an incorrect calculated summary value in another calculated summary in a repeating section

### DIFF
--- a/app/views/contexts/summary/group.py
+++ b/app/views/contexts/summary/group.py
@@ -46,6 +46,7 @@ class Group:
             language=language,
             answer_store=answer_store,
             list_store=list_store,
+            location=location,
             metadata=metadata,
             response_metadata=response_metadata,
             schema=schema,

--- a/schemas/test/en/test_new_calculated_summary_repeating_section.json
+++ b/schemas/test/en/test_new_calculated_summary_repeating_section.json
@@ -644,6 +644,71 @@
                             }
                         },
                         {
+                            "id": "breakdown",
+                            "type": "Question",
+                            "question": {
+                                "id": "breakdown-question",
+                                "title": {
+                                    "text": "Enter two values that add up to the previous calculated summary total of {total_first}",
+                                    "placeholders": [
+                                        {
+                                            "placeholder": "total_first",
+                                            "transforms": [
+                                                {
+                                                    "transform": "format_currency",
+                                                    "arguments": {
+                                                        "number": {
+                                                            "identifier": "number-total-playback",
+                                                            "source": "calculated_summary"
+                                                        }
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "type": "General",
+                                "answers": [
+                                    {
+                                        "id": "breakdown-answer-1",
+                                        "mandatory": false,
+                                        "type": "Currency",
+                                        "label": "First Value",
+                                        "decimal_places": 2,
+                                        "currency": "GBP"
+                                    },
+                                    {
+                                        "id": "breakdown-answer-2",
+                                        "mandatory": false,
+                                        "type": "Currency",
+                                        "label": "Second Value",
+                                        "decimal_places": 2,
+                                        "currency": "GBP"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "type": "CalculatedSummary",
+                            "id": "second-currency-total-playback",
+                            "title": "We calculate the total of number values entered to be %(total)s. Is this correct?",
+                            "calculation": {
+                                "operation": {
+                                    "+": [
+                                        {
+                                            "source": "answers",
+                                            "identifier": "breakdown-answer-1"
+                                        },
+                                        {
+                                            "source": "answers",
+                                            "identifier": "breakdown-answer-2"
+                                        }
+                                    ]
+                                },
+                                "title": "Grand total of previous values"
+                            }
+                        },
+                        {
                             "type": "Interstitial",
                             "id": "calculated-summary-total-confirmation",
                             "content": {

--- a/tests/functional/spec/features/new_calculated_summary_repeating_section.spec.js
+++ b/tests/functional/spec/features/new_calculated_summary_repeating_section.spec.js
@@ -13,6 +13,8 @@ import CurrencyTotalPlaybackPageSkippedFourth from "../../generated_pages/new_ca
 import UnitTotalPlaybackPage from "../../generated_pages/new_calculated_summary_repeating_section/unit-total-playback.page.js";
 import PercentageTotalPlaybackPage from "../../generated_pages/new_calculated_summary_repeating_section/percentage-total-playback.page.js";
 import NumberTotalPlaybackPage from "../../generated_pages/new_calculated_summary_repeating_section/number-total-playback.page.js";
+import BreakdownPage from "../../generated_pages/new_calculated_summary_repeating_section/breakdown.page.js";
+import SecondCurrencyTotalPlaybackPage from "../../generated_pages/new_calculated_summary_repeating_section/second-currency-total-playback.page.js";
 import CalculatedSummaryTotalConfirmation from "../../generated_pages/new_calculated_summary_repeating_section/calculated-summary-total-confirmation.page.js";
 import SubmitPage from "../../generated_pages/new_calculated_summary_repeating_section/personal-details-section-summary.page.js";
 import ThankYouPage from "../../base_pages/thank-you.page.js";
@@ -203,8 +205,22 @@ describe("Feature: Calculated Summary Repeating Section", () => {
       expect($(NumberTotalPlaybackPage.sixthNumberAnswer()).getText()).to.contain("45.67");
     });
 
-    it("Given I complete every calculated summary, When I go to a page with calculated summary piping, Then I should the see the piped calculated summary total for each summary", () => {
+    it("Given I have a calculated summary total that is used as a placeholder in another calculated summary, When I get to the calculated summary page displaying the placeholder, Then I should see the correct total", () => {
       $(NumberTotalPlaybackPage.submit()).click();
+      expect(browser.getUrl()).to.contain(BreakdownPage.pageName);
+      $(BreakdownPage.answer1()).setValue(100.0);
+      $(BreakdownPage.answer2()).setValue(24.58);
+      $(BreakdownPage.submit()).click();
+      expect(browser.getUrl()).to.contain(SecondCurrencyTotalPlaybackPage.pageName);
+      expect($(SecondCurrencyTotalPlaybackPage.calculatedSummaryTitle()).getText()).to.contain(
+        "We calculate the total of number values entered to be £124.58. Is this correct?"
+      );
+      expect($("body").getText()).to.have.string("Enter two values that add up to the previous calculated summary total of £124.58");
+      expect($(SecondCurrencyTotalPlaybackPage.calculatedSummaryAnswer()).getText()).to.contain("124.58");
+    });
+
+    it("Given I complete every calculated summary, When I go to a page with calculated summary piping, Then I should the see the piped calculated summary total for each summary", () => {
+      $(SecondCurrencyTotalPlaybackPage.submit()).click();
 
       const content = $("h1 + ul").getText();
       const textsToAssert = [
@@ -256,6 +272,8 @@ describe("Feature: Calculated Summary Repeating Section", () => {
       $(UnitTotalPlaybackPage.submit()).click();
       $(PercentageTotalPlaybackPage.submit()).click();
       $(NumberTotalPlaybackPage.submit()).click();
+      $(BreakdownPage.submit()).click();
+      $(SecondCurrencyTotalPlaybackPage.submit()).click();
       $(CalculatedSummaryTotalConfirmation.submit()).click();
       expect(browser.getUrl()).to.contain(SetMinMaxBlockPage.pageName);
       $(SetMinMaxBlockPage.setMinimum()).setValue(10.0);
@@ -282,6 +300,8 @@ describe("Feature: Calculated Summary Repeating Section", () => {
       $(UnitTotalPlaybackPage.submit()).click();
       $(PercentageTotalPlaybackPage.submit()).click();
       $(NumberTotalPlaybackPage.submit()).click();
+      $(BreakdownPage.submit()).click();
+      $(SecondCurrencyTotalPlaybackPage.submit()).click();
       $(CalculatedSummaryTotalConfirmation.submit()).click();
       expect(browser.getUrl()).to.contain(SetMinMaxBlockPage.pageName);
       $(SetMinMaxBlockPage.submit()).click();
@@ -309,6 +329,8 @@ describe("Feature: Calculated Summary Repeating Section", () => {
       $(UnitTotalPlaybackPage.submit()).click();
       $(PercentageTotalPlaybackPage.submit()).click();
       $(NumberTotalPlaybackPage.submit()).click();
+      $(BreakdownPage.submit()).click();
+      $(SecondCurrencyTotalPlaybackPage.submit()).click();
       $(CalculatedSummaryTotalConfirmation.submit()).click();
       expect(browser.getUrl()).to.contain(SetMinMaxBlockPage.pageName);
       $(SetMinMaxBlockPage.submit()).click();
@@ -380,6 +402,8 @@ describe("Feature: Calculated Summary Repeating Section", () => {
       $(UnitTotalPlaybackPage.submit()).click();
       $(PercentageTotalPlaybackPage.submit()).click();
       $(NumberTotalPlaybackPage.submit()).click();
+      $(BreakdownPage.submit()).click();
+      $(SecondCurrencyTotalPlaybackPage.submit()).click();
       $(CalculatedSummaryTotalConfirmation.submit()).click();
       $(SetMinMaxBlockPage.setMinimum()).setValue(10.0);
       $(SetMinMaxBlockPage.setMaximum()).setValue(6.0);
@@ -428,5 +452,9 @@ const getToSubmitPage = () => {
   $(UnitTotalPlaybackPage.submit()).click();
   $(PercentageTotalPlaybackPage.submit()).click();
   $(NumberTotalPlaybackPage.submit()).click();
+  $(BreakdownPage.answer1()).setValue(100.0);
+  $(BreakdownPage.answer2()).setValue(24.58);
+  $(BreakdownPage.submit()).click();
+  $(SecondCurrencyTotalPlaybackPage.submit()).click();
   $(CalculatedSummaryTotalConfirmation.submit()).click();
 };


### PR DESCRIPTION
### What is the context of this PR?

Fixes an issue where if a calculated summary included an answer which had a title that referenced another calculated summary's total, the value was being piped as 0.

### How to review 

Use the `test_new_calculated_summary_repeating_section` schema to test the change.

Steps to recreate:
Get to the Number Total Playback page -> Answer the breakdown question -> Get to the Second Currency Total Playback page -> Check the value of the placeholder for the is correct on the page in the sentence: `Enter two values that add up to the previous calculated summary total of £x`

On master the value will be £0

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
