### PR TITLE
Fix bug: add to list is returning straight back to summary

### DIFF
--- a/app/questionnaire/router.py
+++ b/app/questionnaire/router.py
@@ -316,8 +316,8 @@ class Router:
                 )
         return full_routing_path
 
-    def _is_block_complete(
-        self, block_id: str, section_id: str, list_item_id: str
+    def is_block_complete(
+        self, *, block_id: str, section_id: str, list_item_id: str
     ) -> bool:
         return block_id in self._progress_store.get_completed_block_ids(
             section_id, list_item_id
@@ -327,8 +327,10 @@ class Router:
         self, routing_path: RoutingPath
     ) -> Optional[Location]:
         for block_id in routing_path:
-            if not self._is_block_complete(
-                block_id, routing_path.section_id, routing_path.list_item_id
+            if not self.is_block_complete(
+                block_id=block_id,
+                section_id=routing_path.section_id,
+                list_item_id=routing_path.list_item_id,
             ):
                 return Location(
                     block_id=block_id,
@@ -347,8 +349,10 @@ class Router:
             for block_id in routing_path:
                 allowable_path.append(block_id)
 
-                if not self._is_block_complete(
-                    block_id, routing_path.section_id, routing_path.list_item_id
+                if not self.is_block_complete(
+                    block_id=block_id,
+                    section_id=routing_path.section_id,
+                    list_item_id=routing_path.list_item_id,
                 ):
                     return allowable_path
 

--- a/app/views/handlers/list_collector.py
+++ b/app/views/handlers/list_collector.py
@@ -15,6 +15,9 @@ class ListCollector(Question):
                 "questionnaire.block",
                 list_name=self.rendered_block["for_list"],
                 block_id=self.rendered_block["add_block"]["id"],
+                return_to=self._return_to,
+                return_to_answer_id=self._return_to_answer_id,
+                return_to_block_id=self._return_to_block_id,
             )
             return add_url
 
@@ -39,6 +42,7 @@ class ListCollector(Question):
                 for_list=self.rendered_block["for_list"],
                 edit_block_id=self.rendered_block["edit_block"]["id"],
                 remove_block_id=self.rendered_block["remove_block"]["id"],
+                return_to=self._return_to,
             ),
         }
 

--- a/app/views/handlers/list_remove_question.py
+++ b/app/views/handlers/list_remove_question.py
@@ -28,6 +28,9 @@ class ListRemoveQuestion(ListAction):
             self.questionnaire_store_updater.remove_list_item_and_answers(
                 list_name, self._current_location.list_item_id
             )
+            self.evaluate_and_update_section_status_on_list_change(
+                self.parent_block["for_list"]
+            )
 
         return super().handle_post()
 

--- a/app/views/handlers/question.py
+++ b/app/views/handlers/question.py
@@ -207,6 +207,7 @@ class Question(BlockHandler):
 
     def evaluate_and_update_section_status_on_list_change(self, list_name):
         section_ids = self._schema.get_section_ids_dependent_on_list(list_name)
+        section_ids.append(self.current_location.section_id)
 
         section_keys_to_evaluate = (
             self.questionnaire_store_updater.started_section_keys(

--- a/schemas/test/en/test_list_collector_section_summary.json
+++ b/schemas/test/en/test_list_collector_section_summary.json
@@ -131,21 +131,13 @@
                             },
                             "routing_rules": [
                                 {
-                                    "goto": {
-                                        "block": "confirmation-checkbox",
-                                        "when": [
-                                            {
-                                                "id": "any-companies-or-branches-answer",
-                                                "condition": "equals",
-                                                "value": "No"
-                                            }
-                                        ]
-                                    }
+                                    "when": {
+                                        "==": [{ "source": "answers", "identifier": "any-companies-or-branches-answer" }, "No"]
+                                    },
+                                    "block": "confirmation-checkbox"
                                 },
                                 {
-                                    "goto": {
-                                        "block": "any-other-companies-or-branches"
-                                    }
+                                    "block": "any-other-companies-or-branches"
                                 }
                             ]
                         },
@@ -330,6 +322,21 @@
                                 "id": "confirmation-checkbox-question",
                                 "title": "Are all companies or branches based in UK?",
                                 "type": "General"
+                            },
+                            "skip_conditions": {
+                                "when": {
+                                    "!=": [
+                                        {
+                                            "count": [
+                                                {
+                                                    "source": "list",
+                                                    "identifier": "companies"
+                                                }
+                                            ]
+                                        },
+                                        3
+                                    ]
+                                }
                             }
                         }
                     ]

--- a/tests/functional/spec/features/repeating_sections/repeating_sections_with_hub_and_spoke.spec.js
+++ b/tests/functional/spec/features/repeating_sections/repeating_sections_with_hub_and_spoke.spec.js
@@ -165,12 +165,19 @@ describe("Feature: Repeating Sections with Hub and Spoke", () => {
       $(VisitorsListCollectorAddPage.firstName()).setValue("Joe");
       $(VisitorsListCollectorAddPage.lastName()).setValue("Public");
       $(VisitorsListCollectorAddPage.submit()).click();
+      expect(browser.getUrl()).to.contain("/questionnaire/visitors-block");
 
       // Add second visitor
-      $(SectionSummaryPage.visitorListAddLink()).click();
+      $(VisitorsListCollectorPage.yes()).click();
+      $(VisitorsListCollectorPage.submit()).click();
       $(VisitorsListCollectorAddPage.firstName()).setValue("Yvonne");
       $(VisitorsListCollectorAddPage.lastName()).setValue("Yoe");
       $(VisitorsListCollectorAddPage.submit()).click();
+
+      // Exit the visitors list collector
+      $(VisitorsListCollectorPage.no()).click();
+      $(VisitorsListCollectorPage.submit()).click();
+
       $(SectionSummaryPage.submit()).click();
 
       expect($(HubPage.summaryRowState("visitors-section-1")).getText()).to.equal("Not started");
@@ -257,6 +264,10 @@ describe("Feature: Repeating Sections with Hub and Spoke", () => {
       $(VisitorsListCollectorAddPage.firstName()).setValue("Anna");
       $(VisitorsListCollectorAddPage.lastName()).setValue("Doe");
       $(VisitorsListCollectorAddPage.submit()).click();
+
+      $(VisitorsListCollectorPage.no()).click();
+      $(VisitorsListCollectorPage.submit()).click();
+
       $(SectionSummaryPage.submit()).click();
 
       // New visitor added to hub

--- a/tests/functional/spec/list_collector.spec.js
+++ b/tests/functional/spec/list_collector.spec.js
@@ -204,6 +204,8 @@ describe("List Collector", () => {
       $(VisitorListCollectorAddPage.firstNameVisitor()).setValue("Joe");
       $(VisitorListCollectorAddPage.lastNameVisitor()).setValue("Bloggs");
       $(VisitorListCollectorAddPage.submit()).click();
+      $(VisitorListCollectorPage.no()).click();
+      $(VisitorListCollectorPage.submit()).click();
       expect($(PeopleListSectionSummaryPage.visitorsListLabel(2)).getText()).to.contain("Joe Bloggs");
     });
 

--- a/tests/functional/spec/list_collector_section_summary.spec.js
+++ b/tests/functional/spec/list_collector_section_summary.spec.js
@@ -14,7 +14,6 @@ describe("List Collector Section Summary Items", () => {
       drivingQuestionYes();
       addCompany("Company A", "123", true);
       anyMoreCompaniesNo();
-      answerUkBasedQuestion();
       expect(browser.getUrl()).to.contain(SectionSummaryPage.url());
       expect($(SectionSummaryPage.anyCompaniesOrBranchesQuestion()).isExisting()).to.be.true;
       expect($(SectionSummaryPage.anyCompaniesOrBranchesAnswer()).getText()).to.contain("Yes");
@@ -23,7 +22,6 @@ describe("List Collector Section Summary Items", () => {
       drivingQuestionYes();
       addCompany("Company A", "123", true);
       anyMoreCompaniesNo();
-      answerUkBasedQuestion();
       expect($(SectionSummaryPage.companiesListLabel(1)).getText()).to.contain("Name of UK company or branch");
       expect($(companiesListRowItem(1, 1)).getText()).to.contain("Company A");
       expect($(companiesListRowItem(1, 2)).getText()).to.contain("123");
@@ -55,7 +53,6 @@ describe("List Collector Section Summary Items", () => {
       drivingQuestionYes();
       addCompany("Company A", "123", true);
       anyMoreCompaniesNo();
-      answerUkBasedQuestion();
       removeFirstCompany();
       expect(browser.getUrl()).to.contain(SectionSummaryPage.url());
       expect($("body").getText()).to.not.have.string("Company A");
@@ -66,7 +63,6 @@ describe("List Collector Section Summary Items", () => {
       drivingQuestionYes();
       addCompany("Company A", "123", true);
       anyMoreCompaniesNo();
-      answerUkBasedQuestion();
       removeFirstCompany();
       expect(browser.getUrl()).to.contain(SectionSummaryPage.url());
       expect($("body").getText()).to.contain("No UK company or branch added");
@@ -77,7 +73,6 @@ describe("List Collector Section Summary Items", () => {
       anyMoreCompaniesYes();
       addCompany("Company B", "234", true);
       anyMoreCompaniesNo();
-      answerUkBasedQuestion();
       removeFirstCompany();
       expect(browser.getUrl()).to.contain(SectionSummaryPage.url());
       expect($("body").getText()).to.not.have.string("Company A");
@@ -87,7 +82,6 @@ describe("List Collector Section Summary Items", () => {
       drivingQuestionYes();
       addCompany("Company A", "123", true);
       anyMoreCompaniesNo();
-      answerUkBasedQuestion();
       expect(browser.getUrl()).to.contain(SectionSummaryPage.url());
       expect($(SectionSummaryPage.companiesListAddLink()).isExisting()).to.be.true;
     });
@@ -106,15 +100,24 @@ describe("List Collector Section Summary Items", () => {
       drivingQuestionYes();
       addCompany("Company A", "123", true);
       anyMoreCompaniesNo();
-      answerUkBasedQuestion();
       expect($(companiesListRowItem(1, 1)).getText()).to.contain("Company A");
       $(SectionSummaryPage.companiesListEditLink(1)).click();
       expect(browser.getUrl()).to.contain("edit-company/?return_to=section-summary");
       expect($(AnyCompaniesOrBranchesAddPage.companyOrBranchName()).getValue()).to.equal("Company A");
     });
+    it("When I edit an item after adding it, Then I should be redirected to the summary page", () => {
+      drivingQuestionYes();
+      addCompany("Company A", "123", true);
+      anyMoreCompaniesNo();
+      expect($(companiesListRowItem(1, 1)).getText()).to.contain("Company A");
+      $(SectionSummaryPage.companiesListEditLink(1)).click();
+      $(AnyCompaniesOrBranchesAddPage.companyOrBranchName()).setValue("Changed Company");
+      $(AnyCompaniesOrBranchesAddPage.submit()).click();
+      expect(browser.getUrl()).to.contain(SectionSummaryPage.url());
+      expect($(companiesListRowItem(1, 1)).getText()).to.contain("Changed Company");
+    });
     it("When no item is added but I change my answer to the driving question to Yes, Then I should be able to add a new item.", () => {
       drivingQuestionNo();
-      answerUkBasedQuestion();
       expect(browser.getUrl()).to.contain(SectionSummaryPage.url());
       expect($(SectionSummaryPage.companiesListEditLink(1)).isExisting()).to.be.false;
       expect($(SectionSummaryPage.companiesListRemoveLink(1)).isExisting()).to.be.false;
@@ -132,7 +135,6 @@ describe("List Collector Section Summary Items", () => {
       drivingQuestionYes();
       addCompany("Company A", "123", true);
       anyMoreCompaniesNo();
-      answerUkBasedQuestion();
       expect($(companiesListRowItem(1, 1)).getText()).to.contain("Company A");
       $(SectionSummaryPage.anyCompaniesOrBranchesAnswerEdit()).click();
       drivingQuestionNo();
@@ -148,6 +150,102 @@ describe("List Collector Section Summary Items", () => {
       expect($(SectionSummaryPage.companiesListEditLink(1)).isExisting()).to.be.true;
       expect($(SectionSummaryPage.companiesListRemoveLink(1)).isExisting()).to.be.true;
       expect($(SectionSummaryPage.companiesListAddLink()).isExisting()).to.be.true;
+    });
+    it("When I add another company from the summary page, Then I am asked if I want to add any more company before accessing the section summary", () => {
+      drivingQuestionYes();
+      addCompany("Company A", "123", true);
+      anyMoreCompaniesNo();
+      $(SectionSummaryPage.companiesListAddLink()).click();
+      expect(browser.getUrl()).to.contain("/questionnaire/companies/add-company");
+      expect(browser.getUrl()).to.contain("?return_to=section-summary");
+      addCompany("Company B", "456", true);
+      expect(browser.getUrl()).to.contain(AnyCompaniesOrBranchesPage.url());
+      expect($("body").getText()).to.have.string("Company A");
+      expect($("body").getText()).to.have.string("Company B");
+      anyMoreCompaniesNo();
+      expect(browser.getUrl()).to.contain(SectionSummaryPage.url());
+    });
+    it("When I add three companies, Then I am prompted with the confirmation question", () => {
+      drivingQuestionYes();
+      addCompany("Company A", "123", true);
+      anyMoreCompaniesYes();
+      addCompany("Company B", "456", true);
+      anyMoreCompaniesYes();
+      addCompany("Company C", "789", true);
+      anyMoreCompaniesNo();
+      expect(browser.getUrl()).to.contain(UkBasedPage.url());
+    });
+    it("When I add less than 3 companies, Then I am not prompted with the confirmation question", () => {
+      drivingQuestionYes();
+      addCompany("Company A", "123", true);
+      anyMoreCompaniesYes();
+      addCompany("Company B", "456", true);
+      anyMoreCompaniesNo();
+      expect(browser.getUrl()).to.contain(SectionSummaryPage.url());
+    });
+    it("When I add more than 3 companies, Then I am not prompted with the confirmation question", () => {
+      drivingQuestionYes();
+      addCompany("Company A", "123", true);
+      anyMoreCompaniesYes();
+      addCompany("Company B", "456", true);
+      anyMoreCompaniesYes();
+      addCompany("Company C", "789", true);
+      anyMoreCompaniesYes();
+      addCompany("Company D", "135", true);
+      anyMoreCompaniesNo();
+      expect(browser.getUrl()).to.contain(SectionSummaryPage.url());
+    });
+    it("When I add another company from the summary page, and the amount then totals to 3, and the confirmation question hasn't been previously answered, Then I am prompted with the confirmation question", () => {
+      drivingQuestionYes();
+      addCompany("Company A", "123", true);
+      anyMoreCompaniesYes();
+      addCompany("Company B", "456", true);
+      anyMoreCompaniesNo();
+      expect(browser.getUrl()).to.contain(SectionSummaryPage.url());
+      $(SectionSummaryPage.companiesListAddLink()).click();
+      expect(browser.getUrl()).to.contain("/questionnaire/companies/add-company");
+      expect(browser.getUrl()).to.contain("?return_to=section-summary");
+      addCompany("Company C", "234", true);
+      anyMoreCompaniesNo();
+      expect(browser.getUrl()).to.contain(UkBasedPage.url());
+      answerUkBasedQuestion();
+      expect(browser.getUrl()).to.contain(SectionSummaryPage.url());
+    });
+    it("When I remove a company from the summary page, and the amount then totals to 3, and the confirmation question hasn't been previously answered, Then I am prompted with the confirmation question", () => {
+      drivingQuestionYes();
+      addCompany("Company A", "123", true);
+      anyMoreCompaniesYes();
+      addCompany("Company B", "456", true);
+      anyMoreCompaniesYes();
+      addCompany("Company C", "234", true);
+      anyMoreCompaniesYes();
+      addCompany("Company D", "345", true);
+      anyMoreCompaniesNo();
+      expect(browser.getUrl()).to.contain(SectionSummaryPage.url());
+      removeFirstCompany();
+      expect(browser.getUrl()).to.contain(UkBasedPage.url());
+      answerUkBasedQuestion();
+      expect(browser.getUrl()).to.contain(SectionSummaryPage.url());
+    });
+    it("When I remove a company from the summary page, and the amount then totals to 3, but the confirmation question has already been answered, Then I am not prompted with the confirmation question", () => {
+      drivingQuestionYes();
+      addCompany("Company A", "123", true);
+      anyMoreCompaniesYes();
+      addCompany("Company B", "456", true);
+      anyMoreCompaniesYes();
+      addCompany("Company C", "234", true);
+      anyMoreCompaniesNo();
+      expect(browser.getUrl()).to.contain(UkBasedPage.url());
+      answerUkBasedQuestion();
+      expect(browser.getUrl()).to.contain(SectionSummaryPage.url());
+      $(SectionSummaryPage.companiesListAddLink()).click();
+      expect(browser.getUrl()).to.contain("/questionnaire/companies/add-company");
+      expect(browser.getUrl()).to.contain("?return_to=section-summary");
+      addCompany("Company C", "234", true);
+      anyMoreCompaniesNo();
+      expect(browser.getUrl()).to.contain(SectionSummaryPage.url());
+      removeFirstCompany();
+      expect(browser.getUrl()).to.contain(SectionSummaryPage.url());
     });
   });
 });

--- a/tests/integration/questionnaire/test_questionnaire_list_change_evaluates_sections.py
+++ b/tests/integration/questionnaire/test_questionnaire_list_change_evaluates_sections.py
@@ -30,9 +30,11 @@ class TestQuestionnaireListChangeEvaluatesSections(QuestionnaireTestCase):
         self.post()
         self.assertEqualUrl("/questionnaire/")
 
-        self.get("questionnaire/people/add-person/?return_to=section-summary")
+        self.get("questionnaire/people/add-person")
         self.add_person("John", "Doe")
         self.post({"anyone-else": "No"})
+        self.assertEqualUrl("/questionnaire/sections/who-lives-here/")
+        self.post()
         self.assertEqualUrl("/questionnaire/")
 
         self.assertInSelector(

--- a/tests/integration/questionnaire/test_questionnaire_list_collector.py
+++ b/tests/integration/questionnaire/test_questionnaire_list_collector.py
@@ -1,5 +1,7 @@
 from . import SUBMIT_URL_PATH, QuestionnaireTestCase
 
+# pylint: disable=too-many-public-methods
+
 
 class TestQuestionnaireListCollector(QuestionnaireTestCase):
     def get_add_someone_link(self):
@@ -320,3 +322,287 @@ class TestQuestionnaireListCollector(QuestionnaireTestCase):
         self.get(first_person_remove_link)
 
         self.assertInBody("Are you sure you want to remove this person?")
+
+    def test_adding_from_the_summary_page_adds_the_return_to_param_to_the_url(
+        self,
+    ):
+        self.launchSurvey("test_list_collector")
+
+        self.assertInBody("Does anyone else live here?")
+
+        self.post({"anyone-else": "Yes"})
+
+        self.add_person("Marie Claire", "Doe")
+
+        self.assertInSelector("Marie Claire Doe", "[data-qa='list-item-1-label']")
+
+        self.post({"anyone-else": "No"})
+
+        self.post()
+
+        self.post({"another-anyone-else": "No"})
+
+        self.assertInBody("List Collector Summary")
+
+        # Make another mistake
+
+        add_link = self.get_add_someone_link()
+
+        self.get(add_link)
+
+        self.assertInUrl("?return_to=section-summary")
+
+    def test_removing_from_the_summary_page_adds_the_return_to_param_to_the_url(
+        self,
+    ):
+        self.launchSurvey("test_list_collector")
+
+        self.assertInBody("Does anyone else live here?")
+
+        self.post({"anyone-else": "Yes"})
+
+        self.add_person("Marie Claire", "Doe")
+
+        self.assertInSelector("Marie Claire Doe", "[data-qa='list-item-1-label']")
+
+        self.post({"anyone-else": "No"})
+
+        self.post()
+
+        self.post({"another-anyone-else": "No"})
+
+        self.assertInBody("List Collector Summary")
+
+        # Make another mistake
+
+        remove_link = self.get_link("remove", 1)
+
+        self.get(remove_link)
+
+        self.assertInUrl("?return_to=section-summary")
+
+    def test_changing_item_from_the_summary_page_adds_the_return_to_param_to_the_url(
+        self,
+    ):
+        self.launchSurvey("test_list_collector")
+
+        self.assertInBody("Does anyone else live here?")
+
+        self.post({"anyone-else": "Yes"})
+
+        self.add_person("Marie Claire", "Doe")
+
+        self.assertInSelector("Marie Claire Doe", "[data-qa='list-item-1-label']")
+
+        self.post({"anyone-else": "No"})
+
+        self.post()
+
+        self.post({"another-anyone-else": "No"})
+
+        self.assertInBody("List Collector Summary")
+
+        change_link = self.get_link("change", 1)
+
+        self.get(change_link)
+
+        self.assertInUrl("?return_to=section-summary")
+
+    def test_adding_from_the_summary_page_and_then_removing_from_parent_page_keeps_return_to_url_param(
+        self,
+    ):
+        self.launchSurvey("test_list_collector")
+
+        self.assertInBody("Does anyone else live here?")
+
+        self.post({"anyone-else": "Yes"})
+
+        self.add_person("Marie Claire", "Doe")
+
+        self.assertInSelector("Marie Claire Doe", "[data-qa='list-item-1-label']")
+
+        self.post({"anyone-else": "No"})
+
+        self.post()
+
+        self.post({"another-anyone-else": "No"})
+
+        self.assertInBody("List Collector Summary")
+
+        # Add another one form the summary
+
+        add_link = self.get_add_someone_link()
+
+        self.get(add_link)
+
+        self.add_person("Don", "Page")
+
+        self.assertInSelector("Don Page", "[data-qa='list-item-2-label']")
+
+        remove_link = self.get_link("remove", 2)
+
+        self.get(remove_link)
+
+        self.assertInUrl("?return_to=section-summary")
+
+        self.post({"remove-confirmation": "Yes"})
+
+        self.assertInUrl("?return_to=section-summary")
+
+    def test_adding_from_the_summary_page_and_then_changing_from_parent_page_keeps_return_to_url_param(
+        self,
+    ):
+        self.launchSurvey("test_list_collector")
+
+        self.assertInBody("Does anyone else live here?")
+
+        self.post({"anyone-else": "Yes"})
+
+        self.add_person("Marie Claire", "Doe")
+
+        self.assertInSelector("Marie Claire Doe", "[data-qa='list-item-1-label']")
+
+        self.post({"anyone-else": "No"})
+
+        self.post()
+
+        self.post({"another-anyone-else": "No"})
+
+        self.assertInBody("List Collector Summary")
+
+        # Add another one form the summary
+
+        add_link = self.get_add_someone_link()
+
+        self.get(add_link)
+
+        self.add_person("Don", "Page")
+
+        self.assertInSelector("Don Page", "[data-qa='list-item-2-label']")
+
+        change_link = self.get_link("change", 2)
+
+        self.get(change_link)
+
+        self.assertInUrl("?return_to=section-summary")
+
+        self.post({"first-name": "Another", "last-name": "Name"})
+
+        self.assertInUrl("?return_to=section-summary")
+
+    def test_adding_from_the_summary_page_and_then_clicking_previous_link_from_edit_question_block_persists_return_to_url_param(
+        self,
+    ):
+        self.launchSurvey("test_list_collector")
+
+        self.assertInBody("Does anyone else live here?")
+
+        self.post({"anyone-else": "Yes"})
+
+        self.add_person("Marie Claire", "Doe")
+
+        self.assertInSelector("Marie Claire Doe", "[data-qa='list-item-1-label']")
+
+        self.post({"anyone-else": "No"})
+
+        self.post()
+
+        self.post({"another-anyone-else": "No"})
+
+        self.assertInBody("List Collector Summary")
+
+        # Add another one form the summary
+
+        add_link = self.get_add_someone_link()
+
+        self.get(add_link)
+
+        self.add_person("Don", "Page")
+
+        self.assertInSelector("Don Page", "[data-qa='list-item-2-label']")
+
+        change_link = self.get_link("change", 2)
+
+        self.get(change_link)
+
+        self.previous()
+
+        self.assertInUrl("?return_to=section-summary")
+
+    def test_adding_from_the_summary_page_and_then_clicking_previous_link_from_remove_question_block_persists_return_to_url_param(
+        self,
+    ):
+        self.launchSurvey("test_list_collector")
+
+        self.assertInBody("Does anyone else live here?")
+
+        self.post({"anyone-else": "Yes"})
+
+        self.add_person("Marie Claire", "Doe")
+
+        self.assertInSelector("Marie Claire Doe", "[data-qa='list-item-1-label']")
+
+        self.post({"anyone-else": "No"})
+
+        self.post()
+
+        self.post({"another-anyone-else": "No"})
+
+        self.assertInBody("List Collector Summary")
+
+        # Add another one form the summary
+
+        add_link = self.get_add_someone_link()
+
+        self.get(add_link)
+
+        self.add_person("Don", "Page")
+
+        self.assertInSelector("Don Page", "[data-qa='list-item-2-label']")
+
+        remove_link = self.get_link("remove", 2)
+
+        self.get(remove_link)
+
+        self.previous()
+
+        self.assertInUrl("?return_to=section-summary")
+
+    def test_adding_from_the_summary_page_and_then_adding_again_from_list_collector_persists_the_return_to_url_param(
+        self,
+    ):
+        self.launchSurvey("test_list_collector")
+
+        self.assertInBody("Does anyone else live here?")
+
+        self.post({"anyone-else": "Yes"})
+
+        self.add_person("Marie Claire", "Doe")
+
+        self.assertInSelector("Marie Claire Doe", "[data-qa='list-item-1-label']")
+
+        self.post({"anyone-else": "No"})
+
+        self.post()
+
+        self.post({"another-anyone-else": "No"})
+
+        self.assertInBody("List Collector Summary")
+
+        # Add another one form the summary
+
+        add_link = self.get_add_someone_link()
+
+        self.get(add_link)
+
+        self.add_person("Don", "Page")
+
+        self.assertInSelector("Don Page", "[data-qa='list-item-2-label']")
+
+        self.post({"anyone-else": "Yes"})
+
+        self.assertInUrl("?return_to=section-summary")
+
+        self.add_person("Another", "Person")
+
+        self.assertInUrl("?return_to=section-summary")


### PR DESCRIPTION
### What is the context of this PR?
In a schema with a list collector and a summary, when the user completes the list collector block and lands on the summary page, but then adds another item to the list, they are redirected to the summary.

Instead, we want the user to be redirected to the list collector parent page, asking them if they want to add another item to the list collector.

This change also impacts the `change` and `remove` actions.

Thus here are the specs:
* If the user adds from the summary, return to the parent location
* If the user changes an item from the summary, return to the summary
* If the user removes an item from the summary:
    * if the change of list length introduces a new incomplete block, redirect to this block
    * Otherwise, go back to the summary 


### How to review

Smoke tests on the list collector schemas.
Changes in the way list collector schemas behave is expected. See integration and functional tests.




