### PR TITLE
Bug: Flush always using v1 converter

### DIFF
--- a/app/routes/flush.py
+++ b/app/routes/flush.py
@@ -5,11 +5,13 @@ from sdc.crypto.decrypter import decrypt
 from sdc.crypto.encrypter import encrypt
 from structlog import get_logger
 
+from app.authentication.auth_payload_version import AuthPayloadVersion
 from app.authentication.user import User
 from app.globals import get_answer_store, get_metadata, get_questionnaire_store
 from app.keys import KEY_PURPOSE_AUTHENTICATION, KEY_PURPOSE_SUBMISSION
 from app.questionnaire.router import Router
 from app.submitter.converter import convert_answers
+from app.submitter.converter_v2 import convert_answers_v2
 from app.submitter.submission_failed import SubmissionFailedException
 from app.utilities.json import json_dumps
 from app.utilities.schema import load_schema_from_metadata
@@ -76,6 +78,14 @@ def _submit_data(user):
         full_routing_path = router.full_routing_path()
 
         message = json_dumps(
+            convert_answers_v2(
+                schema,
+                questionnaire_store,
+                full_routing_path,
+                submitted_at,
+                flushed=True,
+            )
+            if metadata.version is AuthPayloadVersion.V2 else
             convert_answers(
                 schema,
                 questionnaire_store,

--- a/app/routes/flush.py
+++ b/app/routes/flush.py
@@ -85,8 +85,8 @@ def _submit_data(user):
                 submitted_at,
                 flushed=True,
             )
-            if metadata.version is AuthPayloadVersion.V2 else
-            convert_answers(
+            if metadata.version is AuthPayloadVersion.V2
+            else convert_answers(
                 schema,
                 questionnaire_store,
                 full_routing_path,

--- a/tests/integration/test_flush_data.py
+++ b/tests/integration/test_flush_data.py
@@ -32,7 +32,7 @@ class TestFlushData(IntegrationTestCase):
     def test_flush_data_successful(self):
         self.post(
             url="/flush?token="
-                + self.token_generator.generate_token(self.get_payload())
+            + self.token_generator.generate_token(self.get_payload())
         )
         self.assertStatusOK()
 
@@ -63,14 +63,14 @@ class TestFlushData(IntegrationTestCase):
     def test_double_flush(self):
         self.post(
             url="/flush?token="
-                + self.token_generator.generate_token(self.get_payload())
+            + self.token_generator.generate_token(self.get_payload())
         )
 
         # Once the data has been flushed it is wiped.
         # It can't be flushed again and should return 404 no data on second flush
         self.post(
             url="/flush?token="
-                + self.token_generator.generate_token(self.get_payload())
+            + self.token_generator.generate_token(self.get_payload())
         )
         self.assertStatusCode(404)
 
@@ -89,14 +89,14 @@ class TestFlushData(IntegrationTestCase):
 
         self.post(
             url="/flush?token="
-                + self.token_generator.generate_token(self.get_payload())
+            + self.token_generator.generate_token(self.get_payload())
         )
         self.assertStatusCode(500)
 
     def test_flush_sets_flushed_flag_to_true(self):
         self.post(
             url="/flush?token="
-                + self.token_generator.generate_token(self.get_payload())
+            + self.token_generator.generate_token(self.get_payload())
         )
 
         self.encrypt_instance.assert_called_once()  # pylint: disable=no-member
@@ -116,7 +116,9 @@ class TestFlushData(IntegrationTestCase):
 
     @patch("app.routes.flush.convert_answers_v2")
     @patch("app.routes.flush.convert_answers")
-    def test_flush_data_successful_v1(self, mock_convert_answers, mock_convert_answers_v2):
+    def test_flush_data_successful_v1(
+        self, mock_convert_answers, mock_convert_answers_v2
+    ):
         mock_convert_answer_payload = {
             "case_id": "7e0fd167-36af-4506-806d-421e5ba3544b",
             "tx_id": "5432e910-c6ef-418a-abcc-a8de8c23b0f9",
@@ -129,28 +131,20 @@ class TestFlushData(IntegrationTestCase):
             "collection": {
                 "exercise_sid": "f9fb5e81-9820-44cc-a2c3-16bf382b4d8d",
                 "schema_name": "test_textfield",
-                "period": "201605"
+                "period": "201605",
             },
-            "metadata": {
-                "user_id": "UNKNOWN",
-                "ru_ref": "12346789012A"
-            },
+            "metadata": {"user_id": "UNKNOWN", "ru_ref": "12346789012A"},
             "launch_language_code": "en",
             "data": {
-                "answers": [
-                    {
-                        "answer_id": "name-answer",
-                        "value": "sdfsdaf"
-                    }
-                ],
-                "lists": []
+                "answers": [{"answer_id": "name-answer", "value": "sdfsdaf"}],
+                "lists": [],
             },
-            "started_at": "2023-02-07T11:40:46.845149+00:00"
+            "started_at": "2023-02-07T11:40:46.845149+00:00",
         }
         mock_convert_answers.return_value = mock_convert_answer_payload
         self.post(
             url="/flush?token="
-                + self.token_generator.generate_token(self.get_payload())
+            + self.token_generator.generate_token(self.get_payload())
         )
         self.assertStatusOK()
         mock_convert_answers.assert_called_once()
@@ -158,7 +152,9 @@ class TestFlushData(IntegrationTestCase):
 
     @patch("app.routes.flush.convert_answers_v2")
     @patch("app.routes.flush.convert_answers")
-    def test_flush_data_successful_v2(self, mock_convert_answers, mock_convert_answers_v2):
+    def test_flush_data_successful_v2(
+        self, mock_convert_answers, mock_convert_answers_v2
+    ):
         mock_convert_answer_payload = {
             "case_id": "19300487-87e7-42df-9330-718efb08e660",
             "tx_id": "5d8b97f7-c8bd-42e1-88c9-e7721388463b",
@@ -176,18 +172,13 @@ class TestFlushData(IntegrationTestCase):
                 "period_id": "201605",
                 "ru_name": "ESSENTIAL ENTERPRISE LTD.",
                 "user_id": "UNKNOWN",
-                "ru_ref": "12346789012A"
+                "ru_ref": "12346789012A",
             },
             "data": {
-                "answers": [
-                    {
-                        "answer_id": "name-answer",
-                        "value": "sdfsdf"
-                    }
-                ],
-                "lists": []
+                "answers": [{"answer_id": "name-answer", "value": "sdfsdf"}],
+                "lists": [],
             },
-            "started_at": "2023-02-07T11:42:32.380784+00:00"
+            "started_at": "2023-02-07T11:42:32.380784+00:00",
         }
         self.launchSurveyV2("test_textfield")
         form_data = {"name-answer": "Joe Bloggs"}
@@ -195,7 +186,7 @@ class TestFlushData(IntegrationTestCase):
         mock_convert_answers_v2.return_value = mock_convert_answer_payload
         self.post(
             url="/flush?token="
-                + self.token_generator.generate_token(self.get_payload())
+            + self.token_generator.generate_token(self.get_payload())
         )
         self.assertStatusOK()
         mock_convert_answers_v2.assert_called_once()


### PR DESCRIPTION
### What is the context of this PR?
> Currently v2 flushes are using v1 converter. Added a condition to check the metadata for flush accordingly.
[Trello](https://trello.com/c/mqAs98GC/5556-phm-flush-using-v1-instead-of-v2-which-is-failing-over-validating-in-sdx)

### How to review 
> Use the launcher to check if the v2 flush is using v2 converter

**Comment From Developer**
I was not sure how to test this change, the unit tests covers the actual convertors already. Hence used mock to just insure that the appropriate converter is called based on the launch version selected.
