### PR TITLE
Bug: Answer codes validation skips validation-schema fix

### DIFF
--- a/schemas/test/en/test_list_collector_section_summary.json
+++ b/schemas/test/en/test_list_collector_section_summary.json
@@ -55,12 +55,12 @@
             "code": "5"
         },
         {
-          "answer_id": "first-name",
-          "code": "6"
+            "answer_id": "first-name",
+            "code": "6"
         },
         {
-          "answer_id": "last-name",
-          "code": "7"
+            "answer_id": "last-name",
+            "code": "7"
         }
     ],
     "questionnaire_flow": {

--- a/schemas/test/en/test_list_collector_section_summary.json
+++ b/schemas/test/en/test_list_collector_section_summary.json
@@ -53,6 +53,14 @@
         {
             "answer_id": "householder-checkbox-answer",
             "code": "5"
+        },
+        {
+          "answer_id": "first-name",
+          "code": "6"
+        },
+        {
+          "answer_id": "last-name",
+          "code": "7"
         }
     ],
     "questionnaire_flow": {


### PR DESCRIPTION
### What is the context of this PR?
> As a part of the [this fix](https://github.com/ONSdigital/eq-questionnaire-validator/pull/176), the schema tests were failing on runner due to the added validation. This PR updates the schema to fix the failing tests.
### How to review
> Make sure all schema test passes.

### Checklist
* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
