### PR TITLE
Bug: Runner page width set to 12 columns

### DIFF
--- a/templates/layouts/_base.html
+++ b/templates/layouts/_base.html
@@ -36,6 +36,7 @@
 
 {% set pageConfig = {
   "title": full_page_title,
+  "pageColNumber": 8,
   "footer": footer,
   "cdn": {
     "url": cdn_url

--- a/tests/functional/spec/page_layout.spec.js
+++ b/tests/functional/spec/page_layout.spec.js
@@ -1,0 +1,10 @@
+import HubPage from "../base_pages/hub.page";
+
+describe("Page Layout", () => {
+  it("Given a page in the questionnaire, When I visit the page, Then the page width should be as expected", () => {
+    browser.url(HubPage.url());
+
+    const cssWidthSelector = $('div[class*="ons-col-"][class*="@m"]').getAttribute("class");
+    expect(cssWidthSelector).to.contain("ons-col-8@m");
+  });
+});


### PR DESCRIPTION
### What is the context of this PR?
DS V62 sets the default width to 12 columns, this PR sets it to 8 to as that is what runner requires. This was regressed in https://github.com/ONSdigital/eq-questionnaire-runner/pull/1029

Although this is a UI change which we don't normally test, I have added an assertion which checks the width using the CSS class. Although this couples the test with the DS classes, this change is too important to regress.

### How to review
Ensure the width for pages in runner look as expected.

### Checklist
* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
