### PR TITLE
Fixing validation schema failure due to missing title

### DIFF
--- a/schemas/test/en/test_thank_you_census_household.json
+++ b/schemas/test/en/test_thank_you_census_household.json
@@ -30,6 +30,7 @@
     "sections": [
         {
             "id": "household-section",
+            "title": "Household Section",
             "groups": [
                 {
                     "blocks": [


### PR DESCRIPTION
### What is the context of this PR?
The recent change to the validator suggests if the questionnaire_flow properties type is  constant `Hub` each section should have `required title`. The corresponding fix was a part of https://github.com/ONSdigital/eq-questionnaire-runner/pull/996/files PR which still need to be merged. Hence having this fix.

### How to review
Test schema validation is passing.

### Checklist
* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
