### PR TITLE
Fix signed-out confirmation in other languages

### DIFF
--- a/app/helpers/language_helper.py
+++ b/app/helpers/language_helper.py
@@ -37,6 +37,7 @@ def handle_language(metadata: Optional[MetadataProxy] = None) -> None:
                 )
                 if schema.json["title"] != cookie_session.get("title"):
                     cookie_session["title"] = schema.json["title"]
+
             cookie_session["language_code"] = request_language
             session_store.session_data.language_code = request_language
             session_store.save()
@@ -49,6 +50,10 @@ def get_languages_context(current_language: str) -> Optional[dict[str, list[dict
         for language in allowed_languages:
             context.append(_get_language_context(language, current_language))
         return {"languages": context}
+
+    if (language := cookie_session.get("language_code")) and language in LANGUAGE_TEXT:
+        return {"languages": [_get_language_context(language, language)]}
+
     return None
 
 

--- a/app/helpers/language_helper.py
+++ b/app/helpers/language_helper.py
@@ -37,7 +37,7 @@ def handle_language(metadata: Optional[MetadataProxy] = None) -> None:
                 )
                 if schema.json["title"] != cookie_session.get("title"):
                     cookie_session["title"] = schema.json["title"]
-
+            cookie_session["language_code"] = request_language
             session_store.session_data.language_code = request_language
             session_store.save()
 

--- a/app/helpers/template_helpers.py
+++ b/app/helpers/template_helpers.py
@@ -209,9 +209,9 @@ def get_survey_config(
 ) -> SurveyConfig:
     # The fallback to assigning SURVEY_TYPE to theme is only being added until
     # business feedback on the differentiation between theme and SURVEY_TYPE.
+    language = language or get_locale().language
 
     if metadata := get_metadata(current_user):
-        language = language or get_locale().language
         schema = load_schema_from_metadata(metadata=metadata, language_code=language)
 
     survey_theme = theme or get_survey_type()

--- a/app/routes/session.py
+++ b/app/routes/session.py
@@ -123,6 +123,8 @@ def login():
             "account_service_log_out_url"
         )
 
+    cookie_session["language_code"] = metadata.language_code
+
     return redirect(url_for("questionnaire.get_questionnaire"))
 
 

--- a/app/setup.py
+++ b/app/setup.py
@@ -479,10 +479,7 @@ def get_minimized_asset(filename):
 
 
 def get_locale():
-    if language_code := cookie_session.get("language_code"):
-        return language_code
-
-    return None
+    return cookie_session.get("language_code")
 
 
 def get_timezone():

--- a/app/setup.py
+++ b/app/setup.py
@@ -24,7 +24,6 @@ from app.authentication.authenticator import login_manager
 from app.authentication.cookie_session import SHA256SecureCookieSessionInterface
 from app.authentication.user_id_generator import UserIDGenerator
 from app.cloud_tasks import CloudTaskPublisher, LogCloudTaskPublisher
-from app.globals import get_session_store
 from app.helpers import get_span_and_trace
 from app.jinja_filters import blueprint as filter_blueprint
 from app.keys import KEY_PURPOSE_SUBMISSION
@@ -480,10 +479,8 @@ def get_minimized_asset(filename):
 
 
 def get_locale():
-    session = get_session_store()
-
-    if session and (session_data := session.session_data):
-        return session_data.language_code
+    if language_code := cookie_session.get("language_code"):
+        return language_code
 
     return None
 

--- a/tests/app/helpers/test_template_helpers.py
+++ b/tests/app/helpers/test_template_helpers.py
@@ -1116,3 +1116,15 @@ def test_include_csrf_token(app: Flask, include_csrf_token: bool):
         ).context["include_csrf_token"]
 
     assert result == include_csrf_token
+
+
+def test_get_survey_config_language_retrieved_from_cookie(app: Flask):
+    with app.app_context():
+        cookie_session["language_code"] = "cy"
+        cookie_session["theme"] = "social"
+        result = get_survey_config()
+
+    assert (
+        result.account_service_log_out_url
+        == f"{ACCOUNT_SERVICE_BASE_URL_SOCIAL}/cy/start/"
+    )

--- a/tests/app/helpers/test_template_helpers.py
+++ b/tests/app/helpers/test_template_helpers.py
@@ -1121,7 +1121,7 @@ def test_include_csrf_token(app: Flask, include_csrf_token: bool):
 def test_get_survey_config_language_retrieved_from_cookie(app: Flask):
     with app.app_context():
         cookie_session["language_code"] = "cy"
-        cookie_session["theme"] = "social"
+        cookie_session["theme"] = SurveyType.SOCIAL
         result = get_survey_config()
 
     assert result.account_service_log_out_url == f"{ACCOUNT_SERVICE_BASE_URL}/cy/start/"

--- a/tests/app/helpers/test_template_helpers.py
+++ b/tests/app/helpers/test_template_helpers.py
@@ -1124,7 +1124,4 @@ def test_get_survey_config_language_retrieved_from_cookie(app: Flask):
         cookie_session["theme"] = "social"
         result = get_survey_config()
 
-    assert (
-        result.account_service_log_out_url
-        == f"{ACCOUNT_SERVICE_BASE_URL_SOCIAL}/cy/start/"
-    )
+    assert result.account_service_log_out_url == f"{ACCOUNT_SERVICE_BASE_URL}/cy/start/"

--- a/tests/integration/routes/test_cookie.py
+++ b/tests/integration/routes/test_cookie.py
@@ -15,7 +15,8 @@ class TestCookie(IntegrationTestCase):
         self.assertIsNotNone(cookie.get("survey_id"))
         self.assertIsNotNone(cookie.get("user_ik"))
         self.assertIsNotNone(cookie.get("account_service_base_url"))
-        self.assertEqual(len(cookie), 9)
+        self.assertIsNotNone(cookie.get("language_code"))
+        self.assertEqual(len(cookie), 10)
 
         self.assertIsNone(cookie.get("user_id"))
         self.assertIsNone(cookie.get("_permanent"))

--- a/tests/integration/routes/test_questionnaire_language.py
+++ b/tests/integration/routes/test_questionnaire_language.py
@@ -213,4 +213,6 @@ class TestQuestionnaireLanguage(IntegrationTestCase):
         self.launchSurvey("test_language", language_code="cy")
         # Then: sign out
         self.get(self.getSignOutButton()["href"], follow_redirects=True)
+        # Check the text and logos are in Welsh
         self.assertInBody("Mae eich cynnydd wedi'i gadw")
+        self.assertInBody("Swyddfa Ystadegau Gwladol")

--- a/tests/integration/routes/test_questionnaire_language.py
+++ b/tests/integration/routes/test_questionnaire_language.py
@@ -207,3 +207,10 @@ class TestQuestionnaireLanguage(IntegrationTestCase):
         # Switch the language to welsh and check that the last viewed guidance is still being displayed (in welsh)
         self.get(f"{self.last_url}&language_code=cy")
         self.assertInBody("Dyma'r cwestiwn a gafodd ei weld ddiwethaf yn yr adran hon")
+
+    def test_sign_out_cy_survey(self):
+        # When: load a cy survey
+        self.launchSurvey("test_language", language_code="cy")
+        # Then: sign out
+        self.get(self.getSignOutButton()["href"], follow_redirects=True)
+        self.assertInBody("Mae eich cynnydd wedi'i gadw")


### PR DESCRIPTION
### What is the context of this PR?
Currently, when in Welsh the signed-out page (sign out confirmation) does not display all text in Welsh. This PR
adds all necessary changes, cookie session is being used to store the language now, it is being used by `get_locale` method in schema utilities etc.

### How to review
Launch test_language schema, switch to Welsh, click Save and Exit survey. Sign out confirmation should have all its contents in Welsh. Check new test and expanded cookie test.

### Checklist
* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
