### PR TITLE
Update cookie banner to be multilingual

### DIFF
--- a/app/translations/messages.pot
+++ b/app/translations/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-04-05 10:55+0100\n"
+"POT-Creation-Date: 2023-04-14 12:54+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -50,6 +50,8 @@ msgid "Remove {item_name}"
 msgstr ""
 
 #: app/jinja_filters.py:699
+#: templates/partials/summary/collapsible-summary.html:36
+#: templates/partials/summary/summary.html:20
 msgid "No answer provided"
 msgstr ""
 
@@ -857,7 +859,8 @@ msgstr ""
 msgid "Done"
 msgstr ""
 
-#: templates/feedback.html:14 templates/view-submitted-response.html:16
+#: templates/feedback.html:14 templates/preview.html:15
+#: templates/view-submitted-response.html:16
 msgid "Back"
 msgstr ""
 
@@ -880,7 +883,7 @@ msgstr ""
 msgid "If you can’t answer questions for this person"
 msgstr ""
 
-#: templates/interstitial.html:31 templates/layouts/_questionnaire.html:27
+#: templates/interstitial.html:31 templates/layouts/_questionnaire.html:26
 msgid "Save and continue"
 msgstr ""
 
@@ -912,6 +915,53 @@ msgstr ""
 msgid "Close this window to continue with your current survey"
 msgstr ""
 
+#: templates/preview.html:36
+msgid "Preview of the questions in this survey"
+msgstr ""
+
+#: templates/preview.html:41
+msgid "To answer these questions you need to <a href='{url}'>start survey</a>"
+msgstr ""
+
+#: templates/preview.html:43
+msgid ""
+"You may not have to answer all of these questions. The questions you see "
+"will depend on the answers you provide."
+msgstr ""
+
+#: templates/preview.html:48
+msgid "Print questions"
+msgstr ""
+
+#: templates/preview.html:60
+msgid "Save questions as PDF"
+msgstr ""
+
+#: templates/partials/introduction/preview.html:29
+#: templates/partials/summary/collapsible-summary.html:14
+#: templates/preview.html:81
+msgid "Show"
+msgstr ""
+
+#: templates/layouts/_base.html:74
+#: templates/partials/introduction/preview.html:30
+#: templates/partials/summary/collapsible-summary.html:15
+#: templates/preview.html:82
+msgid "Hide"
+msgstr ""
+
+#: templates/partials/introduction/preview.html:47
+#: templates/partials/summary/collapsible-summary.html:59
+#: templates/preview.html:102
+msgid "Show all"
+msgstr ""
+
+#: templates/partials/introduction/preview.html:48
+#: templates/partials/summary/collapsible-summary.html:60
+#: templates/preview.html:103
+msgid "Hide all"
+msgstr ""
+
 #: templates/signed-out.html:5
 msgid "Signed out"
 msgstr ""
@@ -920,13 +970,13 @@ msgstr ""
 msgid "<h1>Your progress has been saved</h1>"
 msgstr ""
 
-#: templates/signed-out.html:23
+#: templates/signed-out.html:21
 msgid ""
 "To find further information or resume the survey, <a href='{url}'>return "
 "to My Account</a>."
 msgstr ""
 
-#: templates/signed-out.html:29
+#: templates/signed-out.html:23
 msgid "To resume the survey, <a href='{url}'>re-enter your access code</a>."
 msgstr ""
 
@@ -972,19 +1022,19 @@ msgid ""
 "your answers</a> for your records."
 msgstr ""
 
-#: templates/thank-you.html:71
+#: templates/layouts/_base.html:157 templates/thank-you.html:71
 msgid "minute"
 msgstr ""
 
-#: templates/thank-you.html:72
+#: templates/layouts/_base.html:158 templates/thank-you.html:72
 msgid "minutes"
 msgstr ""
 
-#: templates/thank-you.html:73
+#: templates/layouts/_base.html:159 templates/thank-you.html:73
 msgid "second"
 msgstr ""
 
-#: templates/thank-you.html:74
+#: templates/layouts/_base.html:160 templates/thank-you.html:74
 msgid "seconds"
 msgstr ""
 
@@ -1234,8 +1284,68 @@ msgid ""
 "href='{contact_us_url}'>contact us</a>"
 msgstr ""
 
-#: templates/layouts/_questionnaire.html:40
+#: templates/layouts/_base.html:20
+msgid "Previous"
+msgstr ""
+
+#: templates/layouts/_base.html:69
+msgid "Tell us whether you accept cookies"
+msgstr ""
+
+#: templates/layouts/_base.html:70
+msgid ""
+"We use <a href='{cookie_settings_url}'>cookies to collect information</a>"
+" about how you use {cookie_domain}. We use this information to make the "
+"website work as well as possible and improve our services."
+msgstr ""
+
+#: templates/layouts/_base.html:71
+msgid ""
+"You’ve accepted all cookies. You can <a "
+"href='{cookie_settings_url}'>change your cookie preferences</a> at any "
+"time."
+msgstr ""
+
+#: templates/layouts/_base.html:72
+msgid "Accept all cookies"
+msgstr ""
+
+#: templates/layouts/_base.html:73
+msgid "Set cookie preferences"
+msgstr ""
+
+#: templates/layouts/_base.html:130
+msgid "Skip to main content"
+msgstr ""
+
+#: templates/layouts/_base.html:152
+msgid "You will be signed out soon"
+msgstr ""
+
+#: templates/layouts/_base.html:153
+msgid "It appears you have been inactive for a while."
+msgstr ""
+
+#: templates/layouts/_base.html:154
+msgid ""
+"To protect your information, your progress will be saved and you will be "
+"signed out in"
+msgstr ""
+
+#: templates/layouts/_base.html:155
+msgid "You are being signed out"
+msgstr ""
+
+#: templates/layouts/_base.html:156
+msgid "Continue survey"
+msgstr ""
+
+#: templates/layouts/_questionnaire.html:39
 msgid "Choose another section and return to this later"
+msgstr ""
+
+#: templates/layouts/configs/_header.html:11
+msgid "Exit"
 msgstr ""
 
 #: templates/macros/helpers.html:13
@@ -1481,8 +1591,15 @@ msgstr ""
 msgid "Start survey"
 msgstr ""
 
+#: templates/partials/summary/collapsible-summary.html:37
 #: templates/partials/summary/list-summary.html:7
+#: templates/partials/summary/summary.html:21
 msgid "Change"
+msgstr ""
+
+#: templates/partials/summary/collapsible-summary.html:38
+#: templates/partials/summary/summary.html:22
+msgid "Change your answer for:"
 msgstr ""
 
 #: templates/partials/summary/list-summary.html:8

--- a/babel.cfg
+++ b/babel.cfg
@@ -2,3 +2,4 @@
 [ignore: templates/components/**]
 [ignore: templates/layout/**]
 [jinja2: templates/**.html]
+extensions=jinja2.ext.do,jinja2.ext.i18n

--- a/templates/layouts/_base.html
+++ b/templates/layouts/_base.html
@@ -72,6 +72,7 @@
         "primaryButtonText": _('Accept all cookies'),
         "secondaryButtonText": _('Set cookie preferences'),
         "confirmationButtonText": _('Hide'),
+        'lang': language_code
       })
     }}
   {% endif %}

--- a/templates/layouts/_questionnaire.html
+++ b/templates/layouts/_questionnaire.html
@@ -1,6 +1,5 @@
 {% extends 'layouts/_base.html' %}
 {% from "components/button/_macro.njk" import onsButton %}
-{% from "components/cookies-banner/_macro.njk" import onsCookiesBanner %}
 
 {% set block = content.block %}
 {% set form = content.form %}

--- a/tests/functional/base_pages/base.page.js
+++ b/tests/functional/base_pages/base.page.js
@@ -20,7 +20,7 @@ export default class BasePage {
   }
 
   acceptCookies() {
-    return ".ons-js-accept-cookies";
+    return '[data-button="accept"]';
   }
 
   submit() {

--- a/tests/functional/spec/cookie_banner.spec.js
+++ b/tests/functional/spec/cookie_banner.spec.js
@@ -1,4 +1,5 @@
 import InitialPage from "../generated_pages/checkbox/mandatory-checkbox.page";
+import HubPage from "../base_pages/hub.page.js";
 
 describe("Given I am not authenticated and have no cookie,", () => {
   it("When I visit a page in runner, Then the cookie banner shouldn‘t be displayed", async () => {
@@ -28,5 +29,31 @@ describe("Given I start a survey,", () => {
     await $(InitialPage.acceptCookies()).click();
     await browser.refresh();
     await expect(await $(InitialPage.acceptCookies()).isDisplayed()).to.be.false;
+  });
+});
+
+describe("Given I start a survey with multiple languages,", () => {
+  beforeEach(async () => {
+    await browser.deleteAllCookies();
+  });
+  it("When I open the page in english, Then the cookie banner should be displayed in english", async () => {
+    await browser.openQuestionnaire("test_language.json", {
+      language: "en",
+    });
+    await expect(await $(HubPage.acceptCookies()).getText()).to.contain("Accept additional cookies");
+  });
+  it("When I open the page in welsh, Then the cookie banner should be displayed in welsh", async () => {
+    await browser.openQuestionnaire("test_language.json", {
+      language: "cy",
+    });
+    await expect(await $(HubPage.acceptCookies()).getText()).to.contain("Derbyn cwcis ychwanegol");
+  });
+  it("When I open the page in english, Then change the language to welsh the cookie banner should be displayed in welsh", async () => {
+    await browser.openQuestionnaire("test_language.json", {
+      language: "en",
+    });
+    await expect(await $(HubPage.acceptCookies()).getText()).to.contain("Accept additional cookies");
+    await $(HubPage.switchLanguage("cy")).click();
+    await expect(await $(HubPage.acceptCookies()).getText()).to.contain("Derbyn cwcis ychwanegol");
   });
 });


### PR DESCRIPTION
### What is the context of this PR?
Sets the language code on cookie banners and adds the babel extension to the babel config to prevent the cookie banner strings from being ignored by translations.
Also removes an import that isn't being used.

### How to review
- Clear your cookies, load test_language schema, switch to Welsh and see that the cookie banner buttons will change to Welsh.
- Test this in comparison to the `main` branch

### Checklist
* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
