### PR TITLE
Bind additional contexts to flush requests

### DIFF
--- a/app/routes/flush.py
+++ b/app/routes/flush.py
@@ -56,6 +56,11 @@ def flush_data() -> Response:
 
         if metadata := get_metadata(user):
             contextvars.bind_contextvars(tx_id=metadata.tx_id)
+            contextvars.bind_contextvars(ce_id=metadata.collection_exercise_sid)
+            if schema_name := metadata.schema_name:
+                contextvars.bind_contextvars(schema_name=schema_name)
+            if schema_url := metadata.schema_url:
+                contextvars.bind_contextvars(schema_url=schema_url)
         if _submit_data(user):
             return Response(status=200)
         return Response(status=404)

--- a/app/routes/flush.py
+++ b/app/routes/flush.py
@@ -55,8 +55,10 @@ def flush_data() -> Response:
         user = _get_user(decrypted_token["response_id"])
 
         if metadata := get_metadata(user):
-            contextvars.bind_contextvars(tx_id=metadata.tx_id)
-            contextvars.bind_contextvars(ce_id=metadata.collection_exercise_sid)
+            contextvars.bind_contextvars(
+                tx_id=metadata.tx_id,
+                ce_id=metadata.collection_exercise_sid,
+            )
             if schema_name := metadata.schema_name:
                 contextvars.bind_contextvars(schema_name=schema_name)
             if schema_url := metadata.schema_url:

--- a/tests/integration/test_flush_data.py
+++ b/tests/integration/test_flush_data.py
@@ -1,9 +1,13 @@
 import time
 import uuid
 
+from httmock import HTTMock, urlmatch
 from mock import patch
 
+from app.utilities.schema import get_schema_path_map
 from tests.integration.integration_test_case import IntegrationTestCase
+
+SCHEMA_PATH_MAP = get_schema_path_map(include_test_schemas=True)
 
 
 class TestFlushData(IntegrationTestCase):
@@ -28,6 +32,14 @@ class TestFlushData(IntegrationTestCase):
         self.encrypter_patcher.stop()
 
         super().tearDown()
+
+    @staticmethod
+    @urlmatch(netloc=r"eq-survey-register", path=r"\/my-test-schema")
+    def schema_url_mock(_url, _request):
+        schema_path = SCHEMA_PATH_MAP["test"]["en"]["test_textfield"]
+
+        with open(schema_path, encoding="utf8") as json_data:
+            return json_data.read()
 
     def test_flush_data_successful(self):
         self.post(
@@ -191,3 +203,38 @@ class TestFlushData(IntegrationTestCase):
         self.assertStatusOK()
         mock_convert_answers_v2.assert_called_once()
         mock_convert_answers.assert_not_called()
+
+    def test_flush_logs_output(self):
+        with self.assertLogs() as logs:
+            self.post(
+                url=f"/flush?token={self.token_generator.create_token(schema_name='test_textfield', payload=self.get_payload())}"
+            )
+
+            flush_log = logs.output[5]
+
+            self.assertIn("successfully flushed answers", flush_log)
+            self.assertIn("tx_id", flush_log)
+            self.assertIn("ce_id", flush_log)
+            self.assertIn("schema_name", flush_log)
+            self.assertNotIn("schema_url", flush_log)
+
+    def test_flush_logs_output_schema_url(self):
+        schema_url = "http://eq-survey-register.url/my-test-schema"
+        token = self.token_generator.create_token_with_schema_url(
+            "test_textfield", schema_url
+        )
+        with HTTMock(self.schema_url_mock):
+            self.get(url=f"/session?token={token}")
+            self.assertStatusOK()
+            with self.assertLogs() as logs:
+                self.post(
+                    url=f"/flush?token={self.token_generator.create_token_with_schema_url('test_textfield', schema_url, payload=self.get_payload())}"
+                )
+
+                flush_log = logs.output[6]
+
+                self.assertIn("successfully flushed answers", flush_log)
+                self.assertIn("tx_id", flush_log)
+                self.assertIn("ce_id", flush_log)
+                self.assertIn("schema_name", flush_log)
+                self.assertIn("schema_url", flush_log)


### PR DESCRIPTION
### What is the context of this PR?
This binds new context vars to our logs on flush requests. New values are exercise id, schema name and schema url where applicable. 

### How to review
Two new unit tests added to test both logs with and without `schema_url` present.

### Checklist
* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
