### PR TITLE
Fix invalid values in numerical form inputs 

### DIFF
--- a/app/forms/fields/decimal_field_with_separator.py
+++ b/app/forms/fields/decimal_field_with_separator.py
@@ -23,8 +23,16 @@ class DecimalFieldWithSeparator(DecimalField):
     def process_formdata(self, valuelist):
         if valuelist:
             try:
-                self.data = Decimal(
-                    valuelist[0].replace(numbers.get_group_symbol(DEFAULT_LOCALE), "")
-                )
+                data = valuelist[0]
+                if numbers.get_group_symbol(DEFAULT_LOCALE) in data:
+                    data = data.replace(numbers.get_group_symbol(DEFAULT_LOCALE), "")
+                try:
+                    self.data = Decimal(
+                        numbers.format_decimal(
+                            data, locale=DEFAULT_LOCALE, group_separator=False
+                        )
+                    )
+                except InvalidOperation:
+                    self.data = Decimal(data)
             except (ValueError, TypeError, InvalidOperation):
                 pass

--- a/app/forms/fields/integer_field_with_separator.py
+++ b/app/forms/fields/integer_field_with_separator.py
@@ -1,3 +1,5 @@
+from decimal import InvalidOperation
+
 from babel import numbers
 from wtforms import IntegerField
 
@@ -21,8 +23,16 @@ class IntegerFieldWithSeparator(IntegerField):
     def process_formdata(self, valuelist):
         if valuelist:
             try:
-                self.data = int(
-                    valuelist[0].replace(numbers.get_group_symbol(DEFAULT_LOCALE), "")
-                )
+                data = valuelist[0]
+                if numbers.get_group_symbol(DEFAULT_LOCALE) in data:
+                    data = data.replace(numbers.get_group_symbol(DEFAULT_LOCALE), "")
+                try:
+                    self.data = int(
+                        numbers.format_decimal(
+                            data, locale=DEFAULT_LOCALE, group_separator=False
+                        )
+                    )
+                except InvalidOperation:
+                    self.data = int(data)
             except ValueError:
                 pass

--- a/tests/app/forms/test_custom_fields.py
+++ b/tests/app/forms/test_custom_fields.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 import pytest
 from wtforms.fields import Field
 
@@ -29,6 +31,45 @@ def test_integer_field(mock_form):
         integer_field.process_formdata(["NonInteger"])
     except IndexError:
         pytest.fail("Exceptions should not thrown by CustomIntegerField")
+
+
+@pytest.mark.parametrize(
+    "number_input, result",
+    [
+        ("_110", 110),
+        ("1_10", 110),
+        ("1__10", 110),
+        ("1_1,0", 110),
+        ("_1_1,0,0", 1100),
+        ("1.10", None),
+    ],
+)
+def test_integer_field_formats(mock_form, number_input, result):
+    integer_field = IntegerFieldWithSeparator(_form=mock_form, name="aName")
+    assert isinstance(integer_field, Field)
+
+    integer_field.process_formdata([number_input])
+
+    assert integer_field.data == result
+
+
+@pytest.mark.parametrize(
+    "number_input, result",
+    [
+        ("1_1,0", Decimal("110")),
+        ("1.10", Decimal("1.1")),
+        ("_1.1_0", Decimal("1.1")),
+        ("_1.1_0,0", Decimal("1.1")),
+        ("_1._1,0,0", Decimal("1.1")),
+    ],
+)
+def test_decimal_field_formats(mock_form, number_input, result):
+    integer_field = DecimalFieldWithSeparator(_form=mock_form, name="aName")
+    assert isinstance(integer_field, Field)
+
+    integer_field.process_formdata([number_input])
+
+    assert integer_field.data == result
 
 
 def test_decimal_field(mock_form):


### PR DESCRIPTION
### What is the context of this PR?
This adds some extra form data clean up to strip down all supported number symbols but don't cause further errors as a result of bad string to integer/decimal conversion in transforms. It should prevent the issues with invalid number inputs we experienced in the past. Some logic changes were needed for handling all the expected behaviours in runner (eg. percentage field with decimal value as input need to get through `process_formdata` method and raise `ValueError` exception in order to fail form validation).

### How to review
New tests added, make sure all possible inputs are covered. Are there any other form field classes that require this change?

### Checklist
* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
