### PR TITLE
Create supplementary data store

### DIFF
--- a/app/data_models/answer_store.py
+++ b/app/data_models/answer_store.py
@@ -137,15 +137,17 @@ class AnswerStore:
 
         return False
 
-    def remove_all_answers_for_list_item_id(self, list_item_id: str) -> None:
-        """Remove all answers associated with a particular list_item_id.
+    def remove_all_answers_for_list_item_ids(
+        self, list_item_ids: Iterable[str]
+    ) -> None:
+        """Remove all answers associated with any of the list_item_ids passed in.
         This method iterates through the entire list of answers.
 
         *Not efficient.*
         """
         keys_to_delete = []
         for answer in self:
-            if answer.list_item_id == list_item_id:
+            if answer.list_item_id and answer.list_item_id in list_item_ids:
                 keys_to_delete.append((answer.answer_id, answer.list_item_id))
 
         for key in keys_to_delete:

--- a/app/data_models/list_store.py
+++ b/app/data_models/list_store.py
@@ -215,6 +215,10 @@ class ListStore:
 
         return list_item_id
 
+    def delete_list(self, list_name: str) -> None:
+        """Deletes the entire list. Currently, this is only used when old supplementary data is being overwritten"""
+        del self._lists[list_name]
+
     def serialize(self) -> list[ListModelDictType]:
         return [list_model.serialize() for list_model in self]
 

--- a/app/data_models/questionnaire_store.py
+++ b/app/data_models/questionnaire_store.py
@@ -7,6 +7,7 @@ from app.data_models.answer_store import AnswerStore
 from app.data_models.list_store import ListStore
 from app.data_models.metadata_proxy import MetadataProxy
 from app.data_models.progress_store import ProgressStore
+from app.data_models.supplementary_data_store import SupplementaryDataStore
 from app.questionnaire.rules.utils import parse_iso_8601_datetime
 from app.utilities.json import json_dumps, json_loads
 
@@ -28,13 +29,12 @@ class QuestionnaireStore:
         self.version = version
         self._metadata: MutableMapping = {}
         # self.metadata is a read-only view over self._metadata
-        self.metadata: Optional[MetadataProxy] = (
-            MetadataProxy.from_dict(self._metadata) if self._metadata else None
-        )
+        self.metadata: MetadataProxy | None = None
         self.response_metadata: MutableMapping = {}
         self.list_store = ListStore()
         self.answer_store = AnswerStore()
         self.progress_store = ProgressStore()
+        self.supplementary_data_store = SupplementaryDataStore()
         self.submitted_at: Optional[datetime]
         self.collection_exercise_sid: Optional[str]
 
@@ -63,10 +63,74 @@ class QuestionnaireStore:
 
         return self
 
+    def set_supplementary_data(self, to_set: MutableMapping) -> None:
+        """
+        Used to set or update the supplementary data whenever the sds endpoint is called
+        (Which should be once per session, but only if the sds_dataset_id has changed)
+
+        this updates ListStore to add/update any lists for supplementary data and stores the
+        identifier -> list_item_id mappings in the supplementary data store to use in the payload at the end
+        """
+        if self.supplementary_data_store.list_mappings:
+            self._remove_old_supplementary_lists_and_answers(new_data=to_set)
+
+        list_mappings = {
+            list_name: self._create_supplementary_list(list_name, list_data)
+            for list_name, list_data in to_set.get("items", {}).items()
+        }
+
+        self.supplementary_data_store = SupplementaryDataStore(
+            supplementary_data=to_set, list_mappings=list_mappings
+        )
+
+    def _create_supplementary_list(
+        self, list_name: str, list_data: list[dict]
+    ) -> dict[str, str]:
+        """
+        Creates or updates a list in ListStore based off supplementary data
+        returns the identifier -> list_item_id mappings used
+        """
+        list_mapping: dict[str, str] = {}
+        for list_item in list_data:
+            identifier = list_item["identifier"]
+            # if any pre-existing supplementary data already has a mapping for this list item
+            # then its already in the list store and doesn't require adding
+            if not (
+                list_item_id := self.supplementary_data_store.list_mappings.get(
+                    list_name, {}
+                ).get(identifier)
+            ):
+                list_item_id = self.list_store.add_list_item(list_name)
+            list_mapping[identifier] = list_item_id
+        return list_mapping
+
+    def _remove_old_supplementary_lists_and_answers(
+        self, new_data: MutableMapping
+    ) -> None:
+        """
+        In the case that existing supplementary data is being replaced with new data: any list items in the old data
+        but not the new data are removed from the list store and related answers are deleted
+        :param new_data - the new supplementary data for comparison
+        """
+        deleted_list_item_ids: set[str] = set()
+        for list_name, mappings in self.supplementary_data_store.list_mappings.items():
+            if list_name not in new_data.get("items", {}):
+                self.list_store.delete_list(list_name)
+                deleted_list_item_ids.update(mappings.values())
+            else:
+                for identifier, list_item_id in mappings.items():
+                    if identifier not in new_data["items"][list_name]:
+                        self.list_store.delete_list_item(list_name, list_item_id)
+                        deleted_list_item_ids.add(list_item_id)
+        self.answer_store.remove_all_answers_for_list_item_ids(deleted_list_item_ids)
+
     def _deserialize(self, data: str) -> None:
         json_data = json_loads(data)
         self.progress_store = ProgressStore(json_data.get("PROGRESS"))
         self.set_metadata(json_data.get("METADATA", {}))
+        self.supplementary_data_store = SupplementaryDataStore.deserialize(
+            json_data.get("SUPPLEMENTARY_DATA", {})
+        )
         self.answer_store = AnswerStore(json_data.get("ANSWERS"))
         self.list_store = ListStore.deserialize(json_data.get("LISTS"))
         self.response_metadata = json_data.get("RESPONSE_METADATA", {})
@@ -75,6 +139,7 @@ class QuestionnaireStore:
         data = {
             "METADATA": self._metadata,
             "ANSWERS": list(self.answer_store),
+            "SUPPLEMENTARY_DATA": self.supplementary_data_store.serialize(),
             "LISTS": self.list_store.serialize(),
             "PROGRESS": self.progress_store.serialize(),
             "RESPONSE_METADATA": self.response_metadata,

--- a/app/data_models/questionnaire_store.py
+++ b/app/data_models/questionnaire_store.py
@@ -119,7 +119,9 @@ class QuestionnaireStore:
                 deleted_list_item_ids.update(mappings.values())
             else:
                 for identifier, list_item_id in mappings.items():
-                    if identifier not in new_data["items"][list_name]:
+                    if identifier not in [
+                        item["identifier"] for item in new_data["items"][list_name]
+                    ]:
                         self.list_store.delete_list_item(list_name, list_item_id)
                         deleted_list_item_ids.add(list_item_id)
         self.answer_store.remove_all_answers_for_list_item_ids(deleted_list_item_ids)

--- a/app/data_models/supplementary_data_store.py
+++ b/app/data_models/supplementary_data_store.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from functools import cached_property
+from typing import Iterable, Mapping, MutableMapping, TypeAlias
+
+from werkzeug.datastructures import ImmutableDict
+
+SupplementaryDataKeyType: TypeAlias = tuple[str, str | None]
+SupplementaryDataValueType: TypeAlias = dict | str | list | None
+
+
+class SupplementaryDataStore:
+    """
+    An object that stores supplementary data
+    """
+
+    def __init__(
+        self,
+        supplementary_data: MutableMapping | None = None,
+        list_mappings: Mapping[str, Mapping] | None = None,
+    ):
+        """
+        Initialised with the "data" value from the sds api response
+        and list mappings of the form { list_name: { identifier : list_item_id }}
+        """
+        self._raw_data = supplementary_data or {}
+        self._list_mappings = list_mappings or {}
+        # use shallow copy of the data, as items will be popped off
+        self._data_map = self._build_map({**self._raw_data})
+
+    @cached_property
+    def raw_data(self) -> ImmutableDict:
+        return ImmutableDict(self._raw_data)
+
+    @cached_property
+    def list_mappings(self) -> ImmutableDict:
+        return ImmutableDict(self._list_mappings)
+
+    def _build_map(
+        self, data: MutableMapping
+    ) -> dict[SupplementaryDataKeyType, SupplementaryDataValueType]:
+        """
+        The raw data will be of the form
+        {
+          "some_key": "some_value"
+          "items": {
+            "some_list": [
+                {"identifier": ... },
+                {"identifier": ... }
+            ]
+          }
+        }
+        each list item has an identifier which will link to a list-item-id in self.list_mappings
+        for example: {"some_list": {identifier-1: list_item_id-1, identifier-2: list_item_id-2 }}
+
+        resulting map based off list mappings has the form
+        {
+            ("some_key", None): "some_value"
+            ("some_list", list_item_id-1): {"identifier": identifier-1, ...}
+            ("some_list", list_item_id-2): {"identifier": identifier-2, ...}
+        }
+        """
+        list_items = data.pop("items", {})
+        resulting_map: dict[SupplementaryDataKeyType, SupplementaryDataValueType] = {
+            (key, None): value for key, value in data.items()
+        }
+        for list_name, list_data in list_items.items():
+            for item in list_data:
+                identifier = item["identifier"]
+                list_item_id = self._list_mappings[list_name][identifier]
+                resulting_map[(list_name, list_item_id)] = item
+        return resulting_map
+
+    def get_data(
+        self,
+        *,
+        identifier: str,
+        selectors: Iterable[str] | None = None,
+        list_item_id: str | None = None,
+    ) -> SupplementaryDataValueType:
+        """
+        Used to retrieve supplementary data in a similar style to AnswerStore
+        the identifier is the top level key for static data, and the name of the list for list items
+        selectors are used to reference nested data
+
+        For example if you wanted the identifier for the first item in "some_list"
+        it would be get_data(identifier="some_list", selectors=["identifier"], list_item_id=list_item_id-1)
+        """
+        if not (value := self._data_map.get((identifier, list_item_id))):
+            return None
+
+        if selectors:
+            # for nested data, index with each selector
+            for selector in selectors:
+                if not isinstance(value, dict):
+                    raise ValueError(
+                        f"Cannot use the selector `{selector}` on non-nested data"
+                    )
+                value = value[selector]
+
+        return value
+
+    def serialize(self) -> dict:
+        return {
+            "supplementary_data": self._raw_data,
+            "list_mappings": self._list_mappings,
+        }
+
+    @classmethod
+    def deserialize(cls, serialized_data: Mapping) -> SupplementaryDataStore:
+        if not serialized_data:
+            return cls()
+
+        return cls(
+            supplementary_data=serialized_data["supplementary_data"],
+            list_mappings=serialized_data["list_mappings"],
+        )

--- a/app/data_models/supplementary_data_store.py
+++ b/app/data_models/supplementary_data_store.py
@@ -9,6 +9,10 @@ SupplementaryDataKeyType: TypeAlias = tuple[str, str | None]
 SupplementaryDataValueType: TypeAlias = dict | str | list | None
 
 
+class InvalidSupplementaryDataSelector(Exception):
+    pass
+
+
 class SupplementaryDataStore:
     """
     An object that stores supplementary data
@@ -93,7 +97,7 @@ class SupplementaryDataStore:
             # for nested data, index with each selector
             for selector in selectors:
                 if not isinstance(value, dict):
-                    raise ValueError(
+                    raise InvalidSupplementaryDataSelector(
                         f"Cannot use the selector `{selector}` on non-nested data"
                     )
                 value = value[selector]

--- a/app/questionnaire/questionnaire_store_updater.py
+++ b/app/questionnaire/questionnaire_store_updater.py
@@ -154,9 +154,7 @@ class QuestionnaireStoreUpdater:
         """
         self._list_store.delete_list_item(list_name, list_item_id)
 
-        self._answer_store.remove_all_answers_for_list_item_id(
-            list_item_id=list_item_id
-        )
+        self._answer_store.remove_all_answers_for_list_item_ids([list_item_id])
 
         if answers := self.get_relationship_answers_for_list_name(list_name):
             self._remove_relationship_answers_for_list_item_id(list_item_id, answers)

--- a/app/routes/session.py
+++ b/app/routes/session.py
@@ -12,8 +12,12 @@ from werkzeug.exceptions import Unauthorized
 from werkzeug.wrappers.response import Response
 
 from app.authentication.auth_payload_versions import AuthPayloadVersion
-from app.authentication.authenticator import decrypt_token, store_session
+from app.authentication.authenticator import (
+    create_session_questionnaire_store,
+    decrypt_token,
+)
 from app.authentication.jti_claim_storage import JtiTokenUsed, use_jti_claim
+from app.data_models import QuestionnaireStore
 from app.data_models.metadata_proxy import MetadataProxy
 from app.globals import get_session_store, get_session_timeout_in_seconds
 from app.helpers.template_helpers import (
@@ -113,7 +117,8 @@ def login() -> Response:
 
     logger.info("decrypted token and parsed metadata")
 
-    store_session(claims)
+    with create_session_questionnaire_store(claims) as questionnaire_store:
+        _set_questionnaire_supplementary_data(questionnaire_store, metadata)
 
     cookie_session["expires_in"] = get_session_timeout_in_seconds(g.schema)
 
@@ -129,15 +134,39 @@ def login() -> Response:
 
     cookie_session["language_code"] = metadata.language_code
 
-    # Type ignore: survey_id and either ru_ref or qid are required for schemas that use supplementary data
-    if dataset_id := metadata["sds_dataset_id"]:
-        get_supplementary_data(
-            dataset_id=dataset_id,
-            unit_id=metadata["ru_ref"] or metadata["qid"],  # type: ignore
-            survey_id=metadata["survey_id"],  # type: ignore
-        )
-
     return redirect(url_for("questionnaire.get_questionnaire"))
+
+
+def _set_questionnaire_supplementary_data(
+    questionnaire_store: QuestionnaireStore, metadata: MetadataProxy
+) -> None:
+    """
+    If the survey metadata has an sds dataset id, and it either doesn't match what it stored, or there is no stored supplementary data
+    then fetch it and add it to the store
+    """
+    existing_sds_dataset_id = (
+        questionnaire_store.metadata.survey_metadata.data.get("sds_dataset_id")
+        if questionnaire_store.metadata and questionnaire_store.metadata.survey_metadata
+        else None
+    )
+
+    if not (new_sds_dataset_id := metadata["sds_dataset_id"]):
+        if existing_sds_dataset_id:
+            # remove what is already there
+            questionnaire_store.set_supplementary_data({})
+        return
+
+    if existing_sds_dataset_id == new_sds_dataset_id:
+        # no need to fetch again
+        return
+
+    supplementary_data = get_supplementary_data(
+        # Type ignore: survey_id and either ru_ref or qid are required for schemas that use supplementary data
+        dataset_id=new_sds_dataset_id,
+        unit_id=metadata["ru_ref"] or metadata["qid"],  # type: ignore
+        survey_id=metadata["survey_id"],  # type: ignore
+    )
+    questionnaire_store.set_supplementary_data(supplementary_data["data"])
 
 
 def validate_jti(decrypted_token: dict[str, str | list | int]) -> None:

--- a/app/routes/session.py
+++ b/app/routes/session.py
@@ -145,7 +145,7 @@ def _set_questionnaire_supplementary_data(
     then fetch it and add it to the store
     """
     existing_sds_dataset_id = (
-        questionnaire_store.metadata.survey_metadata.data.get("sds_dataset_id")
+        questionnaire_store.metadata.survey_metadata.data["sds_dataset_id"]
         if questionnaire_store.metadata and questionnaire_store.metadata.survey_metadata
         else None
     )

--- a/app/submitter/converter.py
+++ b/app/submitter/converter.py
@@ -70,6 +70,7 @@ def convert_answers(
     answer_store = questionnaire_store.answer_store
     list_store = questionnaire_store.list_store
     progress_store = questionnaire_store.progress_store
+    supplementary_data_store = questionnaire_store.supplementary_data_store
 
     survey_id = schema.json["survey_id"]
 
@@ -97,6 +98,7 @@ def convert_answers(
         metadata=metadata,
         response_metadata=response_metadata,
         progress_store=progress_store,
+        supplementary_data_store=supplementary_data_store,
     )
 
     return payload | optional_properties

--- a/app/submitter/converter_v2.py
+++ b/app/submitter/converter_v2.py
@@ -6,6 +6,7 @@ from structlog import get_logger
 from app.authentication.auth_payload_versions import AuthPayloadVersion
 from app.data_models import AnswerStore, ListStore, ProgressStore, QuestionnaireStore
 from app.data_models.metadata_proxy import MetadataProxy, NoMetadataException
+from app.data_models.supplementary_data_store import SupplementaryDataStore
 from app.questionnaire.questionnaire_schema import (
     DEFAULT_LANGUAGE_CODE,
     QuestionnaireSchema,
@@ -56,6 +57,7 @@ def convert_answers_v2(
     answer_store = questionnaire_store.answer_store
     list_store = questionnaire_store.list_store
     progress_store = questionnaire_store.progress_store
+    supplementary_data_store = questionnaire_store.supplementary_data_store
 
     survey_id = schema.json["survey_id"]
 
@@ -87,6 +89,7 @@ def convert_answers_v2(
         metadata=metadata,
         response_metadata=response_metadata,
         progress_store=progress_store,
+        supplementary_data_store=supplementary_data_store,
     )
 
     logger.info("converted answer ready for submission")
@@ -108,6 +111,7 @@ def get_optional_payload_properties(
     return payload
 
 
+# pylint: disable=too-many-locals
 def get_payload_data(
     answer_store: AnswerStore,
     list_store: ListStore,
@@ -116,7 +120,8 @@ def get_payload_data(
     metadata: MetadataProxy,
     response_metadata: MutableMapping,
     progress_store: ProgressStore,
-) -> OrderedDict[str, Any] | dict[str, list[Any]]:
+    supplementary_data_store: SupplementaryDataStore,
+) -> OrderedDict | dict[str, list | dict]:
     if schema.json["data_version"] == "0.0.1":
         return convert_answers_to_payload_0_0_1(
             metadata=metadata,
@@ -136,10 +141,16 @@ def get_payload_data(
             full_routing_path=full_routing_path,
         )
 
-        data: dict[str, list[Any]] = {
-            "answers": answers,
-            "lists": list_store.serialize(),
-        }
+        lists: list = list_store.serialize()
+        for list_ in lists:
+            # for any lists that were populated by supplementary data, provide the identifier -> list_item_id mappings
+            if mapping := supplementary_data_store.list_mappings.get(list_["name"]):
+                list_["supplementary_data_mapping"] = mapping
+
+        data: dict[str, list | dict] = {"answers": answers, "lists": lists}
+
+        if supplementary_data_store.raw_data:
+            data["supplementary_data"] = supplementary_data_store.raw_data
 
         if answer_codes := schema.json.get("answer_codes"):
             answer_ids_to_filter = {answer.answer_id for answer in answers}

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -17,6 +17,7 @@ from app.data_models.metadata_proxy import MetadataProxy
 from app.data_models.progress_store import ProgressStore
 from app.data_models.session_data import SessionData
 from app.data_models.session_store import SessionStore
+from app.data_models.supplementary_data_store import SupplementaryDataStore
 from app.publisher import PubSubPublisher
 from app.questionnaire.location import Location
 from app.setup import create_app
@@ -161,6 +162,11 @@ def list_store():
 @pytest.fixture
 def progress_store():
     return ProgressStore()
+
+
+@pytest.fixture
+def supplementary_data_store():
+    return SupplementaryDataStore()
 
 
 @pytest.fixture

--- a/tests/app/data_model/conftest.py
+++ b/tests/app/data_model/conftest.py
@@ -5,6 +5,7 @@ import pytest
 from app.data_models.answer_store import Answer
 from app.data_models.progress_store import CompletionStatus
 from app.data_models.session_store import SessionStore
+from app.data_models.supplementary_data_store import SupplementaryDataStore
 from app.storage import storage_encryption
 from tests.app.parser.conftest import get_response_expires_at
 
@@ -96,6 +97,7 @@ def basic_input():
                 "block_ids": ["a-test-block"],
             }
         ],
+        "SUPPLEMENTARY_DATA": {"supplementary_data": {}, "list_mappings": {}},
         "RESPONSE_METADATA": {"test-meta": "test"},
     }
 
@@ -154,3 +156,38 @@ def app_session_store_encoded(mocker, session_data):
         store.user_id, store.user_ik, store.pepper
     )
     return store
+
+
+@pytest.fixture
+def supplementary_data_store_with_data():
+    fake_data = {
+        "schema_version": "v1",
+        "identifier": "12346789012A",
+        "note": {
+            "title": "Volume of total production",
+        },
+        "items": {
+            "products": [
+                {
+                    "identifier": "89929001",
+                    "name": "Articles and equipment for sports or outdoor games",
+                    "cn_codes": "2504 + 250610 + 2512 + 2519 + 2524",
+                    "value_sales": {
+                        "answer_code": "89929001",
+                        "label": "Value of sales",
+                    },
+                },
+                {
+                    "identifier": "201630601",
+                    "name": "Other Minerals",
+                    "cn_codes": "5908 + 5910 + 591110 + 591120 + 591140",
+                    "value_sales": {
+                        "answer_code": "201630601",
+                        "label": "Value of sales",
+                    },
+                },
+            ]
+        },
+    }
+    list_mappings = {"products": {"89929001": "item-1", "201630601": "item-2"}}
+    return SupplementaryDataStore(fake_data, list_mappings)

--- a/tests/app/data_model/test_answer_store.py
+++ b/tests/app/data_model/test_answer_store.py
@@ -103,13 +103,13 @@ def test_remove_answer_without_list_item_id(basic_answer_store):
 
 
 def test_remove_all_answers_for_list_item_id(relationship_answer_store):
-    relationship_answer_store.remove_all_answers_for_list_item_id("abc123")
+    relationship_answer_store.remove_all_answers_for_list_item_ids(["abc123"])
     assert relationship_answer_store.get_answer("answer1") is None
 
 
 def test_remove_all_answers_for_list_item_id_doesnt_exist(relationship_answer_store):
     len_before = len(relationship_answer_store)
-    relationship_answer_store.remove_all_answers_for_list_item_id("not-an-id")
+    relationship_answer_store.remove_all_answers_for_list_item_ids(["not-an-id"])
     assert len(relationship_answer_store) == len_before
 
 

--- a/tests/app/data_model/test_list_store.py
+++ b/tests/app/data_model/test_list_store.py
@@ -91,6 +91,14 @@ def test_delete_list_item_id():
     assert not store._lists  # pylint: disable=protected-access
 
 
+def test_delete_list():
+    store = ListStore()
+    store.add_list_item("people")
+    store.add_list_item("people")
+    store.delete_list("people")
+    assert not store._lists  # pylint: disable=protected-access
+
+
 def test_delete_list_item_id_does_not_raise():
     store = ListStore()
     store.add_list_item("people")

--- a/tests/app/data_model/test_questionnaire_store.py
+++ b/tests/app/data_model/test_questionnaire_store.py
@@ -4,6 +4,7 @@ from app.data_models import QuestionnaireStore
 from app.data_models.answer_store import AnswerStore
 from app.data_models.metadata_proxy import MetadataProxy
 from app.data_models.progress_store import ProgressStore
+from app.data_models.supplementary_data_store import SupplementaryDataStore
 from app.utilities.json import json_dumps, json_loads
 
 
@@ -64,6 +65,9 @@ def test_questionnaire_store_updates_storage(questionnaire_store, basic_input):
     store.answer_store = AnswerStore(basic_input["ANSWERS"])
     store.response_metadata = basic_input["RESPONSE_METADATA"]
     store.progress_store = ProgressStore(basic_input["PROGRESS"])
+    store.supplementary_data_store = SupplementaryDataStore.deserialize(
+        basic_input["SUPPLEMENTARY_DATA"]
+    )
 
     # When
     store.save()

--- a/tests/app/data_model/test_supplementary_data_store.py
+++ b/tests/app/data_model/test_supplementary_data_store.py
@@ -1,0 +1,82 @@
+import pytest
+from werkzeug.datastructures import ImmutableDict
+
+from app.data_models.supplementary_data_store import SupplementaryDataStore
+
+
+def test_supplementary_data_serialisation(supplementary_data_store_with_data):
+    raw_data = supplementary_data_store_with_data.raw_data
+    list_mappings = supplementary_data_store_with_data.list_mappings
+
+    serialized = supplementary_data_store_with_data.serialize()
+
+    assert serialized == {
+        "supplementary_data": raw_data,
+        "list_mappings": list_mappings,
+    }
+
+
+def test_supplementary_data_deserialisation():
+    raw_data = {
+        "identifier": "12346789012A",
+        "items": {
+            "products": [
+                {"identifier": "89929001"},
+                {"identifier": "201630601"},
+            ]
+        },
+    }
+    list_mappings = {"products": {"89929001": "item-1", "201630601": "item-2"}}
+
+    serialized = {
+        "supplementary_data": raw_data,
+        "list_mappings": list_mappings,
+    }
+
+    deserialized = SupplementaryDataStore.deserialize(serialized)
+
+    assert deserialized.raw_data == ImmutableDict(raw_data)
+    assert deserialized.list_mappings == ImmutableDict(list_mappings)
+    assert deserialized._data_map == {  # pylint: disable=protected-access
+        ("identifier", None): "12346789012A",
+        ("products", "item-1"): {"identifier": "89929001"},
+        ("products", "item-2"): {"identifier": "201630601"},
+    }
+
+
+def test_empty_supplementary_data_deserialisation():
+    empty_store = SupplementaryDataStore.deserialize({})
+    assert not empty_store.raw_data
+    assert not empty_store.list_mappings
+    assert not empty_store._data_map  # pylint: disable=protected-access
+
+
+@pytest.mark.parametrize(
+    "identifier,list_item_id,selectors,expected",
+    [
+        ("identifier", None, None, "12346789012A"),
+        ("note", None, ["title"], "Volume of total production"),
+        ("products", "item-2", ["name"], "Other Minerals"),
+        ("products", "item-1", ["value_sales", "answer_code"], "89929001"),
+        ("INVALID", None, None, None),
+    ],
+)
+def test_get_supplementary_data(
+    supplementary_data_store_with_data, identifier, list_item_id, selectors, expected
+):
+    assert (
+        supplementary_data_store_with_data.get_data(
+            identifier=identifier,
+            list_item_id=list_item_id,
+            selectors=selectors,
+        )
+        == expected
+    )
+
+
+def test_get_supplementary_data_invalid_selectors(supplementary_data_store_with_data):
+    with pytest.raises(ValueError) as exception:
+        supplementary_data_store_with_data.get_data(
+            identifier="identifier", selectors=["INVALID"], list_item_id=None
+        )
+        assert "Cannot use the selector `INVALID` on non-nested data" == str(exception)

--- a/tests/app/data_model/test_supplementary_data_store.py
+++ b/tests/app/data_model/test_supplementary_data_store.py
@@ -1,7 +1,10 @@
 import pytest
 from werkzeug.datastructures import ImmutableDict
 
-from app.data_models.supplementary_data_store import SupplementaryDataStore
+from app.data_models.supplementary_data_store import (
+    InvalidSupplementaryDataSelector,
+    SupplementaryDataStore,
+)
 
 
 def test_supplementary_data_serialisation(supplementary_data_store_with_data):
@@ -75,7 +78,7 @@ def test_get_supplementary_data(
 
 
 def test_get_supplementary_data_invalid_selectors(supplementary_data_store_with_data):
-    with pytest.raises(ValueError) as exception:
+    with pytest.raises(InvalidSupplementaryDataSelector) as exception:
         supplementary_data_store_with_data.get_data(
             identifier="identifier", selectors=["INVALID"], list_item_id=None
         )

--- a/tests/app/submitter/conftest.py
+++ b/tests/app/submitter/conftest.py
@@ -12,6 +12,7 @@ from app.data_models import QuestionnaireStore
 from app.data_models.answer import Answer
 from app.data_models.answer_store import AnswerStore
 from app.data_models.metadata_proxy import MetadataProxy
+from app.data_models.supplementary_data_store import SupplementaryDataStore
 from app.questionnaire.questionnaire_schema import QuestionnaireSchema
 from app.settings import ACCOUNT_SERVICE_BASE_URL_SOCIAL
 from app.submitter import RabbitMQSubmitter
@@ -86,6 +87,7 @@ def get_questionnaire_store(version):
     store = QuestionnaireStore(storage)
 
     store.answer_store = AnswerStore()
+    store.supplementary_data_store = SupplementaryDataStore()
     store.answer_store.add_or_update(user_answer)
     store.metadata = METADATA_V2 if version is AuthPayloadVersion.V2 else METADATA_V1
     store.response_metadata = {"started_at": "2018-07-04T14:49:33.448608+00:00"}

--- a/tests/app/submitter/test_convert_payload_0_0_1.py
+++ b/tests/app/submitter/test_convert_payload_0_0_1.py
@@ -99,6 +99,7 @@ def test_answer_with_zero(version):
         questionnaire_store.metadata,
         questionnaire_store.response_metadata,
         questionnaire_store.progress_store,
+        questionnaire_store.supplementary_data_store,
     )
 
     assert data_payload["003"] == "0"
@@ -138,6 +139,7 @@ def test_answer_with_float(version):
         questionnaire_store.metadata,
         questionnaire_store.response_metadata,
         questionnaire_store.progress_store,
+        questionnaire_store.supplementary_data_store,
     )
 
     # Check the converter correctly
@@ -180,6 +182,7 @@ def test_answer_with_string(version):
         questionnaire_store.metadata,
         questionnaire_store.response_metadata,
         questionnaire_store.progress_store,
+        questionnaire_store.supplementary_data_store,
     )
 
     # Check the converter correctly
@@ -222,6 +225,7 @@ def test_answer_without_qcode(version):
         questionnaire_store.metadata,
         questionnaire_store.response_metadata,
         questionnaire_store.progress_store,
+        questionnaire_store.supplementary_data_store,
     )
 
     assert not data_payload
@@ -289,6 +293,7 @@ def test_converter_checkboxes_with_q_codes(version):
         questionnaire_store.metadata,
         questionnaire_store.response_metadata,
         questionnaire_store.progress_store,
+        questionnaire_store.supplementary_data_store,
     )
 
     # Then
@@ -368,6 +373,7 @@ def test_converter_checkboxes_with_q_codes_and_other_value(
         questionnaire_store.metadata,
         questionnaire_store.response_metadata,
         questionnaire_store.progress_store,
+        questionnaire_store.supplementary_data_store,
     )
 
     # Then
@@ -445,6 +451,7 @@ def test_converter_checkboxes_with_missing_detail_answer_value_in_answer_store(v
         questionnaire_store.metadata,
         questionnaire_store.response_metadata,
         questionnaire_store.progress_store,
+        questionnaire_store.supplementary_data_store,
     )
 
     # Then
@@ -517,6 +524,7 @@ def test_converter_checkboxes_with_missing_q_codes_uses_answer_q_code(version):
         questionnaire_store.metadata,
         questionnaire_store.response_metadata,
         questionnaire_store.progress_store,
+        questionnaire_store.supplementary_data_store,
     )
 
     # Then
@@ -571,6 +579,7 @@ def test_converter_q_codes_for_empty_strings(version):
         questionnaire_store.metadata,
         questionnaire_store.response_metadata,
         questionnaire_store.progress_store,
+        questionnaire_store.supplementary_data_store,
     )
 
     # Then
@@ -639,6 +648,7 @@ def test_radio_answer(version):
         questionnaire_store.metadata,
         questionnaire_store.response_metadata,
         questionnaire_store.progress_store,
+        questionnaire_store.supplementary_data_store,
     )
 
     # Then
@@ -685,6 +695,7 @@ def test_number_answer(version):
         questionnaire_store.metadata,
         questionnaire_store.response_metadata,
         questionnaire_store.progress_store,
+        questionnaire_store.supplementary_data_store,
     )
 
     # Then
@@ -730,6 +741,7 @@ def test_percentage_answer(version):
         questionnaire_store.metadata,
         questionnaire_store.response_metadata,
         questionnaire_store.progress_store,
+        questionnaire_store.supplementary_data_store,
     )
 
     # Then
@@ -775,6 +787,7 @@ def test_textarea_answer(version):
         questionnaire_store.metadata,
         questionnaire_store.response_metadata,
         questionnaire_store.progress_store,
+        questionnaire_store.supplementary_data_store,
     )
 
     # Then
@@ -820,6 +833,7 @@ def test_currency_answer(version):
         questionnaire_store.metadata,
         questionnaire_store.response_metadata,
         questionnaire_store.progress_store,
+        questionnaire_store.supplementary_data_store,
     )
 
     # Then
@@ -876,6 +890,7 @@ def test_dropdown_answer(version):
         questionnaire_store.metadata,
         questionnaire_store.response_metadata,
         questionnaire_store.progress_store,
+        questionnaire_store.supplementary_data_store,
     )
 
     # Then
@@ -928,6 +943,7 @@ def test_date_answer(version):
         questionnaire_store.metadata,
         questionnaire_store.response_metadata,
         questionnaire_store.progress_store,
+        questionnaire_store.supplementary_data_store,
     )
 
     # Then
@@ -974,6 +990,7 @@ def test_unit_answer(version):
         questionnaire_store.metadata,
         questionnaire_store.response_metadata,
         questionnaire_store.progress_store,
+        questionnaire_store.supplementary_data_store,
     )
 
     # Then

--- a/tests/app/submitter/test_convert_payload_0_0_3.py
+++ b/tests/app/submitter/test_convert_payload_0_0_3.py
@@ -7,6 +7,7 @@ from app.authentication.auth_payload_versions import AuthPayloadVersion
 from app.data_models.answer import Answer
 from app.data_models.answer_store import AnswerStore
 from app.data_models.list_store import ListStore
+from app.data_models.supplementary_data_store import SupplementaryDataStore
 from app.questionnaire.questionnaire_schema import QuestionnaireSchema
 from app.questionnaire.routing_path import RoutingPath
 from app.submitter.converter_v2 import get_payload_data
@@ -90,6 +91,7 @@ def test_convert_answers_v2_to_payload_0_0_3(version):
         questionnaire_store.metadata,
         questionnaire_store.response_metadata,
         questionnaire_store.progress_store,
+        questionnaire_store.supplementary_data_store,
     )
 
     # Then
@@ -147,6 +149,7 @@ def test_convert_payload_0_0_3_multiple_answers(version):
         questionnaire_store.metadata,
         questionnaire_store.response_metadata,
         questionnaire_store.progress_store,
+        questionnaire_store.supplementary_data_store,
     )
 
     # Then
@@ -199,6 +202,7 @@ def test_radio_answer(version):
         questionnaire_store.metadata,
         questionnaire_store.response_metadata,
         questionnaire_store.progress_store,
+        questionnaire_store.supplementary_data_store,
     )
 
     assert len(data_payload["answers"]) == 1
@@ -241,6 +245,7 @@ def test_number_answer(version):
         questionnaire_store.metadata,
         questionnaire_store.response_metadata,
         questionnaire_store.progress_store,
+        questionnaire_store.supplementary_data_store,
     )
 
     assert len(data_payload["answers"]) == 1
@@ -283,6 +288,7 @@ def test_percentage_answer(version):
         questionnaire_store.metadata,
         questionnaire_store.response_metadata,
         questionnaire_store.progress_store,
+        questionnaire_store.supplementary_data_store,
     )
 
     assert len(data_payload["answers"]) == 1
@@ -327,6 +333,7 @@ def test_textarea_answer(version):
         questionnaire_store.metadata,
         questionnaire_store.response_metadata,
         questionnaire_store.progress_store,
+        questionnaire_store.supplementary_data_store,
     )
 
     assert len(data_payload["answers"]) == 1
@@ -369,6 +376,7 @@ def test_currency_answer(version):
         questionnaire_store.metadata,
         questionnaire_store.response_metadata,
         questionnaire_store.progress_store,
+        questionnaire_store.supplementary_data_store,
     )
 
     assert len(data_payload["answers"]) == 1
@@ -421,6 +429,7 @@ def test_dropdown_answer(version):
         questionnaire_store.metadata,
         questionnaire_store.response_metadata,
         questionnaire_store.progress_store,
+        questionnaire_store.supplementary_data_store,
     )
 
     # Then
@@ -469,6 +478,7 @@ def test_date_answer(version):
         questionnaire_store.metadata,
         questionnaire_store.response_metadata,
         questionnaire_store.progress_store,
+        questionnaire_store.supplementary_data_store,
     )
 
     assert len(data_payload["answers"]) == 1
@@ -517,6 +527,7 @@ def test_month_year_date_answer(version):
         questionnaire_store.metadata,
         questionnaire_store.response_metadata,
         questionnaire_store.progress_store,
+        questionnaire_store.supplementary_data_store,
     )
 
     assert len(data_payload["answers"]) == 1
@@ -560,6 +571,7 @@ def test_unit_answer(version):
         questionnaire_store.metadata,
         questionnaire_store.response_metadata,
         questionnaire_store.progress_store,
+        questionnaire_store.supplementary_data_store,
     )
 
     assert len(data_payload["answers"]) == 1
@@ -616,6 +628,7 @@ def test_primary_person_list_item_conversion(version):
         questionnaire_store.metadata,
         questionnaire_store.response_metadata,
         questionnaire_store.progress_store,
+        questionnaire_store.supplementary_data_store,
     )
 
     data_dict = json_loads(json_dumps(output["answers"]))
@@ -671,6 +684,7 @@ def test_list_item_conversion(version):
         questionnaire_store.metadata,
         questionnaire_store.response_metadata,
         questionnaire_store.progress_store,
+        questionnaire_store.supplementary_data_store,
     )
 
     del answer_objects[-1]
@@ -721,6 +735,7 @@ def test_list_item_conversion_empty_list(version):
         questionnaire_store.metadata,
         questionnaire_store.response_metadata,
         questionnaire_store.progress_store,
+        questionnaire_store.supplementary_data_store,
     )
 
     # Answers not on the routing path
@@ -767,6 +782,7 @@ def test_default_answers_not_present_when_not_answered(version):
         questionnaire_store.metadata,
         questionnaire_store.response_metadata,
         questionnaire_store.progress_store,
+        questionnaire_store.supplementary_data_store,
     )
 
     data = json_loads(json_dumps(output["answers"]))
@@ -825,6 +841,7 @@ def test_list_structure_in_payload_is_as_expected(version):
         questionnaire_store.metadata,
         questionnaire_store.response_metadata,
         questionnaire_store.progress_store,
+        questionnaire_store.supplementary_data_store,
     )
 
     data_dict = json_loads(json_dumps(output["lists"]))
@@ -880,6 +897,7 @@ def test_primary_person_not_in_payload_when_not_answered(version):
         questionnaire_store.metadata,
         questionnaire_store.response_metadata,
         questionnaire_store.progress_store,
+        questionnaire_store.supplementary_data_store,
     )
 
     data_dict = json_loads(json_dumps(output["lists"]))
@@ -957,6 +975,7 @@ def test_relationships_in_payload(version):
         questionnaire_store.metadata,
         questionnaire_store.response_metadata,
         questionnaire_store.progress_store,
+        questionnaire_store.supplementary_data_store,
     )
 
     data = json_loads(json_dumps(output["answers"]))
@@ -1034,6 +1053,7 @@ def test_no_relationships_in_payload(version):
         questionnaire_store.metadata,
         questionnaire_store.response_metadata,
         questionnaire_store.progress_store,
+        questionnaire_store.supplementary_data_store,
     )
 
     data = json_loads(json_dumps(output["answers"]))
@@ -1128,6 +1148,7 @@ def test_unrelated_block_answers_in_payload(version):
         questionnaire_store.metadata,
         questionnaire_store.response_metadata,
         questionnaire_store.progress_store,
+        questionnaire_store.supplementary_data_store,
     )
 
     data = json_loads(json_dumps(output["answers"]))
@@ -1239,6 +1260,7 @@ def test_unrelated_block_answers_not_on_path_not_in_payload(version):
         questionnaire_store.metadata,
         questionnaire_store.response_metadata,
         questionnaire_store.progress_store,
+        questionnaire_store.supplementary_data_store,
     )
 
     data = json_loads(json_dumps(output["answers"]))
@@ -1340,6 +1362,7 @@ def test_relationship_answers_not_on_path_in_payload(version):
         questionnaire_store.metadata,
         questionnaire_store.response_metadata,
         questionnaire_store.progress_store,
+        questionnaire_store.supplementary_data_store,
     )
 
     data = json_loads(json_dumps(output["answers"]))
@@ -1405,6 +1428,7 @@ def test_answers_codes_only_present_for_answered_questions(version):
         questionnaire_store.metadata,
         questionnaire_store.response_metadata,
         questionnaire_store.progress_store,
+        questionnaire_store.supplementary_data_store,
     )
 
     # Then
@@ -1443,6 +1467,7 @@ def test_all_answers_codes_for_answer_options_in_payload_when_one_is_answered(ve
         questionnaire_store.metadata,
         questionnaire_store.response_metadata,
         questionnaire_store.progress_store,
+        questionnaire_store.supplementary_data_store,
     )
 
     # Then
@@ -1479,6 +1504,7 @@ def test_no_answers_codes_in_payload_when_no_questions_answered(version):
         questionnaire_store.metadata,
         questionnaire_store.response_metadata,
         questionnaire_store.progress_store,
+        questionnaire_store.supplementary_data_store,
     )
 
     # Then
@@ -1524,6 +1550,7 @@ def test_payload_dynamic_answers(version):
         questionnaire_store.metadata,
         questionnaire_store.response_metadata,
         questionnaire_store.progress_store,
+        questionnaire_store.supplementary_data_store,
     )
 
     # Then

--- a/tests/integration/routes/test_session.py
+++ b/tests/integration/routes/test_session.py
@@ -91,7 +91,9 @@ class TestSession(IntegrationTestCase):
             self.assertEqual(parsed_json["expires_at"], expected_expires_at)
 
     def test_supplementary_data_is_loaded_when_sds_dataset_id_in_metadata(self):
-        with patch("app.routes.session.get_supplementary_data", return_value={}):
+        with patch(
+            "app.routes.session.get_supplementary_data", return_value={"data": {}}
+        ):
             self.launchSupplementaryDataSurvey()
             self.assertStatusOK()
 


### PR DESCRIPTION
### What is the context of this PR?
This PR implements the creation of the new supplementary data store and the loading of sds data into that store whenever a new questionnaire session is launched (and any existing supplementary dataset id doesn't match)

It handles removing old supplementary data if the new data is different (or there is no new data) and creating or updating the list store for any supplementary data lists.

This is part of the **Loading of supplementary data** card and implements the functionality, along with a simple test for the store, but no other testing yet.

### Implementation decisions
The supplementary data, ideally will be fetched in `session.py` however this needs to happen between the store being created/fetched from storage and the metadata for it being overridden, which all happens in the authenticator. Since it needs the metadata from the login function, a context seemed like the way to go

### How to review
Read through the trello card to understand the requirements and check that the structure of the supplementary data store and how it will be interacted with is suitable 

### How to test functionally
Following the guidance in run-mock-sds-endpoint.md start the mock sds api and pick the `test_supplementary_data` schema. 

1. Save the generated response id somewhere
2. Use the second dataset id from the read-me for the sds dataset id (that one has lists)
3. put a breakpoint on the final line of the login endpoint in `session.py`
4. On opening the survey and hitting that breakpoint, the newly created questionnaire store should have the correct supplementary data, and the list store should also contain the "products" list
5. Using another breakpoint on the first line of `_set_questionnaire_supplementary_data` if you relaunch the survey, with the same response id as before, but using the other supplementary dataset id
    * at first breakpoint the questionnaire store from before is loaded, so will have the old supplementary data, and a list store with "products"
    * on hitting the second breakpoint, the update will be complete, the list store will be empty, and the supplementary data will match that of `supplementary_data_no_repeat.json`
6. Use a break point on `return data` in `converter_v2.py` to check that the supplementary data and list mappings are included correctly.

### Whats next
Tests to cover supplementary data being added, removed, updated on session start. 
Tests for the data being send downstream
Tests to cover a list collector using the supplementary data, and removal of answers from the answer store when supplementary data is removed/updated
