### PR TITLE
Fix `mass-metric-ton` units handling

### DIFF
--- a/app/jinja_filters.py
+++ b/app/jinja_filters.py
@@ -76,8 +76,8 @@ def format_unit(
     length: UnitLengthType = "short",
 ) -> str:
     # mass-metric-ton no longer supported for en_GB and related locales, but still present in business schema and allowed in validator,
-    # until removed from schema we substitute mass-ton for mass-metric-ton and vice versa, before/after unit formatting
-    measurement_unit = "mass-ton" if unit == "mass-metric-ton" else unit
+    # until removed from schema we substitute mass-tonne for mass-metric-ton before format unit
+    measurement_unit = "mass-tonne" if unit == "mass-metric-ton" else unit
 
     formatted_unit: str = units.format_unit(
         value=value,
@@ -85,8 +85,7 @@ def format_unit(
         length=length,
         locale=flask_babel.get_locale(),
     )
-    if unit == "mass-metric-ton":
-        return formatted_unit.replace("tn", "mt").replace("ton", "metric ton")
+
     return formatted_unit
 
 
@@ -100,8 +99,8 @@ def format_unit_input_label(unit: str, unit_length: UnitLengthType = "short") ->
     """
     unit_label: str
     # mass-metric-ton no longer supported for en_GB and related locales, but still present in business schema and allowed in validator,
-    # until removed from schema we substitute mass-ton for mass-metric-ton and vice versa, before/after unit formatting
-    measurement_unit = "mass-ton" if unit == "mass-metric-ton" else unit
+    # until removed from schema we substitute mass-tonne for mass-metric-ton before format unit
+    measurement_unit = "mass-tonne" if unit == "mass-metric-ton" else unit
 
     if unit_length == "long":
         unit_label = units.format_unit(
@@ -118,9 +117,6 @@ def format_unit_input_label(unit: str, unit_length: UnitLengthType = "short") ->
             length=unit_length,
             locale=flask_babel.get_locale(),
         ).strip()
-
-    if unit == "mass-metric-ton":
-        unit_label = unit_label.replace("tn", "mt").replace("ton", "metric ton")
 
     return unit_label
 

--- a/app/jinja_filters.py
+++ b/app/jinja_filters.py
@@ -76,7 +76,7 @@ def format_unit(
     length: UnitLengthType = "short",
 ) -> str:
     # mass-metric-ton no longer supported for en_GB and related locales, but still present in business schema and allowed in validator,
-    # until removed from schema we substitute mass-ton for mass-metric-ton and vice versa before/after unit formatting
+    # until removed from schema we substitute mass-ton for mass-metric-ton and vice versa, before/after unit formatting
     measurement_unit = "mass-ton" if unit == "mass-metric-ton" else unit
 
     formatted_unit: str = units.format_unit(
@@ -100,7 +100,7 @@ def format_unit_input_label(unit: str, unit_length: UnitLengthType = "short") ->
     """
     unit_label: str
     # mass-metric-ton no longer supported for en_GB and related locales, but still present in business schema and allowed in validator,
-    # until removed from schema we substitute mass-ton for mass-metric-ton and vice versa before/after unit formatting
+    # until removed from schema we substitute mass-ton for mass-metric-ton and vice versa, before/after unit formatting
     measurement_unit = "mass-ton" if unit == "mass-metric-ton" else unit
 
     if unit_length == "long":

--- a/app/jinja_filters.py
+++ b/app/jinja_filters.py
@@ -98,9 +98,6 @@ def format_unit_input_label(unit: str, unit_length: UnitLengthType = "short") ->
     :param (str) unit_length length of unit text, can be one of short/long/narrow
     """
     unit_label: str
-    # mass-metric-ton no longer supported for en_GB and related locales, but still present in business schema and allowed in validator,
-    # until removed from schema we substitute mass-tonne for mass-metric-ton before format unit
-    unit = "mass-tonne" if unit == "mass-metric-ton" else unit
 
     if unit_length == "long":
         unit_label = format_unit(value=2, unit=unit, length=unit_length).replace(

--- a/app/jinja_filters.py
+++ b/app/jinja_filters.py
@@ -76,7 +76,7 @@ def format_unit(
     length: UnitLengthType = "short",
 ) -> str:
     # mass-metric-ton no longer supported for en_GB and related locales, but still present in business schema and allowed in validator,
-    # until removed from schema we substitute mass-ton for mass-metric-ton and vice versa
+    # until removed from schema we substitute mass-ton for mass-metric-ton and vice versa before/after unit formatting
     measurement_unit = "mass-ton" if unit == "mass-metric-ton" else unit
 
     formatted_unit: str = units.format_unit(
@@ -100,7 +100,7 @@ def format_unit_input_label(unit: str, unit_length: UnitLengthType = "short") ->
     """
     unit_label: str
     # mass-metric-ton no longer supported for en_GB and related locales, but still present in business schema and allowed in validator,
-    # until removed from schema we substitute mass-ton for mass-metric-ton and vice versa
+    # until removed from schema we substitute mass-ton for mass-metric-ton and vice versa before/after unit formatting
     measurement_unit = "mass-ton" if unit == "mass-metric-ton" else unit
 
     if unit_length == "long":

--- a/app/jinja_filters.py
+++ b/app/jinja_filters.py
@@ -100,22 +100,16 @@ def format_unit_input_label(unit: str, unit_length: UnitLengthType = "short") ->
     unit_label: str
     # mass-metric-ton no longer supported for en_GB and related locales, but still present in business schema and allowed in validator,
     # until removed from schema we substitute mass-tonne for mass-metric-ton before format unit
-    measurement_unit = "mass-tonne" if unit == "mass-metric-ton" else unit
+    unit = "mass-tonne" if unit == "mass-metric-ton" else unit
 
     if unit_length == "long":
-        unit_label = units.format_unit(
-            value=2,
-            measurement_unit=measurement_unit,
-            length=unit_length,
-            locale=flask_babel.get_locale(),
-        ).replace("2 ", "")
+        unit_label = format_unit(value=2, unit=unit, length=unit_length).replace(
+            "2 ", ""
+        )
     else:
         # Type ignore: We pass an empty string  as the value so that we just return the unit label
-        unit_label = units.format_unit(
-            value="",  # type: ignore
-            measurement_unit=measurement_unit,
-            length=unit_length,
-            locale=flask_babel.get_locale(),
+        unit_label = format_unit(
+            value="", unit=unit, length=unit_length  # type: ignore
         ).strip()
 
     return unit_label

--- a/app/jinja_filters.py
+++ b/app/jinja_filters.py
@@ -75,12 +75,18 @@ def format_unit(
     value: int | float | Decimal,
     length: UnitLengthType = "short",
 ) -> str:
+    # mass-metric-ton no longer supported for en_GB and related locales, but still present in business schema and allowed in validator,
+    # until removed from schema we substitute mass-ton for mass-metric-ton and vice versa
+    measurement_unit = "mass-ton" if unit == "mass-metric-ton" else unit
+
     formatted_unit: str = units.format_unit(
         value=value,
-        measurement_unit=unit,
+        measurement_unit=measurement_unit,
         length=length,
         locale=flask_babel.get_locale(),
     )
+    if unit == "mass-metric-ton":
+        return formatted_unit.replace("tn", "mt").replace("ton", "metric ton")
     return formatted_unit
 
 
@@ -93,10 +99,14 @@ def format_unit_input_label(unit: str, unit_length: UnitLengthType = "short") ->
     :param (str) unit_length length of unit text, can be one of short/long/narrow
     """
     unit_label: str
+    # mass-metric-ton no longer supported for en_GB and related locales, but still present in business schema and allowed in validator,
+    # until removed from schema we substitute mass-ton for mass-metric-ton and vice versa
+    measurement_unit = "mass-ton" if unit == "mass-metric-ton" else unit
+
     if unit_length == "long":
         unit_label = units.format_unit(
             value=2,
-            measurement_unit=unit,
+            measurement_unit=measurement_unit,
             length=unit_length,
             locale=flask_babel.get_locale(),
         ).replace("2 ", "")
@@ -104,10 +114,13 @@ def format_unit_input_label(unit: str, unit_length: UnitLengthType = "short") ->
         # Type ignore: We pass an empty string  as the value so that we just return the unit label
         unit_label = units.format_unit(
             value="",  # type: ignore
-            measurement_unit=unit,
+            measurement_unit=measurement_unit,
             length=unit_length,
             locale=flask_babel.get_locale(),
         ).strip()
+
+    if unit == "mass-metric-ton":
+        unit_label = unit_label.replace("tn", "mt").replace("ton", "metric ton")
 
     return unit_label
 

--- a/tests/app/test_jinja_filters.py
+++ b/tests/app/test_jinja_filters.py
@@ -153,9 +153,9 @@ def test_format_percentage(percentage, formatted_percentage):
         ("duration-year", 100, "short", "100 bl", "cy"),
         ("duration-hour", 100, "long", "100 awr", "cy"),
         ("duration-year", 100, "long", "100 mlynedd", "cy"),
-        ("mass-metric-ton", 100, "long", "100 metric tons", "en_GB"),
-        ("mass-metric-ton", 1, "long", "1 metric ton", "en_GB"),
-        ("mass-metric-ton", 100, "short", "100 mt", "en_GB"),
+        ("mass-metric-ton", 100, "long", "100 tonnes", "en_GB"),
+        ("mass-metric-ton", 1, "long", "1 tonne", "en_GB"),
+        ("mass-metric-ton", 100, "short", "100 t", "en_GB"),
     ),
 )
 def test_format_unit(unit, value, length, formatted_unit, language, mocker):
@@ -207,8 +207,8 @@ def test_format_unit(unit, value, length, formatted_unit, language, mocker):
         ("duration-hour", "long", "awr", "cy"),
         ("duration-year", "short", "bl", "cy"),
         ("duration-year", "long", "flynedd", "cy"),
-        ("mass-metric-ton", "long", "metric tons", "en_GB"),
-        ("mass-metric-ton", "short", "mt", "en_GB"),
+        ("mass-metric-ton", "long", "tonnes", "en_GB"),
+        ("mass-metric-ton", "short", "t", "en_GB"),
     ),
 )
 def test_format_unit_input_label(unit, length, formatted_unit, language, mocker):

--- a/tests/app/test_jinja_filters.py
+++ b/tests/app/test_jinja_filters.py
@@ -153,6 +153,9 @@ def test_format_percentage(percentage, formatted_percentage):
         ("duration-year", 100, "short", "100 bl", "cy"),
         ("duration-hour", 100, "long", "100 awr", "cy"),
         ("duration-year", 100, "long", "100 mlynedd", "cy"),
+        ("mass-metric-ton", 100, "long", "100 metric tons", "en_GB"),
+        ("mass-metric-ton", 1, "long", "1 metric ton", "en_GB"),
+        ("mass-metric-ton", 100, "short", "100 mt", "en_GB"),
     ),
 )
 def test_format_unit(unit, value, length, formatted_unit, language, mocker):
@@ -204,6 +207,8 @@ def test_format_unit(unit, value, length, formatted_unit, language, mocker):
         ("duration-hour", "long", "awr", "cy"),
         ("duration-year", "short", "bl", "cy"),
         ("duration-year", "long", "flynedd", "cy"),
+        ("mass-metric-ton", "long", "metric tons", "en_GB"),
+        ("mass-metric-ton", "short", "mt", "en_GB"),
     ),
 )
 def test_format_unit_input_label(unit, length, formatted_unit, language, mocker):


### PR DESCRIPTION
### What is the context of this PR?
`mass-metric-ton` is no longer supported for `en_GB` and related locales, but still present in business schema and allowed in validator. Until removed from schema and validator definitions we want to substitute `mass-ton` for `mass-metric-ton` and vice versa, before and after unit formatting.

### How to review
New test cases in existing unit tests.

### Checklist
* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
