### PR TITLE
Remove update_section_completeness call in list actions

### DIFF
--- a/app/views/handlers/list_action.py
+++ b/app/views/handlers/list_action.py
@@ -84,7 +84,6 @@ class ListAction(Question):
                 self.current_location.section_id, self.current_location.list_item_id
             )
             self.questionnaire_store_updater.remove_dependent_blocks_and_capture_dependent_sections()
-            self._update_section_completeness()
             self.questionnaire_store_updater.update_progress_for_dependent_sections()
             self.questionnaire_store_updater.save()
 

--- a/app/views/handlers/list_repeating_question.py
+++ b/app/views/handlers/list_repeating_question.py
@@ -47,12 +47,5 @@ class ListRepeatingQuestion(ListAction):
                 list_item_id=self.current_location.list_item_id,
             )
 
-        # Cannot invoke parent handle_post as that would invoke self.update_section_completeness which overwrites the progress update done here
         self.questionnaire_store_updater.update_answers(self.form.data)
-        if self.questionnaire_store_updater.is_dirty():
-            self._routing_path = self.router.routing_path(
-                self.current_location.section_id, self.current_location.list_item_id
-            )
-            self.questionnaire_store_updater.remove_dependent_blocks_and_capture_dependent_sections()
-            self.questionnaire_store_updater.update_progress_for_dependent_sections()
-            self.questionnaire_store_updater.save()
+        super().handle_post()


### PR DESCRIPTION
### What is the context of this PR?
This removes `update_section_completeness` call that adds list items progress for child blocks which wasn't done in the past and wasn't required for looping 3.5. The only time childs are used is for repeating blocks.

### How to review
Check that all tests still pass.

### Checklist
* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
