### PR TITLE
Bug Fix: None language code defaults to "en"

### DIFF
--- a/app/routes/session.py
+++ b/app/routes/session.py
@@ -23,6 +23,7 @@ from app.helpers.template_helpers import (
 )
 from app.questionnaire import QuestionnaireSchema
 from app.routes.errors import _render_error_page
+from app.settings import DEFAULT_LOCALE
 from app.utilities.metadata_parser import validate_runner_claims
 from app.utilities.metadata_parser_v2 import (
     validate_questionnaire_claims,
@@ -126,7 +127,7 @@ def login() -> Response:
             "account_service_log_out_url"
         )
 
-    cookie_session["language_code"] = metadata.language_code
+    cookie_session["language_code"] = metadata.language_code or DEFAULT_LOCALE
 
     return redirect(url_for("questionnaire.get_questionnaire"))
 

--- a/app/routes/session.py
+++ b/app/routes/session.py
@@ -22,8 +22,8 @@ from app.helpers.template_helpers import (
     render_template,
 )
 from app.questionnaire import QuestionnaireSchema
+from app.questionnaire.questionnaire_schema import DEFAULT_LANGUAGE_CODE
 from app.routes.errors import _render_error_page
-from app.settings import DEFAULT_LOCALE
 from app.utilities.metadata_parser import validate_runner_claims
 from app.utilities.metadata_parser_v2 import (
     validate_questionnaire_claims,
@@ -127,7 +127,7 @@ def login() -> Response:
             "account_service_log_out_url"
         )
 
-    cookie_session["language_code"] = metadata.language_code or DEFAULT_LOCALE
+    cookie_session["language_code"] = metadata.language_code or DEFAULT_LANGUAGE_CODE
 
     return redirect(url_for("questionnaire.get_questionnaire"))
 

--- a/tests/integration/create_token.py
+++ b/tests/integration/create_token.py
@@ -163,5 +163,18 @@ class TokenGenerator:
 
         return self.generate_token(payload_vars)
 
+    def create_token_v2_with_none_language_code(
+        self, schema_name, theme="default", **extra_payload
+    ):
+        payload_for_theme = (
+            PAYLOAD_V2_SOCIAL if theme == "social" else PAYLOAD_V2_BUSINESS
+        )
+        payload_vars = self._get_payload_with_params(
+            schema_name=schema_name, payload=payload_for_theme, **extra_payload
+        )
+        del payload_vars["language_code"]
+
+        return self.generate_token(payload_vars)
+
     def generate_token(self, payload):
         return encrypt(payload, self._key_store, KEY_PURPOSE_AUTHENTICATION)

--- a/tests/integration/create_token.py
+++ b/tests/integration/create_token.py
@@ -163,14 +163,9 @@ class TokenGenerator:
 
         return self.generate_token(payload_vars)
 
-    def create_token_v2_with_none_language_code(
-        self, schema_name, theme="default", **extra_payload
-    ):
-        payload_for_theme = (
-            PAYLOAD_V2_SOCIAL if theme == "social" else PAYLOAD_V2_BUSINESS
-        )
+    def create_token_with_none_language_code(self, schema_name, **extra_payload):
         payload_vars = self._get_payload_with_params(
-            schema_name=schema_name, payload=payload_for_theme, **extra_payload
+            schema_name=schema_name, **extra_payload
         )
         del payload_vars["language_code"]
 

--- a/tests/integration/questionnaire/test_questionnaire_locale.py
+++ b/tests/integration/questionnaire/test_questionnaire_locale.py
@@ -4,7 +4,7 @@ from tests.integration.integration_test_case import IntegrationTestCase
 class TestSession(IntegrationTestCase):
     def test_none_language_code_defaults_to_en(self):
         # Given a questionnaire with an answer of type mass-metric-tonnes launches with no language code in the runner claims
-        token = self.token_generator.create_token_v2_with_none_language_code(
+        token = self.token_generator.create_token_with_none_language_code(
             "test_unit_patterns"
         )
         self.get(url=f"/session?token={token}")

--- a/tests/integration/questionnaire/test_questionnaire_locale.py
+++ b/tests/integration/questionnaire/test_questionnaire_locale.py
@@ -2,7 +2,7 @@ from tests.integration.integration_test_case import IntegrationTestCase
 
 
 class TestSession(IntegrationTestCase):
-    def test_none_language_code_defaults_to_en_GB(self):
+    def test_none_language_code_defaults_to_en(self):
         # Given a questionnaire with an answer of type mass-metric-tonnes launches with no language code in the runner claims
         token = self.token_generator.create_token_v2_with_none_language_code(
             "test_unit_patterns"
@@ -15,7 +15,7 @@ class TestSession(IntegrationTestCase):
         self.post()
         self.post()
 
-        # Then the cookie_session[language_code] will have defaulted to DEFAULT_LOCALE (en_GB), and the tooltip will show "tonnes" not "metric tons"
+        # Then the cookie_session[language_code] will have defaulted to DEFAULT_LANGUAGE_CODE (en), and the tooltip will show "tonnes" not "metric tons"
         self.assertInBody("Weight Units")
         self.assertInSelector("tonnes", "[id='mass-metric-ton-type']")
         self.assertNotInSelector("metric tons", "[id='mass-metric-ton-type']")

--- a/tests/integration/questionnaire/test_questionnaire_locale.py
+++ b/tests/integration/questionnaire/test_questionnaire_locale.py
@@ -1,0 +1,21 @@
+from tests.integration.integration_test_case import IntegrationTestCase
+
+
+class TestSession(IntegrationTestCase):
+    def test_none_language_code_defaults_to_en_GB(self):
+        # Given a questionnaire with an answer of type mass-metric-tonnes launches with no language code in the runner claims
+        token = self.token_generator.create_token_v2_with_none_language_code(
+            "test_unit_patterns"
+        )
+        self.get(url=f"/session?token={token}")
+
+        # Skip to the mass-metric-tonnes answer
+        self.post()
+        self.post()
+        self.post()
+        self.post()
+
+        # Then the cookie_session[language_code] will have defaulted to DEFAULT_LOCALE (en_GB), and the tooltip will show "tonnes" not "metric tons"
+        self.assertInBody("Weight Units")
+        self.assertInSelector("tonnes", "[id='mass-metric-ton-type']")
+        self.assertNotInSelector("metric tons", "[id='mass-metric-ton-type']")


### PR DESCRIPTION
### What is the context of this PR?
This PR implements a fix for answer type `mass-metric-tonnes` displaying the tooltip of "metric tons" when it should be "tonnes" regardless of whether the language being set is "en" or "en_GB". 
A fix was implemented in a previous PR to ensure `get_locale` returns "en_GB" instead of "en" when "en" is set as the `language_code`. This however assumed there would always be a `language_code` set, if `None` is provided as the `language_code`, `get_locale` will return "en".
This PR fixes this issue by ensuring `None` `language_code` defaults to `DEFAULT_LANGUAGE_CODE` (en).

### Changes
**session.py**: `cookie_session["language_code"]` defaults to `DEFAULT_LANGUAGE_CODE` if `metadata.language_code` is `None`.

**create_token.py**: New integration test helper method `create_token_v2_with_none_language_code` which takes a schema name and theme, creates the relevant default runner claims, deletes the language code and returns a generated token. 

**test_questionnaire_locale**: New integration test class which has a new test to open a new `test_unit_patterns` survey without a language code in the claims and asserting that the `mass-metric-tonnes` answer tooltip shows "tonnes" and not "metric tons", indicating that a missing language code defaults to "en". 

### How to review
Select either survey `qfs_0002` or `test_unit_patterns` in launcher, and set language to "not set"
Navigate to the answer with type `mass-metric-tonnes`.
Hover over the tooltip and ensure it displays "tonnes", not "mass-metric-tons". 

The new integration test passes, as do all other existing tests. 
