### PR TITLE
Use identifier rather than unit_id for supplementary data

### DIFF
--- a/app/routes/session.py
+++ b/app/routes/session.py
@@ -160,7 +160,7 @@ def _set_questionnaire_supplementary_data(
     supplementary_data = get_supplementary_data(
         # Type ignore: survey_id and either ru_ref or qid are required for schemas that use supplementary data
         dataset_id=new_sds_dataset_id,
-        unit_id=metadata["ru_ref"] or metadata["qid"],  # type: ignore
+        identifier=metadata["ru_ref"] or metadata["qid"],  # type: ignore
         survey_id=metadata["survey_id"],  # type: ignore
     )
     logger.info(

--- a/app/services/supplementary_data.py
+++ b/app/services/supplementary_data.py
@@ -41,7 +41,7 @@ class InvalidSupplementaryData(Exception):
     pass
 
 
-def get_supplementary_data(*, dataset_id: str, unit_id: str, survey_id: str) -> dict:
+def get_supplementary_data(*, dataset_id: str, identifier: str, survey_id: str) -> dict:
     # Type ignore: current_app is a singleton in this application and has the key_store key in its eq attribute.
     key_store = current_app.eq["key_store"]  # type: ignore
     if not key_store.get_key(purpose=KEY_PURPOSE_SDS, key_type="private"):
@@ -49,7 +49,7 @@ def get_supplementary_data(*, dataset_id: str, unit_id: str, survey_id: str) -> 
 
     supplementary_data_url = current_app.config["SDS_API_BASE_URL"]
 
-    parameters = {"dataset_id": dataset_id, "unit_id": unit_id}
+    parameters = {"dataset_id": dataset_id, "identifier": identifier}
 
     encoded_parameters = urlencode(parameters)
     constructed_supplementary_data_url = (
@@ -84,7 +84,7 @@ def get_supplementary_data(*, dataset_id: str, unit_id: str, survey_id: str) -> 
         return validate_supplementary_data(
             supplementary_data=supplementary_data,
             dataset_id=dataset_id,
-            unit_id=unit_id,
+            identifier=identifier,
             survey_id=survey_id,
         )
 
@@ -114,13 +114,13 @@ def decrypt_supplementary_data(
 
 
 def validate_supplementary_data(
-    supplementary_data: Mapping, dataset_id: str, unit_id: str, survey_id: str
+    supplementary_data: Mapping, dataset_id: str, identifier: str, survey_id: str
 ) -> dict:
     try:
         return validate_supplementary_data_v1(
             supplementary_data=supplementary_data,
             dataset_id=dataset_id,
-            unit_id=unit_id,
+            identifier=identifier,
             survey_id=survey_id,
         )
     except ValidationError as e:

--- a/app/utilities/supplementary_data_parser.py
+++ b/app/utilities/supplementary_data_parser.py
@@ -33,7 +33,7 @@ class SupplementaryData(Schema, StripWhitespaceMixin):
         # pylint: disable=no-self-use, unused-argument
         if data and data["identifier"] != self.context["identifier"]:
             raise ValidationError(
-                "Supplementary data did not return the specified Unit ID"
+                "Supplementary data did not return the specified Identifier"
             )
 
 

--- a/app/utilities/supplementary_data_parser.py
+++ b/app/utilities/supplementary_data_parser.py
@@ -29,9 +29,9 @@ class SupplementaryData(Schema, StripWhitespaceMixin):
     items = fields.Nested(ItemsData, required=False, unknown=INCLUDE)
 
     @validates_schema()
-    def validate_unit_id(self, data, **kwargs):
+    def validate_identifier(self, data, **kwargs):
         # pylint: disable=no-self-use, unused-argument
-        if data and data["identifier"] != self.context["unit_id"]:
+        if data and data["identifier"] != self.context["identifier"]:
             raise ValidationError(
                 "Supplementary data did not return the specified Unit ID"
             )
@@ -65,7 +65,7 @@ class SupplementaryDataMetadataSchema(Schema, StripWhitespaceMixin):
 def validate_supplementary_data_v1(
     supplementary_data: Mapping,
     dataset_id: str,
-    unit_id: str,
+    identifier: str,
     survey_id: str,
 ) -> dict:
     """Validate claims required for supplementary data"""
@@ -74,7 +74,7 @@ def validate_supplementary_data_v1(
     )
     supplementary_data_metadata_schema.context = {
         "dataset_id": dataset_id,
-        "unit_id": unit_id,
+        "identifier": identifier,
         "survey_id": survey_id,
     }
     validated_supplementary_data = supplementary_data_metadata_schema.load(

--- a/tests/app/parser/test_supplementary_data_parser.py
+++ b/tests/app/parser/test_supplementary_data_parser.py
@@ -47,7 +47,7 @@ def test_invalid_supplementary_data_payload_raises_error():
         validate_supplementary_data(
             supplementary_data={},
             dataset_id="44f1b432-9421-49e5-bd26-e63e18a30b69",
-            unit_id="12346789012A",
+            identifier="12346789012A",
             survey_id="123",
         )
 
@@ -58,7 +58,7 @@ def test_validate_supplementary_data_payload():
     validated_payload = validate_supplementary_data_v1(
         supplementary_data=SUPPLEMENTARY_DATA_PAYLOAD,
         dataset_id="44f1b432-9421-49e5-bd26-e63e18a30b69",
-        unit_id="12346789012A",
+        identifier="12346789012A",
         survey_id="123",
     )
 
@@ -70,7 +70,7 @@ def test_validate_supplementary_data_payload_incorrect_dataset_id():
         validate_supplementary_data_v1(
             supplementary_data=SUPPLEMENTARY_DATA_PAYLOAD,
             dataset_id="331507ca-1039-4624-a342-7cbc3630e217",
-            unit_id="12346789012A",
+            identifier="12346789012A",
             survey_id="123",
         )
 
@@ -85,7 +85,7 @@ def test_validate_supplementary_data_payload_incorrect_survey_id():
         validate_supplementary_data_v1(
             supplementary_data=SUPPLEMENTARY_DATA_PAYLOAD,
             dataset_id="44f1b432-9421-49e5-bd26-e63e18a30b69",
-            unit_id="12346789012A",
+            identifier="12346789012A",
             survey_id="234",
         )
 
@@ -95,12 +95,12 @@ def test_validate_supplementary_data_payload_incorrect_survey_id():
     )
 
 
-def test_validate_supplementary_data_payload_incorrect_unit_id():
+def test_validate_supplementary_data_payload_incorrect_identifier():
     with pytest.raises(ValidationError) as error:
         validate_supplementary_data_v1(
             supplementary_data=SUPPLEMENTARY_DATA_PAYLOAD,
             dataset_id="44f1b432-9421-49e5-bd26-e63e18a30b69",
-            unit_id="000000000001",
+            identifier="000000000001",
             survey_id="123",
         )
 
@@ -123,7 +123,7 @@ def test_supplementary_data_payload_with_no_items_is_validated():
     validated_payload = validate_supplementary_data_v1(
         supplementary_data=payload,
         dataset_id="44f1b432-9421-49e5-bd26-e63e18a30b69",
-        unit_id="12346789012A",
+        identifier="12346789012A",
         survey_id="123",
     )
 
@@ -143,7 +143,7 @@ def test_validate_supplementary_data_payload_missing_survey_id():
         validate_supplementary_data_v1(
             supplementary_data=payload,
             dataset_id="44f1b432-9421-49e5-bd26-e63e18a30b69",
-            unit_id="12346789012A",
+            identifier="12346789012A",
             survey_id="123",
         )
 
@@ -164,7 +164,7 @@ def test_validate_supplementary_data_payload_with_unknown_field():
     validated_payload = validate_supplementary_data_v1(
         supplementary_data=payload,
         dataset_id="44f1b432-9421-49e5-bd26-e63e18a30b69",
-        unit_id="12346789012A",
+        identifier="12346789012A",
         survey_id="123",
     )
 
@@ -186,7 +186,7 @@ def test_validate_supplementary_data_invalid_schema_version():
         validate_supplementary_data_v1(
             supplementary_data=payload,
             dataset_id="001",
-            unit_id="12346789012A",
+            identifier="12346789012A",
             survey_id="123",
         )
 
@@ -201,7 +201,7 @@ def test_validate_supplementary_data_payload_missing_identifier_in_items():
         validate_supplementary_data_v1(
             supplementary_data=payload,
             dataset_id="44f1b432-9421-49e5-bd26-e63e18a30b69",
-            unit_id="12346789012A",
+            identifier="12346789012A",
             survey_id="123",
         )
 

--- a/tests/app/parser/test_supplementary_data_parser.py
+++ b/tests/app/parser/test_supplementary_data_parser.py
@@ -106,7 +106,7 @@ def test_validate_supplementary_data_payload_incorrect_identifier():
 
     assert (
         str(error.value)
-        == "{'data': {'_schema': ['Supplementary data did not return the specified Unit ID']}}"
+        == "{'data': {'_schema': ['Supplementary data did not return the specified Identifier']}}"
     )
 
 

--- a/tests/app/services/test_request_supplementary_data.py
+++ b/tests/app/services/test_request_supplementary_data.py
@@ -36,7 +36,7 @@ def test_get_supplementary_data_200(
         )
         loaded_supplementary_data = get_supplementary_data(
             dataset_id="44f1b432-9421-49e5-bd26-e63e18a30b69",
-            unit_id="12346789012A",
+            identifier="12346789012A",
             survey_id="123",
         )
 
@@ -64,7 +64,7 @@ def test_get_supplementary_data_non_200(
         with pytest.raises(SupplementaryDataRequestFailed) as exc:
             get_supplementary_data(
                 dataset_id="44f1b432-9421-49e5-bd26-e63e18a30b69",
-                unit_id="12346789012A",
+                identifier="12346789012A",
                 survey_id="123",
             )
 
@@ -80,7 +80,7 @@ def test_get_supplementary_data_request_failed(app: Flask):
         with pytest.raises(SupplementaryDataRequestFailed) as exc:
             get_supplementary_data(
                 dataset_id="44f1b432-9421-49e5-bd26-e63e18a30b69",
-                unit_id="12346789012A",
+                identifier="12346789012A",
                 survey_id="123",
             )
 
@@ -103,7 +103,7 @@ def test_get_supplementary_data_retries_timeout_error(
         try:
             supplementary_data = get_supplementary_data(
                 dataset_id="44f1b432-9421-49e5-bd26-e63e18a30b69",
-                unit_id="12346789012A",
+                identifier="12346789012A",
                 survey_id="123",
             )
         except SupplementaryDataRequestFailed:
@@ -135,7 +135,7 @@ def test_get_supplementary_data_retries_transient_error(
         try:
             supplementary_data = get_supplementary_data(
                 dataset_id="44f1b432-9421-49e5-bd26-e63e18a30b69",
-                unit_id="12346789012A",
+                identifier="12346789012A",
                 survey_id="123",
             )
         except SupplementaryDataRequestFailed:
@@ -161,7 +161,7 @@ def test_get_supplementary_data_max_retries(app: Flask, mocker):
         with pytest.raises(SupplementaryDataRequestFailed) as exc:
             get_supplementary_data(
                 dataset_id="44f1b432-9421-49e5-bd26-e63e18a30b69",
-                unit_id="12346789012A",
+                identifier="12346789012A",
                 survey_id="123",
             )
 
@@ -217,6 +217,6 @@ def test_get_supplementary_data_raises_missing_supplementary_data_key_error_when
         with pytest.raises(MissingSupplementaryDataKey):
             get_supplementary_data(
                 dataset_id="44f1b432-9421-49e5-bd26-e63e18a30b69",
-                unit_id="12346789012A",
+                identifier="12346789012A",
                 survey_id="123",
             )


### PR DESCRIPTION
### What is the context of this PR?
SDS have changed the unit_id query parameter to identifier, therefore we need to update our Runner API call and the Mock API to make use of the new naming.

### How to review
Check that you are still able to load supplementary data using the mock API.

### Checklist
* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
