### PR TITLE
Update valid units and remove metric ton support

### DIFF
--- a/app/jinja_filters.py
+++ b/app/jinja_filters.py
@@ -75,13 +75,9 @@ def format_unit(
     value: int | float | Decimal,
     length: UnitLengthType = "short",
 ) -> str:
-    # mass-metric-ton no longer supported for en_GB and related locales, but still present in business schema and allowed in validator,
-    # until removed from schema we substitute mass-tonne for mass-metric-ton before format unit
-    measurement_unit = "mass-tonne" if unit == "mass-metric-ton" else unit
-
     formatted_unit: str = units.format_unit(
         value=value,
-        measurement_unit=measurement_unit,
+        measurement_unit=unit,
         length=length,
         locale=flask_babel.get_locale(),
     )

--- a/schemas/test/en/test_placeholder_transform.json
+++ b/schemas/test/en/test_placeholder_transform.json
@@ -284,7 +284,7 @@
                                     {
                                         "id": "average-distance",
                                         "mandatory": false,
-                                        "unit": "mile",
+                                        "unit": "length-mile",
                                         "type": "Unit",
                                         "unit_length": "long",
                                         "label": "Average commuting distance",
@@ -315,7 +315,7 @@
                                                                     "source": "answers",
                                                                     "identifier": "average-distance"
                                                                 },
-                                                                "unit": "mile",
+                                                                "unit": "length-mile",
                                                                 "unit_length": "long"
                                                             }
                                                         }

--- a/schemas/test/en/test_unit_patterns.json
+++ b/schemas/test/en/test_unit_patterns.json
@@ -250,11 +250,11 @@
                             "question": {
                                 "answers": [
                                     {
-                                        "id": "mass-metric-ton",
+                                        "id": "mass-ton",
                                         "label": "Mass tonnes",
                                         "mandatory": false,
                                         "type": "Unit",
-                                        "unit": "mass-metric-ton",
+                                        "unit": "mass-ton",
                                         "unit_length": "short"
                                     }
                                 ],

--- a/schemas/test/en/test_unit_patterns.json
+++ b/schemas/test/en/test_unit_patterns.json
@@ -250,11 +250,11 @@
                             "question": {
                                 "answers": [
                                     {
-                                        "id": "mass-ton",
+                                        "id": "mass-tonne",
                                         "label": "Mass tonnes",
                                         "mandatory": false,
                                         "type": "Unit",
-                                        "unit": "mass-ton",
+                                        "unit": "mass-tonne",
                                         "unit_length": "short"
                                     }
                                 ],

--- a/scripts/run_validator.sh
+++ b/scripts/run_validator.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-tag=unit-types-update
+tag=latest
 TAG=${tag} docker-compose -f docker-compose-schema-validator.yml up -d

--- a/scripts/run_validator.sh
+++ b/scripts/run_validator.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-tag=latest
+tag=unit-types-update
 TAG=${tag} docker-compose -f docker-compose-schema-validator.yml up -d

--- a/tests/app/test_jinja_filters.py
+++ b/tests/app/test_jinja_filters.py
@@ -153,9 +153,9 @@ def test_format_percentage(percentage, formatted_percentage):
         ("duration-year", 100, "short", "100 bl", "cy"),
         ("duration-hour", 100, "long", "100 awr", "cy"),
         ("duration-year", 100, "long", "100 mlynedd", "cy"),
-        ("mass-metric-ton", 100, "long", "100 tonnes", "en_GB"),
-        ("mass-metric-ton", 1, "long", "1 tonne", "en_GB"),
-        ("mass-metric-ton", 100, "short", "100 t", "en_GB"),
+        ("mass-ton", 100, "long", "100 tons", "en_GB"),
+        ("mass-ton", 1, "long", "1 ton", "en_GB"),
+        ("mass-ton", 100, "short", "100 tn", "en_GB"),
     ),
 )
 def test_format_unit(unit, value, length, formatted_unit, language, mocker):
@@ -207,8 +207,8 @@ def test_format_unit(unit, value, length, formatted_unit, language, mocker):
         ("duration-hour", "long", "awr", "cy"),
         ("duration-year", "short", "bl", "cy"),
         ("duration-year", "long", "flynedd", "cy"),
-        ("mass-metric-ton", "long", "tonnes", "en_GB"),
-        ("mass-metric-ton", "short", "t", "en_GB"),
+        ("mass-ton", "long", "tons", "en_GB"),
+        ("mass-ton", "short", "tn", "en_GB"),
     ),
 )
 def test_format_unit_input_label(unit, length, formatted_unit, language, mocker):

--- a/tests/app/test_jinja_filters.py
+++ b/tests/app/test_jinja_filters.py
@@ -153,9 +153,9 @@ def test_format_percentage(percentage, formatted_percentage):
         ("duration-year", 100, "short", "100 bl", "cy"),
         ("duration-hour", 100, "long", "100 awr", "cy"),
         ("duration-year", 100, "long", "100 mlynedd", "cy"),
-        ("mass-ton", 100, "long", "100 tons", "en_GB"),
-        ("mass-ton", 1, "long", "1 ton", "en_GB"),
-        ("mass-ton", 100, "short", "100 tn", "en_GB"),
+        ("mass-tonne", 100, "long", "100 tonnes", "en_GB"),
+        ("mass-tonne", 1, "long", "1 tonne", "en_GB"),
+        ("mass-tonne", 100, "short", "100 t", "en_GB"),
     ),
 )
 def test_format_unit(unit, value, length, formatted_unit, language, mocker):
@@ -207,8 +207,8 @@ def test_format_unit(unit, value, length, formatted_unit, language, mocker):
         ("duration-hour", "long", "awr", "cy"),
         ("duration-year", "short", "bl", "cy"),
         ("duration-year", "long", "flynedd", "cy"),
-        ("mass-ton", "long", "tons", "en_GB"),
-        ("mass-ton", "short", "tn", "en_GB"),
+        ("mass-tonne", "long", "tonnes", "en_GB"),
+        ("mass-tonne", "short", "t", "en_GB"),
     ),
 )
 def test_format_unit_input_label(unit, length, formatted_unit, language, mocker):

--- a/tests/functional/spec/features/units.spec.js
+++ b/tests/functional/spec/features/units.spec.js
@@ -52,6 +52,6 @@ describe("Units", () => {
     await $(SetDurationUnitsBlockPage.submit()).click();
     await $(SetAreaUnitsBlockPage.submit()).click();
     await $(SetVolumeUnitsBlockPage.submit()).click();
-    await expect(await $("body").getText()).to.have.string("tons");
+    await expect(await $("body").getText()).to.have.string("tonnes");
   });
 });

--- a/tests/functional/spec/features/units.spec.js
+++ b/tests/functional/spec/features/units.spec.js
@@ -52,7 +52,6 @@ describe("Units", () => {
     await $(SetDurationUnitsBlockPage.submit()).click();
     await $(SetAreaUnitsBlockPage.submit()).click();
     await $(SetVolumeUnitsBlockPage.submit()).click();
-    await expect(await $("body").getText()).to.have.string("tonnes");
-    await expect(await $("body").getText()).to.not.have.string("metric tons");
+    await expect(await $("body").getText()).to.have.string("tons");
   });
 });

--- a/tests/integration/questionnaire/test_questionnaire_locale.py
+++ b/tests/integration/questionnaire/test_questionnaire_locale.py
@@ -3,19 +3,19 @@ from tests.integration.integration_test_case import IntegrationTestCase
 
 class TestSession(IntegrationTestCase):
     def test_none_language_code_defaults_to_en(self):
-        # Given a questionnaire with an answer of type mass-ton launches with no language code in the runner claims
+        # Given a questionnaire with an answer of type mass-tonne launches with no language code in the runner claims
         token = self.token_generator.create_token_with_none_language_code(
             "test_unit_patterns"
         )
         self.get(url=f"/session?token={token}")
 
-        # Skip to the mass-metric-tonnes answer
+        # Skip to the mass-tonnes answer
         self.post()
         self.post()
         self.post()
         self.post()
 
-        # Then the cookie_session[language_code] will have defaulted to DEFAULT_LANGUAGE_CODE (en), and the tooltip will show "tons" not "metric tons"
+        # Then the cookie_session[language_code] will have defaulted to DEFAULT_LANGUAGE_CODE (en), and the tooltip will show "tonnes" not "metric tons"
         self.assertInBody("Weight Units")
-        self.assertInSelector("tons", "[id='mass-ton-type']")
-        self.assertNotInSelector("metric tons", "[id='mass-ton-type']")
+        self.assertInSelector("tonnes", "[id='mass-tonne-type']")
+        self.assertNotInSelector("metric tons", "[id='mass-tonne-type']")

--- a/tests/integration/questionnaire/test_questionnaire_locale.py
+++ b/tests/integration/questionnaire/test_questionnaire_locale.py
@@ -3,7 +3,7 @@ from tests.integration.integration_test_case import IntegrationTestCase
 
 class TestSession(IntegrationTestCase):
     def test_none_language_code_defaults_to_en(self):
-        # Given a questionnaire with an answer of type mass-metric-tonnes launches with no language code in the runner claims
+        # Given a questionnaire with an answer of type mass-ton launches with no language code in the runner claims
         token = self.token_generator.create_token_with_none_language_code(
             "test_unit_patterns"
         )
@@ -15,7 +15,7 @@ class TestSession(IntegrationTestCase):
         self.post()
         self.post()
 
-        # Then the cookie_session[language_code] will have defaulted to DEFAULT_LANGUAGE_CODE (en), and the tooltip will show "tonnes" not "metric tons"
+        # Then the cookie_session[language_code] will have defaulted to DEFAULT_LANGUAGE_CODE (en), and the tooltip will show "tons" not "metric tons"
         self.assertInBody("Weight Units")
-        self.assertInSelector("tonnes", "[id='mass-metric-ton-type']")
-        self.assertNotInSelector("metric tons", "[id='mass-metric-ton-type']")
+        self.assertInSelector("tons", "[id='mass-ton-type']")
+        self.assertNotInSelector("metric tons", "[id='mass-ton-type']")


### PR DESCRIPTION
### What is the context of this PR?
This removes metric ton support from runner and update related tests and schemas plus updates to use supported units
in existing schemas.

### How to review
Existing func/unit/integrations tests are updated. Check if the changes make sense (metric ton) no longer supported.

### Checklist
* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
