### PR TITLE
Update CSP policy urls for GA4

### DIFF
--- a/app/setup.py
+++ b/app/setup.py
@@ -58,9 +58,8 @@ CSP_POLICY = {
     "font-src": ["'self'", "data:", "https://fonts.gstatic.com"],
     "script-src": [
         "'self'",
-        "https://www.googletagmanager.com",
-        "https://www.google-analytics.com",
-        "https://ssl.google-analytics.com",
+        "https://tagmanager.google.com",
+        "https://*.googletagmanager.com",
         "'unsafe-inline'",
     ],
     "style-src": [
@@ -69,13 +68,19 @@ CSP_POLICY = {
         "https://fonts.googleapis.com",
         "'unsafe-inline'",
     ],
-    "connect-src": ["'self'", "https://www.google-analytics.com"],
+    "connect-src": [
+        "'self'",
+        "https://*.google-analytics.com",
+        "https://*.analytics.google.com",
+        "https://*.googletagmanager.com",
+    ],
     "img-src": [
         "'self'",
         "data:",
-        "https://www.google-analytics.com",
         "https://ssl.gstatic.com",
         "https://www.gstatic.com",
+        "https://*.google-analytics.com",
+        "https://*.googletagmanager.com",
     ],
     "object-src": ["'none'"],
     "base-uri": ["'none'"],

--- a/tests/integration/test_app_create.py
+++ b/tests/integration/test_app_create.py
@@ -137,8 +137,8 @@ class TestCreateApp(unittest.TestCase):  # pylint: disable=too-many-public-metho
             csp_policy_parts = headers["Content-Security-Policy"].split("; ")
             self.assertIn(f"default-src 'self' {cdn_url}", csp_policy_parts)
             self.assertIn(
-                "script-src 'self' https://www.googletagmanager.com https://www.google-analytics.com "
-                f"https://ssl.google-analytics.com 'unsafe-inline' {cdn_url} 'nonce-{request.csp_nonce}'",
+                "script-src 'self' https://tagmanager.google.com https://*.googletagmanager.com "
+                f"'unsafe-inline' {cdn_url} 'nonce-{request.csp_nonce}'",
                 csp_policy_parts,
             )
             self.assertIn(
@@ -146,7 +146,8 @@ class TestCreateApp(unittest.TestCase):  # pylint: disable=too-many-public-metho
                 csp_policy_parts,
             )
             self.assertIn(
-                f"img-src 'self' data: https://www.google-analytics.com https://ssl.gstatic.com https://www.gstatic.com {cdn_url}",
+                "img-src 'self' data: https://ssl.gstatic.com https://www.gstatic.com https://*.google-analytics.com"
+                f" https://*.googletagmanager.com {cdn_url}",
                 csp_policy_parts,
             )
             self.assertIn(
@@ -154,7 +155,8 @@ class TestCreateApp(unittest.TestCase):  # pylint: disable=too-many-public-metho
                 csp_policy_parts,
             )
             self.assertIn(
-                f"connect-src 'self' https://www.google-analytics.com {cdn_url} {address_lookup_api_url}",
+                "connect-src 'self' https://*.google-analytics.com https://*.analytics.google.com"
+                f" https://*.googletagmanager.com {cdn_url} {address_lookup_api_url}",
                 csp_policy_parts,
             )
             self.assertIn(


### PR DESCRIPTION
### What is the context of this PR?
Following the move to Google Analytics 4, our CSP policy needs updating as per the docs here: https://developers.google.com/tag-platform/tag-manager/csp

### How to review
Deploy a staging env using this branch with GTM enabled or use my staging env [here](https://rhys-staging-2023-08-07-launcher.eq.gcp.onsdigital.uk/).

Check that when using this branch there are no CSP policy violations in the Dev Tools console (compare with the console for our real staging env where errors should be visible, ensure logging is set to Verbose in order to see the violations).

### Checklist
* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
