### PR TITLE
Tweak README with python-snappy dependency install workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ pip install --upgrade pip setuptools pipenv
 pipenv install --dev
 ```
 
-###### NOTE: You may encounter an issue with the `python-snappy` install with the `pipenv` install above on Mac OSX. If so, install with the recommended [workaround command](https://github.com/andrix/python-snappy#frequently-asked-questions) instead:
+###### NOTE: You may encounter an issue with the `python-snappy` installation with `pipenv` above on Mac OSX. If so, install with the recommended [workaround command](https://github.com/andrix/python-snappy#frequently-asked-questions) instead:
 ``` shell
 CPPFLAGS="-I/usr/local/include -L/usr/local/lib" pipenv install --dev
 ```

--- a/README.md
+++ b/README.md
@@ -71,6 +71,11 @@ pip install --upgrade pip setuptools pipenv
 pipenv install --dev
 ```
 
+###### NOTE: You may encounter an issue with the `python-snappy` install with the `pipenv` install above on Mac OSX. If so, install with the recommended [workaround command](https://github.com/andrix/python-snappy#frequently-asked-questions) instead:
+``` shell
+CPPFLAGS="-I/usr/local/include -L/usr/local/lib" pipenv install --dev
+```
+
 To update the design system templates run:
 
 ``` shell


### PR DESCRIPTION
### What is the context of this PR?
I encountered an issue locally when following the readme to install the dependencies with `pipenv`. The workaround is to follow the guidance [here](https://github.com/andrix/python-snappy#frequently-asked-questions)

### How to review
Check that the readme change makes sense

### Checklist
* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
