### PR TITLE
Fix functional tests to reflect url change

### DIFF
--- a/tests/functional/spec/exit.spec.js
+++ b/tests/functional/spec/exit.spec.js
@@ -20,7 +20,7 @@ describe("Post submission exit", () => {
     await click(SubmitPage.submit());
     await click(HubPage.submit());
     await $(CensusThankYouPage.exit()).click();
-    await expect(await browser.getUrl()).to.equal("https://census.gov.uk/en/start");
+    await expect(await browser.getUrl()).to.equal("https://www.ons.gov.uk/census");
   });
 
   it("Given I have clicked the exit button, When I navigate back, Then I am taken to the session timed out page", async () => {


### PR DESCRIPTION
### What is the context of this PR?
Functional tests have started failing because https://census.gov.uk/en/start has changed to https://www.ons.gov.uk/census and one of the functional tests is checking for a specific url. This PR is just to update that url. No other changes made since census config is soon to be removed.

### How to review
All tests pass

### Checklist
* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
