### PR TITLE
Add require-await rule for functional test linting

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -68,6 +68,7 @@
       {
         "blocks": "never"
       }
-    ]
+    ],
+      "require-await": "error"
   }
 }

--- a/tests/functional/spec/answer_action_redirect_to_list_add_block_checkbox.spec.js
+++ b/tests/functional/spec/answer_action_redirect_to_list_add_block_checkbox.spec.js
@@ -37,7 +37,7 @@ describe("Answer Action: Redirect To List Add Question (Checkbox)", () => {
       await expect(browser).toHaveUrlContaining(AnyoneLiveAtListCollector.pageName);
 
       const peopleExpected = ["Marcus Twin"];
-      checkItemsInList(peopleExpected, AnyoneLiveAtListCollector.listLabel);
+      await checkItemsInList(peopleExpected, AnyoneLiveAtListCollector.listLabel);
     });
 
     it('When the user click the "Previous" link from the list collector, Then, they are taken to the last complete block', async () => {

--- a/tests/functional/spec/answer_action_redirect_to_list_add_block_radio.spec.js
+++ b/tests/functional/spec/answer_action_redirect_to_list_add_block_radio.spec.js
@@ -37,7 +37,7 @@ describe("Answer Action: Redirect To List Add Question (Radio)", () => {
       await expect(browser).toHaveUrlContaining(AnyoneLiveAtListCollector.pageName);
 
       const peopleExpected = ["Marcus Twin"];
-      checkItemsInList(peopleExpected, AnyoneLiveAtListCollector.listLabel);
+      await checkItemsInList(peopleExpected, AnyoneLiveAtListCollector.listLabel);
     });
 
     it('When the user click the "Previous" link from the list collector, Then, they are taken to the last complete block', async () => {

--- a/tests/functional/spec/features/calculated_summary/calculated_summary_test_case.js
+++ b/tests/functional/spec/features/calculated_summary/calculated_summary_test_case.js
@@ -451,7 +451,7 @@ class TestCase {
       await expect(browser).toHaveUrlContaining(CurrencyTotalPlaybackPage.pageName);
     });
     it("Given I have entered a range of positive and negative values, When I reach the calculated summary, Then the total is correct", async () => {
-      assertSummaryValues(expectedAnswerValues);
+      await assertSummaryValues(expectedAnswerValues);
       await expect(await $(CurrencyTotalPlaybackPage.calculatedSummaryTitle()).getText()).toBe(
         `We calculate the total of currency values entered to be ${expectedTotalValue}. Is this correct?`,
       );

--- a/tests/functional/spec/features/calculated_summary/new_calculated_summary_repeating_section.spec.js
+++ b/tests/functional/spec/features/calculated_summary/new_calculated_summary_repeating_section.spec.js
@@ -233,7 +233,9 @@ describe("Feature: Calculated Summary Repeating Section", () => {
       const content = $("h1 + ul").getText();
       const textsToAssert = ["Total currency values: £9.36", "Total unit values: 1,467", "Total percentage values: 79", "Total number values: 124.58"];
 
-      textsToAssert.forEach(async (text) => await expect(content).toBe(text));
+      for (const text of textsToAssert) {
+        await expect(content).toBe(text);
+      }
     });
 
     it("Given I have an answer minimum based on a calculated summary total, When I enter an invalid answer, Then I should see an error message on the page", async () => {
@@ -319,7 +321,7 @@ describe("Feature: Calculated Summary Repeating Section", () => {
     });
   });
 
-  describe("Given I have a Calculated Summary in a Repeating Section", async () => {
+  describe("Given I have a Calculated Summary in a Repeating Section", () => {
     before("Get to Final Summary", async () => {
       await browser.openQuestionnaire("test_new_calculated_summary_repeating_section.json");
       await click(HubPage.submit());

--- a/tests/functional/spec/features/dynamic_answer_options/function_driven.js
+++ b/tests/functional/spec/features/dynamic_answer_options/function_driven.js
@@ -30,7 +30,7 @@ const openQuestionnaireAndSetUp = async (schema) => {
   await click(ReferenceDatePage.submit());
 };
 
-testCases.forEach(async (testCase) => {
+testCases.forEach((testCase) => {
   describe(`Feature: Dynamically generated answer options driven by a function (${testCase.schemaName})`, () => {
     describe("Selecting/Deselecting", () => {
       before("Open questionnaire", async () => {

--- a/tests/functional/spec/features/grand_calculated_summary/grand_calculated_summary_inside_repeating_section.spec.js
+++ b/tests/functional/spec/features/grand_calculated_summary/grand_calculated_summary_inside_repeating_section.spec.js
@@ -67,7 +67,7 @@ describe("Grand Calculated Summary inside a repeating section", () => {
     await expect(await $(GrandCalculatedSummaryVehiclePage.calculatedSummaryBaseCostLabel()).getText()).toBe("Vehicle base cost");
     await expect(await $(GrandCalculatedSummaryVehiclePage.calculatedSummaryRunningCostLabel()).getText()).toBe("Monthly Car costs");
     await expect(await $(GrandCalculatedSummaryVehiclePage.grandCalculatedSummaryQuestion()).getText()).toBe("Grand total Car expenditure");
-    assertSummaryValues(["£90.00", "£225.00", "£315.00"]);
+    await assertSummaryValues(["£90.00", "£225.00", "£315.00"]);
   });
 
   it("Given I immediately use that Grand Calculated Summary for validation, When I enter a sum of values too high, Then I see an error message", async () => {
@@ -112,7 +112,7 @@ describe("Grand Calculated Summary inside a repeating section", () => {
     await expect(await $(GrandCalculatedSummaryVehiclePage.calculatedSummaryBaseCostLabel()).getText()).toBe("Vehicle base cost");
     await expect(await $(GrandCalculatedSummaryVehiclePage.calculatedSummaryRunningCostLabel()).getText()).toBe("Monthly Van costs");
     await expect(await $(GrandCalculatedSummaryVehiclePage.grandCalculatedSummaryQuestion()).getText()).toBe("Grand total Van expenditure");
-    assertSummaryValues(["£90.00", "£95.00", "£185.00"]);
+    await assertSummaryValues(["£90.00", "£95.00", "£185.00"]);
   });
 
   it("Given I am at a Grand Summary inside a repeating section, When I click the change link for a repeating calculated summary, Then I am taken to the correct page", async () => {

--- a/tests/functional/spec/features/grand_calculated_summary/grand_calculated_summary_repeating_answers.spec.js
+++ b/tests/functional/spec/features/grand_calculated_summary/grand_calculated_summary_repeating_answers.spec.js
@@ -262,8 +262,8 @@ describe("Feature: Grand Calculated Summary", () => {
       await expect(await $(GrandCalculatedSummary3Page.grandCalculatedSummaryTitle()).getText()).toBe(
         "Grand Calculated Summary for monthly spending on bills and services is calculated to be £280.00. Is this correct?",
       );
-      assertSummaryValues(["£250.00", "£30.00", "£280.00"]);
-      assertSummaryItems([
+      await assertSummaryValues(["£250.00", "£30.00", "£280.00"]);
+      await assertSummaryItems([
         "Total monthly expenditure on utility bills",
         "Total monthly expenditure on streaming services",
         "Total monthly expenditure on bills and streaming services",
@@ -275,8 +275,8 @@ describe("Feature: Grand Calculated Summary", () => {
       await expect(await $(GrandCalculatedSummary4Page.grandCalculatedSummaryTitle()).getText()).toBe(
         "Grand Calculated Summary for internet usage is calculated to be 100 GB. Is this correct?",
       );
-      assertSummaryValues(["45 GB", "55 GB", "100 GB"]);
-      assertSummaryItems(["Total internet usage on streaming services", "Total internet usage on other services", "Total internet usage"]);
+      await assertSummaryValues(["45 GB", "55 GB", "100 GB"]);
+      await assertSummaryItems(["Total internet usage on streaming services", "Total internet usage on other services", "Total internet usage"]);
     });
 
     it("Given I have multiple calculated summaries of static, repeating and dynamic answers, When I reach the grand calculated summary of them all, Then I see the correct total and items", async () => {
@@ -284,8 +284,8 @@ describe("Feature: Grand Calculated Summary", () => {
       await expect(await $(GrandCalculatedSummary5Page.grandCalculatedSummaryTitle()).getText()).toBe(
         "Grand Calculated Summary for total monthly household expenditure is calculated to be £1,130.00. Is this correct?",
       );
-      assertSummaryValues(["£550.00", "£300.00", "£0.00", "£250.00", "£30.00", "£1,130.00"]);
-      assertSummaryValues([
+      await assertSummaryValues(["£550.00", "£300.00", "£0.00", "£250.00", "£30.00", "£1,130.00"]);
+      await assertSummaryValues([
         "Total monthly food expenditure",
         "Total monthly clothes expenditure",
         "Total games expenditure",

--- a/tests/functional/spec/features/question_summary/custom_question_summary.spec.js
+++ b/tests/functional/spec/features/question_summary/custom_question_summary.spec.js
@@ -9,7 +9,7 @@ describe("Summary Screen", () => {
   });
 
   it("Given a survey has question summary concatenations and has been completed when on the summary page then the correct response should be displayed formatted correctly", async () => {
-    completeAllQuestions();
+    await completeAllQuestions();
     await expect(await $(SubmitPage.summaryRowState("name-question-concatenated-answer")).getText()).toBe("John Smith");
     await expect(await $(SubmitPage.summaryRowState("address-question-concatenated-answer")).getText()).toBe("Cardiff Road\nNewport\nNP10 8XG");
     await expect(await $(SubmitPage.summaryRowState("age-question-concatenated-answer")).getText()).toBe("7\nThis age is an estimate");

--- a/tests/functional/spec/features/repeating_blocks/list_collector_repeating_blocks.spec.js
+++ b/tests/functional/spec/features/repeating_blocks/list_collector_repeating_blocks.spec.js
@@ -89,7 +89,7 @@ describe("List Collector Repeating Blocks", () => {
       await $(AnyOtherCompaniesOrBranchesPage.yes()).click();
       await click(AnyOtherCompaniesOrBranchesPage.submit());
       await addCompany("MOD", "789", "3", "3", "2023", true);
-      checkItemsInList(["ONS", "GOV", "MOD"], AnyOtherCompaniesOrBranchesPage.listLabel);
+      await checkItemsInList(["ONS", "GOV", "MOD"], AnyOtherCompaniesOrBranchesPage.listLabel);
     });
 
     it("When the user edits an item, Then the name of the item is able to be changed", async () => {
@@ -103,7 +103,7 @@ describe("List Collector Repeating Blocks", () => {
       await $(AnyOtherCompaniesOrBranchesPage.listRemoveLink(2)).click();
       await $(RemoveCompanyPage.yes()).click();
       await click(RemoveCompanyPage.submit());
-      checkItemsInList(["ONS", "MOD"], AnyOtherCompaniesOrBranchesPage.listLabel);
+      await checkItemsInList(["ONS", "MOD"], AnyOtherCompaniesOrBranchesPage.listLabel);
       await expect(await $(AnyOtherCompaniesOrBranchesPage.listLabel(2)).getText()).not.toContain("Government");
       await expect(await $(AnyOtherCompaniesOrBranchesPage.listLabel(2)).getText()).toBe("MOD");
     });
@@ -112,7 +112,7 @@ describe("List Collector Repeating Blocks", () => {
       await $(AnyOtherCompaniesOrBranchesPage.yes()).click();
       await click(AnyOtherCompaniesOrBranchesPage.submit());
       await addCompany("Council", "101", "4", "4", "2023", false, true);
-      checkItemsInList(["ONS", "MOD", "Council"], AnyOtherCompaniesOrBranchesPage.listLabel);
+      await checkItemsInList(["ONS", "MOD", "Council"], AnyOtherCompaniesOrBranchesPage.listLabel);
     });
 
     it("When a user has finished making changes to the list, Then section can be completed and the questionnaire submitted", async () => {
@@ -159,11 +159,11 @@ describe("List Collector Repeating Blocks", () => {
       await addCompany("NAV", "101", "4", "4", "2023", true, true);
 
       // Only the ONS and NAV items should be complete
-      checkItemsInList(["ONS", "GOV", "MOD", "NAV"], AnyOtherCompaniesOrBranchesPage.listLabel);
-      checkListItemComplete(`dt[data-qa="list-item-1-label"]`);
-      checkListItemIncomplete(`dt[data-qa="list-item-2-label"]`);
-      checkListItemIncomplete(`dt[data-qa="list-item-3-label"]`);
-      checkListItemComplete(`dt[data-qa="list-item-1-label"]`);
+      await checkItemsInList(["ONS", "GOV", "MOD", "NAV"], AnyOtherCompaniesOrBranchesPage.listLabel);
+      await checkListItemComplete(`dt[data-qa="list-item-1-label"]`);
+      await checkListItemIncomplete(`dt[data-qa="list-item-2-label"]`);
+      await checkListItemIncomplete(`dt[data-qa="list-item-3-label"]`);
+      await checkListItemComplete(`dt[data-qa="list-item-1-label"]`);
     });
 
     it("When an item has incomplete repeating blocks, Then using submit on the list collector page will navigate the user to the first incomplete repeating block.", async () => {
@@ -193,10 +193,10 @@ describe("List Collector Repeating Blocks", () => {
     it("When the last remaining incomplete repeating block is completed, Then all items are marked as completed with the checkmark icon.", async () => {
       await $(CompaniesRepeatingBlock2Page.authorisedTraderUkRadioNo()).click();
       await click(CompaniesRepeatingBlock2Page.submit());
-      checkListItemComplete(`dt[data-qa="list-item-1-label"]`);
-      checkListItemComplete(`dt[data-qa="list-item-2-label"]`);
-      checkListItemComplete(`dt[data-qa="list-item-3-label"]`);
-      checkListItemComplete(`dt[data-qa="list-item-4-label"]`);
+      await checkListItemComplete(`dt[data-qa="list-item-1-label"]`);
+      await checkListItemComplete(`dt[data-qa="list-item-2-label"]`);
+      await checkListItemComplete(`dt[data-qa="list-item-3-label"]`);
+      await checkListItemComplete(`dt[data-qa="list-item-4-label"]`);
     });
 
     it("When the user clicks a change link from the section summary and submits without changing an answer, Then the user is returned to the section summary anchored to the answer they clicked on", async () => {
@@ -305,8 +305,8 @@ describe("List Collector Repeating Blocks", () => {
       await $(CompaniesRepeatingBlock2Page.authorisedTraderUkRadioNo()).click();
       await click(CompaniesRepeatingBlock2Page.submit());
       await expect(browser).toHaveUrlContaining(AnyOtherCompaniesOrBranchesPage.pageName);
-      checkListItemComplete(`dt[data-qa="list-item-1-label"]`);
-      checkListItemComplete(`dt[data-qa="list-item-2-label"]`);
+      await checkListItemComplete(`dt[data-qa="list-item-1-label"]`);
+      await checkListItemComplete(`dt[data-qa="list-item-2-label"]`);
     });
 
     it("When another incomplete item is added via the section summary, Then navigating to the submit page of the section will redirect to the list collector page.", async () => {

--- a/tests/functional/spec/features/supplementary_data/supplementary_data.spec.js
+++ b/tests/functional/spec/features/supplementary_data/supplementary_data.spec.js
@@ -259,8 +259,8 @@ describe("Using supplementary data", () => {
     await expect(await $(CalculatedSummaryVolumeSalesPage.calculatedSummaryTitle()).getText()).toBe(
       "We calculate the total volume of sales over the previous quarter to be 150 kg. Is this correct?",
     );
-    assertSummaryItems(["Volume of sales for Articles and equipment for sports or outdoor games", "Volume of sales for Kitchen Equipment"]);
-    assertSummaryValues(["100 kg", "50 kg"]);
+    await assertSummaryItems(["Volume of sales for Articles and equipment for sports or outdoor games", "Volume of sales for Kitchen Equipment"]);
+    await assertSummaryValues(["100 kg", "50 kg"]);
     await click(CalculatedSummaryVolumeSalesPage.submit());
   });
 
@@ -268,8 +268,8 @@ describe("Using supplementary data", () => {
     await expect(await $(CalculatedSummaryVolumeTotalPage.calculatedSummaryTitle()).getText()).toBe(
       "We calculate the total volume produced over the previous quarter to be 500 kg. Is this correct?",
     );
-    assertSummaryItems(["Total volume produced for Articles and equipment for sports or outdoor games", "Total volume produced for Kitchen Equipment"]);
-    assertSummaryValues(["200 kg", "300 kg"]);
+    await assertSummaryItems(["Total volume produced for Articles and equipment for sports or outdoor games", "Total volume produced for Kitchen Equipment"]);
+    await assertSummaryValues(["200 kg", "300 kg"]);
     await click(CalculatedSummaryVolumeTotalPage.submit());
   });
 
@@ -287,18 +287,18 @@ describe("Using supplementary data", () => {
     await expect(await $(CalculatedSummaryValueSalesPage.calculatedSummaryTitle()).getText()).toBe(
       "We calculate the total value of sales over the previous quarter to be £660.00. Is this correct?",
     );
-    assertSummaryItems([
+    await assertSummaryItems([
       "Value of sales for Articles and equipment for sports or outdoor games",
       "Value of sales for Kitchen Equipment",
       "Value of sales from other categories",
     ]);
-    assertSummaryValues(["£110.00", "£220.00", "£330.00"]);
+    await assertSummaryValues(["£110.00", "£220.00", "£330.00"]);
     await click(CalculatedSummaryValueSalesPage.submit());
   });
 
   it("Given I have a section summary for product details, When I reach the summary page, Then I see the supplementary data and my answers rendered correctly", async () => {
     await expect(await $$(summaryRowTitles)[0].getText()).toBe("Sales during the previous quarter");
-    assertSummaryItems([
+    await assertSummaryItems([
       "Articles and equipment for sports or outdoor games",
       "Volume of sales for Articles and equipment for sports or outdoor games",
       "Total volume produced for Articles and equipment for sports or outdoor games",
@@ -309,7 +309,7 @@ describe("Using supplementary data", () => {
       "Value of sales for Kitchen Equipment",
       "Value of sales from other categories",
     ]);
-    assertSummaryValues(["100 kg", "200 kg", "110 kg", "50 kg", "300 kg", "220 kg", "£110.00", "£220.00", "£330.00"]);
+    await assertSummaryValues(["100 kg", "200 kg", "110 kg", "50 kg", "300 kg", "220 kg", "£110.00", "£220.00", "£330.00"]);
     await click(Section6Page.submit());
   });
 
@@ -345,7 +345,16 @@ describe("Using supplementary data", () => {
     await click(HubPage.submit());
     await $(ThankYouPage.savePrintAnswersLink()).click();
 
-    assertSummaryTitles(["Company Details", "Employees", "Additional Employees", "Harry Potter", "Bruce Wayne", "Jane Doe", "John Smith", "Product details"]);
+    await assertSummaryTitles([
+      "Company Details",
+      "Employees",
+      "Additional Employees",
+      "Harry Potter",
+      "Bruce Wayne",
+      "Jane Doe",
+      "John Smith",
+      "Product details",
+    ]);
 
     // Company details
     await expect(await $(ViewSubmittedResponsePage.emailQuestion()).getText()).toBe("Is contact@lidl.org still the correct contact email for Lidl?");

--- a/tests/functional/spec/features/validation/date_validation/date-single.spec.js
+++ b/tests/functional/spec/features/validation/date_validation/date-single.spec.js
@@ -5,7 +5,7 @@ import { click } from "../../../../helpers";
 describe("Feature: Validation for single date periods", () => {
   beforeEach(async () => {
     await browser.openQuestionnaire("test_date_validation_single.json");
-    completeFirstDatePage();
+    await completeFirstDatePage();
   });
 
   describe("Given I enter a date before the minimum offset meta date", () => {

--- a/tests/functional/spec/features/validation/sum/equal_total_in_separate_section_repeating.spec.js
+++ b/tests/functional/spec/features/validation/sum/equal_total_in_separate_section_repeating.spec.js
@@ -58,7 +58,7 @@ const answerAndSubmitEntertainmentBreakdownQuestion = async (breakdown1, breakdo
   await click(EntertainmentBreakdownPage.submit());
 };
 
-const assertRepeatingSectionOnChange = async (repeatIndex, currentBreakdown1, currentBreakdown2, currentBreakdown3, newTotal) => {
+const assertRepeatingSectionOnChange = (repeatIndex, currentBreakdown1, currentBreakdown2, currentBreakdown3, newTotal) => {
   it(`When I click 'Continue with section' on repeating section ${repeatIndex}, Then I should be taken to the spending breakdown question and my previous answers should be prefilled`, async () => {
     await $(HubPage.summaryRowLink(repeatingSectionId(repeatIndex))).click();
 

--- a/tests/functional/spec/list_collector.spec.js
+++ b/tests/functional/spec/list_collector.spec.js
@@ -53,7 +53,7 @@ describe("List Collector", () => {
 
     it("The collector shows all of the household members in the summary", async () => {
       const peopleExpected = ["Marcus Twin", "Samuel Clemens", "Olivia Clemens", "Suzy Clemens"];
-      checkItemsInList(peopleExpected, ListCollectorPage.listLabel);
+      await checkItemsInList(peopleExpected, ListCollectorPage.listLabel);
     });
 
     it("The questionnaire allows the name of a person to be changed", async () => {
@@ -111,7 +111,7 @@ describe("List Collector", () => {
 
     it("The collector shows everyone on the summary", async () => {
       const peopleExpected = ["Samuel Clemens", "Olivia Clemens", "Suzy Clemens", "Clara Clemens", "Jean Clemens"];
-      checkItemsInList(peopleExpected, ListCollectorPage.listLabel);
+      await checkItemsInList(peopleExpected, ListCollectorPage.listLabel);
     });
 
     it("When No is answered on the list collector the user sees an interstitial", async () => {
@@ -127,7 +127,7 @@ describe("List Collector", () => {
 
     it("The collector still shows the same list of people on the summary", async () => {
       const peopleExpected = ["Samuel Clemens", "Olivia Clemens", "Suzy Clemens", "Clara Clemens", "Jean Clemens"];
-      checkItemsInList(peopleExpected, ListCollectorPage.listLabel);
+      await checkItemsInList(peopleExpected, ListCollectorPage.listLabel);
     });
 
     it("The collector allows the user to add another person to the same list", async () => {

--- a/tests/functional/spec/list_collector_variants.spec.js
+++ b/tests/functional/spec/list_collector_variants.spec.js
@@ -30,7 +30,7 @@ describe("List Collector With Variants", () => {
 
     it("The user can see all household members in the summary", async () => {
       const peopleExpected = ["Samuel Clemens"];
-      checkItemsInList(peopleExpected, ListCollectorPage.listLabel);
+      await checkItemsInList(peopleExpected, ListCollectorPage.listLabel);
     });
 
     it("The questionnaire has the correct question text on the change and remove pages", async () => {
@@ -76,7 +76,7 @@ describe("List Collector With Variants", () => {
 
     it("The user can see all household members in the summary", async () => {
       const peopleExpected = ["Samuel Clemens"];
-      checkItemsInList(peopleExpected, ListCollectorPage.listLabel);
+      await checkItemsInList(peopleExpected, ListCollectorPage.listLabel);
     });
 
     it("The questionnaire has the correct question text on the change and remove pages", async () => {

--- a/tests/functional/spec/multiple_answers.spec.js
+++ b/tests/functional/spec/multiple_answers.spec.js
@@ -33,7 +33,7 @@ describe("Multiple Answers", () => {
   describe("Given I have completed a questionnaire that has multiple answers per question", () => {
     beforeEach("Load the questionnaire and answer all questions", async () => {
       await browser.openQuestionnaire("test_multiple_answers.json");
-      answerAllQuestions();
+      await answerAllQuestions();
     });
 
     it("When I am on the summary, Then all answers are displayed", async () => {


### PR DESCRIPTION
### What is the context of this PR?
This PR introduces the `require-await` eslint rule for Runner's functional tests. 

Some of the functional tests in runner use asynchronous helper functions to assert behaviour, but do not await these functions, resulting in the check not actually happening. This is hiding potential bugs in functionality. 

* Added the eslint rule `require-await` and updated tests caught by this rule. Interestingly, this rule only picks up arrow functions missing an `await` in our functional tests.
* Updated other tests that had missing `await`s. These missing `await`s were reported by the JetBrains IDE code analysis tool.

### How to review
Try running the linter with `make lint-js` and the `require-await` rule should pass.

### Checklist
* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
