### PR TITLE
Reintroduce unsafe-inline keyword to style-src of CSP policy

### DIFF
--- a/app/setup.py
+++ b/app/setup.py
@@ -65,6 +65,7 @@ CSP_POLICY = {
     "style-src": [
         "'self'",
         "https://fonts.googleapis.com",
+        "'unsafe-inline'",
     ],
     "connect-src": [
         "'self'",

--- a/tests/integration/test_app_create.py
+++ b/tests/integration/test_app_create.py
@@ -144,7 +144,7 @@ class TestCreateApp(unittest.TestCase):  # pylint: disable=too-many-public-metho
                 csp_policy_parts,
             )
             self.assertIn(
-                f"style-src 'self' https://fonts.googleapis.com {cdn_url}",
+                f"style-src 'self' https://fonts.googleapis.com 'unsafe-inline' {cdn_url}",
                 csp_policy_parts,
             )
             self.assertIn(


### PR DESCRIPTION
### What is the context of this PR?
There are some CSP violations present in our latest deploy of runner after we migrated to GA4 and removed `unsafe-inline` keyword from the CSP policy. Removing the unsafe-line is causing issues with the SVG which uses inline styles.

### How to review
Test that reintroducing the keyword causes these violations to stop in deployed environment.

### Checklist
* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
