### PR TITLE
Allow the hub to be enabled with repeating sections

### DIFF
--- a/app/questionnaire/router.py
+++ b/app/questionnaire/router.py
@@ -91,14 +91,13 @@ class Router:
                     self._schema.get_repeating_list_for_section(section_id)
                 )
 
-                items = (
+                items: ListModel | list[None] = (
                     self._data_stores.list_store.get(repeating_list_for_section)
                     if repeating_list_for_section
                     else [None]
                 )
 
-                # Type ignore: items is an iterable as per the ListModel __iter__ method
-                for list_item_id in items:  # type: ignore
+                for list_item_id in items:
                     section_key = SectionKey(section_id, list_item_id)
                     if not self._data_stores.progress_store.is_section_complete(
                         section_key

--- a/app/questionnaire/router.py
+++ b/app/questionnaire/router.py
@@ -3,6 +3,7 @@ from typing import Generator, Mapping
 from flask import url_for
 
 from app.data_models.data_stores import DataStores
+from app.data_models.list_store import ListModel
 from app.questionnaire import QuestionnaireSchema
 from app.questionnaire.location import Location, SectionKey
 from app.questionnaire.path_finder import PathFinder

--- a/app/questionnaire/router.py
+++ b/app/questionnaire/router.py
@@ -82,11 +82,30 @@ class Router:
         return location.block_id in self._get_allowable_path(routing_path)
 
     def can_access_hub(self) -> bool:
-        return self._schema.is_flow_hub and all(
-            self._data_stores.progress_store.is_section_complete(SectionKey(section_id))
-            for section_id in self._schema.get_section_ids_required_for_hub()
-            if section_id in self.enabled_section_ids
-        )
+        if not self._schema.is_flow_hub:
+            return False
+
+        for section_id in self._schema.get_section_ids_required_for_hub():
+            if section_id in self.enabled_section_ids:
+                repeating_list_for_section = (
+                    self._schema.get_repeating_list_for_section(section_id)
+                )
+
+                items = (
+                    self._data_stores.list_store.get(repeating_list_for_section)
+                    if repeating_list_for_section
+                    else [None]
+                )
+
+                # Type ignore: items is an iterable as per the ListModel __iter__ method
+                for list_item_id in items:  # type: ignore
+                    section_key = SectionKey(section_id, list_item_id)
+                    if not self._data_stores.progress_store.is_section_complete(
+                        section_key
+                    ):
+                        return False
+
+        return True
 
     def can_display_section_summary(self, section_key: SectionKey) -> bool:
         return bool(

--- a/schemas/test/en/test_hub_section_required_with_repeat.json
+++ b/schemas/test/en/test_hub_section_required_with_repeat.json
@@ -1,0 +1,431 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "language": "en",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.3",
+    "survey_id": "0",
+    "title": "Hub & Spoke Enabled with Required Repeating Sections",
+    "theme": "default",
+    "description": "A questionnaire to demo hub and spoke functionality with required repeating sections",
+    "metadata": [
+        {
+            "name": "user_id",
+            "type": "string"
+        },
+        {
+            "name": "period_id",
+            "type": "string"
+        },
+        {
+            "name": "ru_name",
+            "type": "string"
+        }
+    ],
+    "questionnaire_flow": {
+        "type": "Hub",
+        "options": {
+            "required_completed_sections": ["list-collector-section", "personal-details-section"]
+        }
+    },
+    "sections": [
+        {
+            "summary": {
+                "show_on_completion": true,
+                "items": [
+                    {
+                        "type": "List",
+                        "for_list": "people",
+                        "title": "Household members",
+                        "add_link_text": "Add someone to this household",
+                        "empty_list_text": "There are no householders"
+                    }
+                ]
+            },
+            "id": "list-collector-section",
+            "title": "Household",
+            "groups": [
+                {
+                    "id": "group",
+                    "title": "List",
+                    "blocks": [
+                        {
+                            "id": "primary-person-list-collector",
+                            "type": "PrimaryPersonListCollector",
+                            "for_list": "people",
+                            "add_or_edit_block": {
+                                "id": "add-or-edit-primary-person",
+                                "type": "PrimaryPersonListAddOrEditQuestion",
+                                "question": {
+                                    "id": "primary-person-add-or-edit-question",
+                                    "type": "General",
+                                    "title": "What is your name?",
+                                    "answers": [
+                                        {
+                                            "id": "first-name",
+                                            "label": "First name",
+                                            "mandatory": true,
+                                            "type": "TextField"
+                                        },
+                                        {
+                                            "id": "last-name",
+                                            "label": "Last name",
+                                            "mandatory": true,
+                                            "type": "TextField"
+                                        }
+                                    ]
+                                }
+                            },
+                            "question": {
+                                "id": "primary-confirmation-question",
+                                "type": "General",
+                                "title": "Do you live here?",
+                                "answers": [
+                                    {
+                                        "id": "you-live-here",
+                                        "mandatory": true,
+                                        "type": "Radio",
+                                        "options": [
+                                            {
+                                                "label": "Yes",
+                                                "value": "Yes",
+                                                "action": {
+                                                    "type": "RedirectToListAddBlock"
+                                                }
+                                            },
+                                            {
+                                                "label": "No",
+                                                "value": "No"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "id": "list-collector",
+                            "type": "ListCollector",
+                            "for_list": "people",
+                            "question": {
+                                "id": "confirmation-question",
+                                "type": "General",
+                                "title": "Does anyone else live here?",
+                                "answers": [
+                                    {
+                                        "id": "anyone-else",
+                                        "mandatory": true,
+                                        "type": "Radio",
+                                        "options": [
+                                            {
+                                                "label": "Yes",
+                                                "value": "Yes",
+                                                "action": {
+                                                    "type": "RedirectToListAddBlock"
+                                                }
+                                            },
+                                            {
+                                                "label": "No",
+                                                "value": "No"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "add_block": {
+                                "id": "add-person",
+                                "type": "ListAddQuestion",
+                                "question": {
+                                    "id": "add-question",
+                                    "type": "General",
+                                    "title": "What is the name of the person?",
+                                    "answers": [
+                                        {
+                                            "id": "first-name",
+                                            "label": "First name",
+                                            "mandatory": true,
+                                            "type": "TextField"
+                                        },
+                                        {
+                                            "id": "last-name",
+                                            "label": "Last name",
+                                            "mandatory": true,
+                                            "type": "TextField"
+                                        }
+                                    ]
+                                }
+                            },
+                            "edit_block": {
+                                "id": "edit-person",
+                                "type": "ListEditQuestion",
+                                "question": {
+                                    "id": "edit-question",
+                                    "type": "General",
+                                    "title": "What is the name of the person?",
+                                    "answers": [
+                                        {
+                                            "id": "first-name",
+                                            "label": "First name",
+                                            "mandatory": true,
+                                            "type": "TextField"
+                                        },
+                                        {
+                                            "id": "last-name",
+                                            "label": "Last name",
+                                            "mandatory": true,
+                                            "type": "TextField"
+                                        }
+                                    ]
+                                }
+                            },
+                            "remove_block": {
+                                "id": "remove-person",
+                                "type": "ListRemoveQuestion",
+                                "question": {
+                                    "id": "remove-question",
+                                    "type": "General",
+                                    "title": "Are you sure you want to remove this person?",
+                                    "answers": [
+                                        {
+                                            "id": "remove-confirmation",
+                                            "mandatory": true,
+                                            "type": "Radio",
+                                            "options": [
+                                                {
+                                                    "label": "Yes",
+                                                    "value": "Yes",
+                                                    "action": {
+                                                        "type": "RemoveListItemAndAnswers"
+                                                    }
+                                                },
+                                                {
+                                                    "label": "No",
+                                                    "value": "No"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "summary": {
+                                "title": "Household members",
+                                "item_title": {
+                                    "text": "{person_name}",
+                                    "placeholders": [
+                                        {
+                                            "placeholder": "person_name",
+                                            "transforms": [
+                                                {
+                                                    "arguments": {
+                                                        "delimiter": " ",
+                                                        "list_to_concatenate": [
+                                                            {
+                                                                "source": "answers",
+                                                                "identifier": "first-name"
+                                                            },
+                                                            {
+                                                                "source": "answers",
+                                                                "identifier": "last-name"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "transform": "concatenate_list"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "personal-details-section",
+            "title": "Personal Details",
+            "summary": {
+                "show_on_completion": true
+            },
+            "repeat": {
+                "for_list": "people",
+                "title": {
+                    "text": "{person_name}",
+                    "placeholders": [
+                        {
+                            "placeholder": "person_name",
+                            "transforms": [
+                                {
+                                    "transform": "concatenate_list",
+                                    "arguments": {
+                                        "list_to_concatenate": [
+                                            {
+                                                "source": "answers",
+                                                "identifier": "first-name"
+                                            },
+                                            {
+                                                "source": "answers",
+                                                "identifier": "last-name"
+                                            }
+                                        ],
+                                        "delimiter": " "
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            "groups": [
+                {
+                    "id": "personal-details-group",
+                    "title": "Personal Details",
+                    "blocks": [
+                        {
+                            "id": "proxy",
+                            "question": {
+                                "answers": [
+                                    {
+                                        "default": "Yes",
+                                        "id": "proxy-answer",
+                                        "mandatory": false,
+                                        "options": [
+                                            {
+                                                "label": "No, I’m answering for myself",
+                                                "value": "No, I’m answering for myself"
+                                            },
+                                            {
+                                                "label": "Yes",
+                                                "value": "Yes"
+                                            }
+                                        ],
+                                        "type": "Radio"
+                                    }
+                                ],
+                                "id": "proxy-question",
+                                "title": "Are you answering the questions on behalf of someone else?",
+                                "type": "General"
+                            },
+                            "type": "Question"
+                        },
+                        {
+                            "id": "date-of-birth",
+                            "question_variants": [
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "date-of-birth-answer",
+                                                "mandatory": true,
+                                                "maximum": {
+                                                    "value": "now"
+                                                },
+                                                "minimum": {
+                                                    "offset_by": {
+                                                        "years": -115
+                                                    },
+                                                    "value": "2019-10-13"
+                                                },
+                                                "type": "Date"
+                                            }
+                                        ],
+                                        "guidance": {
+                                            "contents": [
+                                                {
+                                                    "description": "For example 31 12 1970"
+                                                }
+                                            ]
+                                        },
+                                        "id": "date-of-birth-question",
+                                        "title": "What is your date of birth?",
+                                        "type": "General"
+                                    },
+                                    "when": {
+                                        "==": [
+                                            {
+                                                "source": "answers",
+                                                "identifier": "proxy-answer"
+                                            },
+                                            "No, I’m answering for myself"
+                                        ]
+                                    }
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "date-of-birth-answer",
+                                                "mandatory": true,
+                                                "maximum": {
+                                                    "value": "now"
+                                                },
+                                                "minimum": {
+                                                    "offset_by": {
+                                                        "years": -115
+                                                    },
+                                                    "value": "2019-10-13"
+                                                },
+                                                "type": "Date"
+                                            }
+                                        ],
+                                        "guidance": {
+                                            "contents": [
+                                                {
+                                                    "description": "For example 31 12 1970"
+                                                }
+                                            ]
+                                        },
+                                        "id": "date-of-birth-question",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name_possessive",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": [
+                                                                    {
+                                                                        "source": "answers",
+                                                                        "identifier": "first-name"
+                                                                    },
+                                                                    {
+                                                                        "source": "answers",
+                                                                        "identifier": "last-name"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        },
+                                                        {
+                                                            "arguments": {
+                                                                "string_to_format": {
+                                                                    "source": "previous_transform"
+                                                                }
+                                                            },
+                                                            "transform": "format_possessive"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "What is <em>{person_name_possessive}</em> date of birth?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": {
+                                        "==": [
+                                            {
+                                                "source": "answers",
+                                                "identifier": "proxy-answer"
+                                            },
+                                            "Yes"
+                                        ]
+                                    }
+                                }
+                            ],
+                            "type": "Question"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/schemas/test/en/test_hub_section_required_with_repeat_supplementary.json
+++ b/schemas/test/en/test_hub_section_required_with_repeat_supplementary.json
@@ -1,0 +1,414 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "language": "en",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.3",
+    "survey_id": "123",
+    "title": "Test Hub Enabled with Repeats Using Supplementary Data",
+    "theme": "default",
+    "description": "A questionnaire to demo the Hub enabled when repeating sections using Supplementary data are complete.",
+    "metadata": [
+        {
+            "name": "survey_id",
+            "type": "string"
+        },
+        {
+            "name": "user_id",
+            "type": "string"
+        },
+        {
+            "name": "period_id",
+            "type": "string"
+        },
+        {
+            "name": "ru_name",
+            "type": "string"
+        },
+        {
+            "name": "sds_dataset_id",
+            "type": "string"
+        }
+    ],
+    "supplementary_data": {
+        "lists": ["employees"]
+    },
+    "questionnaire_flow": {
+        "type": "Hub",
+        "options": {
+            "required_completed_sections": ["introduction-section", "section-2", "section-3"]
+        }
+    },
+    "post_submission": {
+        "view_response": true
+    },
+    "sections": [
+        {
+            "id": "introduction-section",
+            "title": "Introduction",
+            "groups": [
+                {
+                    "id": "introduction-group",
+                    "title": "Introduction Group",
+                    "blocks": [
+                        {
+                            "id": "loaded-successfully-block",
+                            "type": "Interstitial",
+                            "content": {
+                                "title": "Supplementary Data",
+                                "contents": [
+                                    {
+                                        "title": "You have successfully loaded Supplementary data",
+                                        "description": "Press continue to proceed to the introduction",
+                                        "guidance": {
+                                            "contents": [
+                                                {
+                                                    "description": "The purpose of this block, is to test that supplementary data loads successfully, separate to using the supplementary data"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "id": "introduction-block",
+                            "type": "Introduction",
+                            "primary_content": [
+                                {
+                                    "id": "business-details",
+                                    "title": {
+                                        "text": "You are completing this survey for {company_name}",
+                                        "placeholders": [
+                                            {
+                                                "placeholder": "company_name",
+                                                "value": {
+                                                    "source": "supplementary_data",
+                                                    "identifier": "company_name"
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "contents": [
+                                        {
+                                            "description": {
+                                                "text": "If the company details or structure have changed contact us on {telephone_number_link}",
+                                                "placeholders": [
+                                                    {
+                                                        "placeholder": "telephone_number_link",
+                                                        "value": {
+                                                            "source": "supplementary_data",
+                                                            "identifier": "company_details",
+                                                            "selectors": ["telephone_number"]
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        {
+                                            "guidance": {
+                                                "contents": [
+                                                    {
+                                                        "title": "Guidance for completing this survey",
+                                                        "list": [
+                                                            "The company name, telephone number all come from supplementary data",
+                                                            "if you picked the supplementary dataset with guidance, there will be a 3rd bullet point below this one, with the supplementary guidance.",
+                                                            {
+                                                                "text": "{survey_guidance}",
+                                                                "placeholders": [
+                                                                    {
+                                                                        "placeholder": "survey_guidance",
+                                                                        "transforms": [
+                                                                            {
+                                                                                "transform": "first_non_empty_item",
+                                                                                "arguments": {
+                                                                                    "items": [
+                                                                                        {
+                                                                                            "source": "supplementary_data",
+                                                                                            "identifier": "guidance"
+                                                                                        }
+                                                                                    ]
+                                                                                }
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "section-2",
+            "title": "Employees",
+            "groups": [
+                {
+                    "id": "employee-reporting",
+                    "blocks": [
+                        {
+                            "id": "list-collector-employees",
+                            "type": "ListCollectorContent",
+                            "page_title": "Employees",
+                            "for_list": "employees",
+                            "content": {
+                                "title": "Employees",
+                                "contents": [
+                                    {
+                                        "definition": {
+                                            "title": "Company employees",
+                                            "contents": [
+                                                {
+                                                    "description": "List of previously reported employees."
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "description": "You have previously reported on the above employees. Press continue to proceed to the next section where you can add any additional employees."
+                                    }
+                                ]
+                            },
+                            "summary": {
+                                "title": "employees",
+                                "item_title": {
+                                    "text": "{employee_name}",
+                                    "placeholders": [
+                                        {
+                                            "placeholder": "employee_name",
+                                            "transforms": [
+                                                {
+                                                    "arguments": {
+                                                        "delimiter": " ",
+                                                        "list_to_concatenate": [
+                                                            {
+                                                                "source": "supplementary_data",
+                                                                "identifier": "employees",
+                                                                "selectors": ["personal_details", "forename"]
+                                                            },
+                                                            {
+                                                                "source": "supplementary_data",
+                                                                "identifier": "employees",
+                                                                "selectors": ["personal_details", "surname"]
+                                                            }
+                                                        ]
+                                                    },
+                                                    "transform": "concatenate_list"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "section-3",
+            "title": "Employee Details",
+            "summary": {
+                "show_on_completion": true
+            },
+            "repeat": {
+                "for_list": "employees",
+                "title": {
+                    "text": "{employee_name}",
+                    "placeholders": [
+                        {
+                            "placeholder": "employee_name",
+                            "transforms": [
+                                {
+                                    "arguments": {
+                                        "delimiter": " ",
+                                        "list_to_concatenate": [
+                                            {
+                                                "source": "supplementary_data",
+                                                "identifier": "employees",
+                                                "selectors": ["personal_details", "forename"]
+                                            },
+                                            {
+                                                "source": "supplementary_data",
+                                                "identifier": "employees",
+                                                "selectors": ["personal_details", "surname"]
+                                            }
+                                        ]
+                                    },
+                                    "transform": "concatenate_list"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            "groups": [
+                {
+                    "id": "employee-detail-questions",
+                    "blocks": [
+                        {
+                            "type": "Question",
+                            "id": "length-of-employment",
+                            "question": {
+                                "id": "length-employment-question",
+                                "type": "General",
+                                "title": {
+                                    "text": "When did {employee_name} start working for {company_name}?",
+                                    "placeholders": [
+                                        {
+                                            "placeholder": "company_name",
+                                            "value": {
+                                                "source": "supplementary_data",
+                                                "identifier": "company_name"
+                                            }
+                                        },
+                                        {
+                                            "placeholder": "employee_name",
+                                            "transforms": [
+                                                {
+                                                    "arguments": {
+                                                        "delimiter": " ",
+                                                        "list_to_concatenate": [
+                                                            {
+                                                                "source": "supplementary_data",
+                                                                "identifier": "employees",
+                                                                "selectors": ["personal_details", "forename"]
+                                                            },
+                                                            {
+                                                                "source": "supplementary_data",
+                                                                "identifier": "employees",
+                                                                "selectors": ["personal_details", "surname"]
+                                                            }
+                                                        ]
+                                                    },
+                                                    "transform": "concatenate_list"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "answers": [
+                                    {
+                                        "id": "employment-start",
+                                        "label": {
+                                            "text": "Start date at {company_name}",
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "company_name",
+                                                    "value": {
+                                                        "source": "supplementary_data",
+                                                        "identifier": "company_name"
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "mandatory": true,
+                                        "type": "Date",
+                                        "maximum": {
+                                            "value": "now"
+                                        },
+                                        "minimum": {
+                                            "value": {
+                                                "source": "supplementary_data",
+                                                "identifier": "incorporation_date"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "id": "conditional-employee-block",
+                            "type": "Question",
+                            "skip_conditions": {
+                                "when": {
+                                    "!=": [
+                                        {
+                                            "count": [
+                                                {
+                                                    "source": "list",
+                                                    "identifier": "employees"
+                                                }
+                                            ]
+                                        },
+                                        3
+                                    ]
+                                }
+                            },
+                            "question": {
+                                "id": "conditional-employee-question",
+                                "guidance": {
+                                    "contents": [
+                                        {
+                                            "description": "This block is enabled because there are 3 employees in the supplementary dataset"
+                                        }
+                                    ]
+                                },
+                                "type": "General",
+                                "title": {
+                                    "text": "Has {employee_name} been promoted since starting at {company_name}?",
+                                    "placeholders": [
+                                        {
+                                            "placeholder": "company_name",
+                                            "value": {
+                                                "source": "supplementary_data",
+                                                "identifier": "company_name"
+                                            }
+                                        },
+                                        {
+                                            "placeholder": "employee_name",
+                                            "transforms": [
+                                                {
+                                                    "arguments": {
+                                                        "delimiter": " ",
+                                                        "list_to_concatenate": [
+                                                            {
+                                                                "source": "supplementary_data",
+                                                                "identifier": "employees",
+                                                                "selectors": ["personal_details", "forename"]
+                                                            },
+                                                            {
+                                                                "source": "supplementary_data",
+                                                                "identifier": "employees",
+                                                                "selectors": ["personal_details", "surname"]
+                                                            }
+                                                        ]
+                                                    },
+                                                    "transform": "concatenate_list"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "answers": [
+                                    {
+                                        "id": "promoted-yes-no-answer",
+                                        "mandatory": true,
+                                        "type": "Radio",
+                                        "options": [
+                                            {
+                                                "label": "Yes",
+                                                "value": "Yes"
+                                            },
+                                            {
+                                                "label": "No",
+                                                "value": "No"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/tests/app/questionnaire/test_router.py
+++ b/tests/app/questionnaire/test_router.py
@@ -112,6 +112,126 @@ class TestRouter(RouterTestCase):
 
         assert expected_path == routing_path
 
+    def test_can_access_hub(self):
+        self.schema = load_schema_from_name(
+            "test_repeating_sections_with_hub_and_spoke"
+        )
+
+        assert self.router.can_access_hub()
+
+    def test_can_access_hub_with_required_sections_enabled_and_sections_complete(self):
+        self.schema = load_schema_from_name("test_hub_section_required_and_enabled")
+
+        self.data_stores.progress_store = ProgressStore(
+            [
+                ProgressDict(
+                    section_id="household-section",
+                    block_ids=["household-relationships-block"],
+                    status=CompletionStatus.COMPLETED,
+                ),
+                ProgressDict(
+                    section_id="relationships-section",
+                    block_ids=["relationships-count"],
+                    status=CompletionStatus.COMPLETED,
+                ),
+            ],
+        )
+
+        assert self.router.can_access_hub()
+
+    def test_can_access_hub_with_required_sections_enabled_and_section_incomplete(self):
+        self.schema = load_schema_from_name("test_hub_section_required_and_enabled")
+
+        self.data_stores.progress_store = ProgressStore(
+            [
+                ProgressDict(
+                    section_id="household-section",
+                    block_ids=["household-relationships-block"],
+                    status=CompletionStatus.IN_PROGRESS,
+                ),
+            ],
+        )
+
+        assert not self.router.can_access_hub()
+
+    def test_can_access_hub_with_required_sections_enabled_and_repeating_sections_complete(
+        self,
+    ):
+        self.schema = load_schema_from_name("test_hub_section_required_with_repeat")
+
+        self.data_stores.progress_store = ProgressStore(
+            [
+                ProgressDict(
+                    section_id="list-collector-section",
+                    block_ids=["primary-person-list-collector", "list-collector"],
+                    status=CompletionStatus.COMPLETED,
+                ),
+                ProgressDict(
+                    section_id="personal-details-section",
+                    block_ids=["proxy", "date-of-birth"],
+                    status=CompletionStatus.COMPLETED,
+                    list_item_id="XLvVvS",
+                ),
+                ProgressDict(
+                    section_id="personal-details-section",
+                    block_ids=["proxy", "date-of-birth"],
+                    status=CompletionStatus.COMPLETED,
+                    list_item_id="mJPRpW",
+                ),
+            ],
+        )
+
+        self.data_stores.list_store = ListStore(
+            [
+                {
+                    "items": ["XLvVvS", "mJPRpW"],
+                    "name": "people",
+                    "primary_person": "XLvVvS",
+                }
+            ]
+        )
+
+        assert self.router.can_access_hub()
+
+    def test_can_access_hub_with_required_sections_enabled_and_repeating_sections_incomplete(
+        self,
+    ):
+        self.schema = load_schema_from_name("test_hub_section_required_with_repeat")
+
+        self.data_stores.progress_store = ProgressStore(
+            [
+                ProgressDict(
+                    section_id="list-collector-section",
+                    block_ids=["primary-person-list-collector", "list-collector"],
+                    status=CompletionStatus.COMPLETED,
+                ),
+                ProgressDict(
+                    section_id="personal-details-section",
+                    block_ids=["proxy", "date-of-birth"],
+                    status=CompletionStatus.COMPLETED,
+                    list_item_id="XLvVvS",
+                ),
+                ProgressDict(
+                    section_id="personal-details-section",
+                    block_ids=["proxy"],
+                    status=CompletionStatus.IN_PROGRESS,
+                    list_item_id="mJPRpW",
+                ),
+            ],
+        )
+
+        self.data_stores.list_store = ListStore(
+            [
+                {
+                    "items": ["XLvVvS", "mJPRpW"],
+                    "name": "people",
+                    "primary_person": "XLvVvS",
+                }
+            ]
+        )
+
+        assert not self.router.can_access_hub()
+
 
 class TestRouterPathCompletion(RouterTestCase):
     def test_is_complete(self):

--- a/tests/functional/spec/features/hub_and_spoke/hub_and_spoke.spec.js
+++ b/tests/functional/spec/features/hub_and_spoke/hub_and_spoke.spec.js
@@ -295,7 +295,7 @@ describe("Feature: Hub and Spoke", () => {
       });
     });
 
-    it("When the repeating sections are complete. Then the hub should be displayed", async () => {
+    it("When all the repeating sections are complete, Then the hub should be displayed", async () => {
       await click(LoadedSuccessfullyBlockPage.submit());
       await click(IntroductionBlockPage.submit());
 

--- a/tests/functional/spec/features/hub_and_spoke/hub_and_spoke.spec.js
+++ b/tests/functional/spec/features/hub_and_spoke/hub_and_spoke.spec.js
@@ -246,7 +246,7 @@ describe("Feature: Hub and Spoke", () => {
       await browser.openQuestionnaire("test_hub_section_required_with_repeat.json");
     });
 
-    it("When the repeating sections are complete. Then the hub should be displayed", async () => {
+    it("When all the repeating sections are complete, Then the hub should be displayed", async () => {
       await $(PrimaryPersonListCollectorPage.yes()).click();
       await $(PrimaryPersonListCollectorPage.submit()).click();
       await $(PrimaryPersonListCollectorAddPage.firstName()).setValue("Marcus");

--- a/tests/functional/spec/features/hub_and_spoke/hub_and_spoke.spec.js
+++ b/tests/functional/spec/features/hub_and_spoke/hub_and_spoke.spec.js
@@ -12,9 +12,11 @@ import ListCollectorSectionSummaryPage from "../../../generated_pages/hub_sectio
 import ProxyRepeatPage from "../../../generated_pages/hub_section_required_with_repeat/proxy.page.js";
 import { click } from "../../../helpers";
 import DateOfBirthPage from "../../../generated_pages/hub_section_required_with_repeat/date-of-birth.page";
-import PrimaryPersonListCollectorPage from "../../../generated_pages/relationships_primary/primary-person-list-collector.page";
-import PrimaryPersonListCollectorAddPage from "../../../generated_pages/relationships_primary/primary-person-list-collector-add.page";
-import ListCollectorPage from "../../../generated_pages/relationships_primary/list-collector.page";
+import PrimaryPersonListCollectorPage from "../../../generated_pages/hub_section_required_with_repeat/primary-person-list-collector.page";
+import PrimaryPersonListCollectorAddPage from "../../../generated_pages/hub_section_required_with_repeat/primary-person-list-collector-add.page";
+import ListCollectorPage from "../../../generated_pages/hub_section_required_with_repeat/list-collector.page";
+import ListCollectorAddPage from "../../../generated_pages/hub_section_required_with_repeat/list-collector-add.page";
+import RepeatingSummaryPage from "../../../generated_pages/hub_section_required_with_repeat/personal-details-section-summary.page";
 import { getRandomString } from "../../../jwt_helper";
 import LoadedSuccessfullyBlockPage from "../../../generated_pages/hub_section_required_with_repeat_supplementary/loaded-successfully-block.page";
 import IntroductionBlockPage from "../../../generated_pages/hub_section_required_with_repeat_supplementary/introduction-block.page";
@@ -252,20 +254,36 @@ describe("Feature: Hub and Spoke", () => {
       await $(PrimaryPersonListCollectorAddPage.firstName()).setValue("Marcus");
       await $(PrimaryPersonListCollectorAddPage.lastName()).setValue("Twin");
       await click(PrimaryPersonListCollectorAddPage.submit());
+      await $(ListCollectorPage.yes()).click();
+      await $(ListCollectorPage.submit()).click();
+      await $(ListCollectorAddPage.firstName()).setValue("John");
+      await $(ListCollectorAddPage.lastName()).setValue("Doe");
+      await click(ListCollectorAddPage.submit());
       await $(ListCollectorPage.no()).click();
       await $(ListCollectorPage.submit()).click();
       await click(ListCollectorSectionSummaryPage.submit());
 
+      // Try to access the hub
+      await browser.url(HubPage.url());
+
+      // Redirected to the repeating sections to be completed
       await $(ProxyRepeatPage.yes()).click();
       await $(ProxyRepeatPage.submit()).click();
       await $(DateOfBirthPage.day()).setValue(12);
       await $(DateOfBirthPage.month()).setValue(4);
       await $(DateOfBirthPage.year()).setValue(2021);
       await click(DateOfBirthPage.submit());
+      await $(RepeatingSummaryPage.submit()).click();
+      await $(ProxyRepeatPage.yes()).click();
+      await $(ProxyRepeatPage.submit()).click();
+      await $(DateOfBirthPage.day()).setValue(1);
+      await $(DateOfBirthPage.month()).setValue(1);
+      await $(DateOfBirthPage.year()).setValue(2000);
+      await $(RepeatingSummaryPage.submit()).click();
       await expect(browser).toHaveUrlContaining(HubPage.url());
     });
 
-    it("When the repeating sections are incomplete. Then the hub should not be displayed", async () => {
+    it("When the repeating sections are incomplete, Then the hub should not be displayed", async () => {
       await $(PrimaryPersonListCollectorPage.yes()).click();
       await $(PrimaryPersonListCollectorPage.submit()).click();
       await $(PrimaryPersonListCollectorAddPage.firstName()).setValue("Marcus");

--- a/tests/integration/questionnaire/test_questionnaire_hub.py
+++ b/tests/integration/questionnaire/test_questionnaire_hub.py
@@ -177,3 +177,50 @@ class TestQuestionnaireHub(IntegrationTestCase):
 
         # Then I should be redirected to the second section
         self.assertEqualUrl("/questionnaire/relationships-count/")
+
+    def test_hub_section_enabled_and_accessible_with_repeating_sections(self):
+        # Given the hub is enabled and there are two required sections (and one is for a repeat)
+        self.launchSurvey("test_hub_section_required_with_repeat")
+
+        # When I answer I complete the first section and the repeating section
+        self.post({"you-live-here": "Yes"})
+        self.post({"first-name": "John", "last-name": "Doe"})
+        self.post({"anyone-else": "No"})
+        self.post()
+        self.post({"proxy-answer": "Yes"})
+        self.post(
+            {
+                "date-of-birth-answer-day": 1,
+                "date-of-birth-answer-month": 2,
+                "date-of-birth-answer-year": 1999,
+            }
+        )
+        self.post()
+
+        # Then I should see the hub
+        self.assertEqualUrl(HUB_URL_PATH)
+
+    def test_hub_section_is_inaccessible_when_all_repeats_not_complete(self):
+        # Given the hub is enabled and there are two required sections (and one is for a repeat)
+        self.launchSurvey("test_hub_section_required_with_repeat")
+
+        # When I  complete the first section and the first repeat, but not the second repeat
+        self.post({"you-live-here": "Yes"})
+        self.post({"first-name": "John", "last-name": "Doe"})
+        self.post({"anyone-else": "Yes"})
+        self.post({"first-name": "Jane", "last-name": "Doe"})
+        self.post({"anyone-else": "No"})
+        self.post()
+        self.post({"proxy-answer": "Yes"})
+        self.post(
+            {
+                "date-of-birth-answer-day": 1,
+                "date-of-birth-answer-month": 2,
+                "date-of-birth-answer-year": 1999,
+            }
+        )
+        self.post()
+
+        # Then the hub should not yet be accessible
+        self.get(HUB_URL_PATH)
+        self.assertInUrl("/proxy")


### PR DESCRIPTION
### What is the context of this PR?

Previously the `required_completed_sections` field in our schemas did not work for repeating sections. This change allows the hub to be toggled on/off based the completeness of a repeating section.

### How to review

Use the `test_hub_section_required_with_repeat` schema, and check that you are only able to access the hub page once you have completed all of the repeating sections. Also added `test_hub_section_required_with_repeat_supplementary` to demo the same functionality with a repeating section that is being populated with a list sourced from supplementary data. 

### Checklist
* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
