### PR TITLE
Ignore node_modules in pylint and fix useless suppression warnings

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -48,7 +48,7 @@ ignore=CVS
 # ignore-list. The regex matches against paths and can be in Posix or Windows
 # format. Because '\' represents the directory delimiter on Windows systems, it
 # can't be used as an escape character.
-ignore-paths=
+ignore-paths=node_modules
 
 # Files or directories matching the regular expression patterns are skipped.
 # The regex matches against base names, not paths. The default value ignores

--- a/tests/app/data_model/conftest.py
+++ b/tests/app/data_model/conftest.py
@@ -1,4 +1,3 @@
-# pylint: disable=redefined-outer-name
 from datetime import datetime, timedelta, timezone
 
 import pytest

--- a/tests/app/helpers/test_template_helpers.py
+++ b/tests/app/helpers/test_template_helpers.py
@@ -1,4 +1,3 @@
-# pylint: disable=too-many-lines
 from typing import Type
 
 import pytest


### PR DESCRIPTION
### What is the context of this PR?

Updates the `pylintrc` file so that node_modules are ignored, as warnings relating to those files were being output when `make lint-python` was being run.

Removes two pylint ignores that are no longer needed.

### How to review

Run `make lint-python` and check that there are no issues

### Checklist
* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
