### PR TITLE
Update README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
 # eQ Questionnaire Runner
 
-![Build Status](https://github.com/ONSdigital/eq-questionnaire-runner/workflows/main/badge.svg)
-[![codecov](https://codecov.io/gh/ONSdigital/eq-questionnaire-runner/branch/main/graph/badge.svg)](https://codecov.io/gh/ONSdigital/eq-questionnaire-runner/branch/main)
-[![Codacy Badge](https://api.codacy.com/project/badge/Grade/4c39ddd3285748f8bfb6b70fd5aaf9cc)](https://www.codacy.com/manual/ONSDigital/eq-questionnaire-runner?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=ONSdigital/eq-questionnaire-runner&amp;utm_campaign=Badge_Grade)
+[![Build Status](https://github.com/ONSdigital/eq-questionnaire-runner/actions/workflows/main.yml/badge.svg)](https://github.com/ONSdigital/eq-questionnaire-runner/actions/workflows/main.yml)
+[![Build Status](https://github.com/ONSdigital/eq-questionnaire-runner/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/ONSdigital/eq-questionnaire-runner/actions/workflows/codeql-analysis.yml)
+![Coverage](https://img.shields.io/badge/Coverage-100%25-2FC050.svg)
+
+[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+[![Checked with mypy](https://www.mypy-lang.org/static/mypy_badge.svg)](https://mypy-lang.org/)
+[![poetry-managed](https://img.shields.io/badge/poetry-managed-blue)](https://python-poetry.org/)
+[![License - MIT](https://img.shields.io/badge/licence%20-MIT-1ac403.svg)](https://github.com/ONSdigital/eq-questionnaire-runner/blob/main/LICENSE)
 
 ## Run with Docker
 


### PR DESCRIPTION
### What is the context of this PR?
What it says on the tin.

Codecov badge has been removed as we no longer use Codecov.

### How to review
- Ensure the badges render correctly. https://github.com/ONSdigital/eq-questionnaire-runner/blob/update-readme-badges/README.md
- Is there anything else we would like to add?

### Checklist
* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
