### PR TITLE
Update to Docker Compose v2

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -142,11 +142,11 @@ jobs:
       - name: Install npm deps
         run: npm install
       - name: Docker compose
-        run: docker-compose --version && RUNNER_ENV_FILE=.functional-tests.env docker-compose up --build -d
+        run: docker compose --version && RUNNER_ENV_FILE=.functional-tests.env docker compose up --build -d
       - name: Functional tests
         run: make test-functional-suite SUITE=${{ matrix.suite }}
       - name: Docker compose shutdown
-        run: RUNNER_ENV_FILE=.functional-tests.env docker-compose kill
+        run: RUNNER_ENV_FILE=.functional-tests.env docker compose kill
   docker-push:
     runs-on: ubuntu-22.04
     steps:

--- a/Makefile
+++ b/Makefile
@@ -100,19 +100,19 @@ run-uwsgi-async: link-development-env
 	WEB_SERVER_TYPE=uwsgi-async pipenv run ./run_app.sh
 
 dev-compose-up:
-	docker-compose -f docker-compose-dev-mac.yml pull eq-questionnaire-launcher
-	docker-compose -f docker-compose-dev-mac.yml pull sds
-	docker-compose -f docker-compose-dev-mac.yml pull cir
-	docker-compose -f docker-compose-dev-mac.yml up -d
+	docker compose -f docker-compose-dev-mac.yml pull eq-questionnaire-launcher
+	docker compose -f docker-compose-dev-mac.yml pull sds
+	docker compose -f docker-compose-dev-mac.yml pull cir
+	docker compose -f docker-compose-dev-mac.yml up -d
 
 dev-compose-up-linux:
-	docker-compose -f docker-compose-dev-linux.yml up -d
+	docker compose -f docker-compose-dev-linux.yml up -d
 
 dev-compose-down:
-	docker-compose -f docker-compose-dev-mac.yml down
+	docker compose -f docker-compose-dev-mac.yml down
 
 dev-compose-down-linux:
-	docker-compose -f docker-compose-dev-linux.yml down
+	docker compose -f docker-compose-dev-linux.yml down
 
 profile:
 	pipenv run python profile_application.py

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Install Docker for your system: [https://www.docker.com/](https://www.docker.com
 To get eq-questionnaire-runner running the following command will build and run the containers
 
 ``` shell
-RUNNER_ENV_FILE=.development.env docker-compose up -d
+RUNNER_ENV_FILE=.development.env docker compose up -d
 ```
 
 To launch a survey, navigate to [http://localhost:8000/](http://localhost:8000/)
@@ -22,13 +22,13 @@ However, any new dependencies that are added would require a re-build.
 To rebuild the eq-questionnaire-runner container, the following command can be used.
 
 ``` shell
-RUNNER_ENV_FILE=.development.env docker-compose build
+RUNNER_ENV_FILE=.development.env docker compose build
 ```
 
 If you need to rebuild the container from scratch to re-load any dependencies then you can run the following
 
 ``` shell
-RUNNER_ENV_FILE=.development.env docker-compose build --no-cache
+RUNNER_ENV_FILE=.development.env docker compose build --no-cache
 ```
 
 ## Run locally

--- a/scripts/run_validator.sh
+++ b/scripts/run_validator.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 tag=latest
-TAG=${tag} docker-compose -f docker-compose-schema-validator.yml up -d
+TAG=${tag} docker compose -f docker-compose-schema-validator.yml up -d


### PR DESCRIPTION
### What is the context of this PR?
`docker-compose`  command not being found on GIthub actions. It is due to docker-compose  being a V1 Docker  Compose Command which is now removed. 
This PR fixes this issue by using the V2 command `docker compose` for actions and all of runner.

### How to review
- Check if Github Actions work with the new Docker Compose
- Check the new Docker Compose command mentioned in the README works as expected. (Make sure you are on compose v2 https://docs.docker.com/compose/migrate/)
- Ensure there are no reference using the old `docker-compose` format.

### Checklist
* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
