### PR TITLE
Address DAC issue update visually hidden text on change and remove links

### DIFF
--- a/app/jinja_filters.py
+++ b/app/jinja_filters.py
@@ -437,7 +437,7 @@ class SummaryAction:
         edit_link_aria_label: str,
     ) -> None:
         self.text = edit_link_text
-        self.visuallyHiddenText = edit_link_aria_label + " " + item_title
+        self.visuallyHiddenText = f'{edit_link_aria_label} {item_title}'
         self.url = answer["link"]
 
         self.attributes = {
@@ -679,7 +679,7 @@ def map_list_collector_config(
             }
 
             if edit_link_aria_label:
-                edit_link_hidden_text = edit_link_aria_label.format(item_name=item_name)
+                edit_link_hidden_text = f'{edit_link_aria_label.format(item_name=item_name)} {item_name}'
             edit_link["visuallyHiddenText"] = edit_link_hidden_text
 
             actions.append(edit_link)
@@ -693,7 +693,7 @@ def map_list_collector_config(
             actions.append(
                 {
                     "text": remove_link_text,
-                    "visuallyHiddenText": remove_link_hidden_text,
+                    "visuallyHiddenText": f'{remove_link_hidden_text} {item_name}',
                     "url": list_item.get("remove_link"),
                     "attributes": {"data-qa": f"list-item-remove-{index}-link"},
                 }

--- a/templates/partials/summary/summary.html
+++ b/templates/partials/summary/summary.html
@@ -16,23 +16,23 @@
           {% do summary_groups.append
             (
               {
-                  "groupTitle": group.title if group.title else None,
-                  "id": group.id if group.id else None,
-                  "rows": map_summary_item_config(
-                    group=group,
-                    summary_type=summary_type,
-                    answers_are_editable=content.summary.answers_are_editable,
-                    no_answer_provided=_("No answer provided"),
-                    remove_link_text=_("Remove") if not view_submitted_response else "",
-                    remove_link_aria_label=_("Remove your answer for:") if not view_submitted_response else "",
-                    edit_link_text=_("Change") if not view_submitted_response else "",
-                    edit_link_aria_label=_("Change your answer for:") if not view_submitted_response else "",
-                    calculated_question=content.summary.calculated_question
-                  ),
-                  "classes": "ons-u-mt-m" if loop.index > 1 else "",
-                  "placeholderText": group.placeholder_text,
-                  "summaryLink": group.links.add_link,
-                }
+                "groupTitle": group.title if group.title else None,
+                "id": group.id if group.id else None,
+                "rows": map_summary_item_config(
+                  group=group,
+                  summary_type=summary_type,
+                  answers_are_editable=content.summary.answers_are_editable,
+                  no_answer_provided=_("No answer provided"),
+                  remove_link_text=_("Remove") if not view_submitted_response else "",
+                  remove_link_aria_label=_("Remove your answer for:") if not view_submitted_response else "",
+                  edit_link_text=_("Change") if not view_submitted_response else "",
+                  edit_link_aria_label=_("Change your answer for:") if not view_submitted_response else "",
+                  calculated_question=content.summary.calculated_question
+                ),
+                "classes": "ons-u-mt-m" if loop.index > 1 else "",
+                "placeholderText": group.placeholder_text,
+                "summaryLink": group.links.add_link,
+              }
             )
           %}
         {%- endif -%}

--- a/tests/app/test_jinja_filters.py
+++ b/tests/app/test_jinja_filters.py
@@ -599,7 +599,7 @@ def test_map_list_collector_config():
                 {
                     "actions": [
                         {
-                            "visuallyHiddenText": "edit_link_aria_label",
+                            "visuallyHiddenText": "edit_link_aria_label Mark Bloggs (You)",
                             "attributes": {"data-qa": "list-item-change-1-link"},
                             "text": "edit_link_text",
                             "url": "/primary/change",
@@ -620,13 +620,13 @@ def test_map_list_collector_config():
                 {
                     "actions": [
                         {
-                            "visuallyHiddenText": "edit_link_aria_label",
+                            "visuallyHiddenText": "edit_link_aria_label Joe Bloggs",
                             "attributes": {"data-qa": "list-item-change-2-link"},
                             "text": "edit_link_text",
                             "url": "/nonprimary/change",
                         },
                         {
-                            "visuallyHiddenText": "remove_link_aria_label",
+                            "visuallyHiddenText": "remove_link_aria_label Joe Bloggs",
                             "attributes": {"data-qa": "list-item-remove-2-link"},
                             "text": "remove_link_text",
                             "url": "/nonprimary/remove",
@@ -715,13 +715,13 @@ def test_map_list_collector_config_with_related_answers_and_answer_title():
                 {
                     "actions": [
                         {
-                            "visuallyHiddenText": "edit_link_aria_label",
+                            "visuallyHiddenText": "edit_link_aria_label Name of UK company or branch",
                             "attributes": {"data-qa": "list-item-change-1-link"},
                             "text": "edit_link_text",
                             "url": "/nonprimary/change",
                         },
                         {
-                            "visuallyHiddenText": "remove_link_aria_label",
+                            "visuallyHiddenText": "remove_link_aria_label Name of UK company or branch",
                             "attributes": {"data-qa": "list-item-remove-1-link"},
                             "text": "remove_link_text",
                             "url": "/nonprimary/remove",
@@ -1006,13 +1006,13 @@ def test_summary_item_config_with_list_collector():
                 {
                     "actions": [
                         {
-                            "visuallyHiddenText": "Change your answer for:",
+                            "visuallyHiddenText": "Change your answer for: Company A",
                             "attributes": {"data-qa": "list-item-change-1-link"},
                             "text": "Change",
                             "url": "change_link_url",
                         },
                         {
-                            "visuallyHiddenText": "Remove Company A",
+                            "visuallyHiddenText": "Remove your answer for: Company A",
                             "attributes": {"data-qa": "list-item-remove-1-link"},
                             "text": "Remove",
                             "url": "remove_link_url",
@@ -1143,7 +1143,7 @@ def test_summary_item_config_with_list_collector():
         summary_type="SectionSummary",
         answers_are_editable=True,
         no_answer_provided="No answer Provided",
-        remove_link_aria_label="Remove Company A",
+        remove_link_aria_label="Remove your answer for:",
         remove_link_text="Remove",
         edit_link_text="Change",
         edit_link_aria_label="Change your answer for:",
@@ -1161,13 +1161,15 @@ def test_summary_item_config_with_list_collector_and_one_related_answer():
                 {
                     "actions": [
                         {
-                            "visuallyHiddenText": "Change your answer for:",
+                            "visuallyHiddenText": "Change your answer for: "
+                            "Company A",
                             "attributes": {"data-qa": "list-item-change-1-link"},
                             "text": "Change",
                             "url": "change_link_url",
                         },
                         {
-                            "visuallyHiddenText": "Remove Company A",
+                            "visuallyHiddenText": "Remove your answer for: "
+                            "Company A",
                             "attributes": {"data-qa": "list-item-remove-1-link"},
                             "text": "Remove",
                             "url": "remove_link_url",
@@ -1262,7 +1264,7 @@ def test_summary_item_config_with_list_collector_and_one_related_answer():
         summary_type="SectionSummary",
         answers_are_editable=True,
         no_answer_provided="No answer Provided",
-        remove_link_aria_label="Remove Company A",
+        remove_link_aria_label="Remove your answer for:",
         remove_link_text="Remove",
         edit_link_text="Change",
         edit_link_aria_label="Change your answer for:",


### PR DESCRIPTION
### What is the context of this PR?
This PR makes the change to append the item title on to the change and remove link hidden text for summary items created from list collectors. This is already done for other summary items which I have updated to use f strings.

This fixes a DAC issue where the title of the row isn't added to the hidden text on the link so users that use screen readers don't get the full context of the link.

### How to review
- Launch the `test_grand_calculated_summary_inside_repeating_section` schema
- Progress through the survey until you get to the vehicle costs summary
- Check the visually hidden text on the links all add the row title on to the end of "Change your answer for:" or "Remove your answer for:" and does not just contain that text.
- Compare this with main
- The difference should be seen on the "Road Tax" and "Parking Permit" rows

### Checklist
* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
