### PR TITLE
Fix version obsolete warning

### DIFF
--- a/docker-compose-dev-linux.yml
+++ b/docker-compose-dev-linux.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
     datastore:
         image: knarz/datastore-emulator

--- a/docker-compose-dev-mac.yml
+++ b/docker-compose-dev-mac.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
     datastore:
         image: knarz/datastore-emulator

--- a/docker-compose-schema-validator.yml
+++ b/docker-compose-schema-validator.yml
@@ -1,6 +1,3 @@
----
-version: '3'
-
 services:
   ajv-validator:
     image: onsdigital/eq-questionnaire-validator:${TAG}-ajv

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
 
     datastore:


### PR DESCRIPTION
### What is the context of this PR?
Noticed we are now getting a 'version' is obsolete warning when running `make dev-compose-up` locally. Found out the 'version' line is now considered obsolete from the `docker-compose.yml` file now (Docker version 25.0.5) so I have removed it to fix this warning.

<img width="905" alt="Screenshot 2024-04-24 at 11 19 20" src="https://github.com/ONSdigital/eq-questionnaire-runner/assets/42928680/533d727c-f3d7-490a-8559-ac65af717136">

### How to review
- Run `make dev-compose-up` and check that there are no warnings
- Run `make run-validator` and check that there are no warnings
- Compare this to the main branch when running these commands and you should see warnings

### Checklist
* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
