### PR TITLE
Ignore babel minor version dependabot bumps for now

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -59,9 +59,10 @@ updates:
           - "black"
           - "djlint"
     ignore:
-      - dependency-name: "pylint*"
-        update-types: [ "version-update:semver-major" ]
+      # Pinned to v2.14.0: problem for translations found with v2.15.0, see: https://github.com/ONSdigital/eq-questionnaire-runner/pull/1384
       - dependency-name: "babel"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: "pylint*"
         update-types: [ "version-update:semver-major" ]
       - dependency-name: "pytest*"
         update-types: ["version-update:semver-minor"]

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -59,7 +59,7 @@ updates:
           - "black"
           - "djlint"
     ignore:
-      # Pinned to v2.14.0: problem for translations found with v2.15.0, see: https://github.com/ONSdigital/eq-questionnaire-runner/pull/1384
+      # Temporarily pinned to v2.14.0 - problem for translations found in v2.15.0, see: https://github.com/ONSdigital/eq-questionnaire-runner/pull/1384
       - dependency-name: "babel"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
       - dependency-name: "pylint*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ pdfkit = "^1.0.0"
 ordered-set = "^4.1.0"
 cachetools = "^5.3.0.7"
 gevent = "^24.2.1"
-babel = "==2.14.0"
+babel = "==2.14.0"  # problem for translations found with v2.15.0 , see: https://github.com/ONSdigital/eq-questionnaire-runner/pull/1384
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ pdfkit = "^1.0.0"
 ordered-set = "^4.1.0"
 cachetools = "^5.3.0.7"
 gevent = "^24.2.1"
-babel = "==2.14.0"  # problem for translations found with v2.15.0 , see: https://github.com/ONSdigital/eq-questionnaire-runner/pull/1384
+babel = "==2.14.0"  # Temporarily pinned - problem for translations found in v2.15.0, see: https://github.com/ONSdigital/eq-questionnaire-runner/pull/1384
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
### What is the context of this PR?
Following a recent PR to pin the babel version to `v2.14.0`, we should temporarily prevent dependabot bumping the minor version to `v2.15.0` until the problem has been resolved because this is causing the build to fail.

### How to review
Fork this repo and trigger a dependabot PR from this branch - the babel minor version increment should be excluded and the build should pass

### Checklist
* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
