### PR TITLE
Update to Poetry 1.8.3

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
-          version: 1.8.2
+          version: 1.8.3
           virtualenvs-create: true
       - uses: actions/setup-python@v5
         with:
@@ -58,7 +58,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
-          version: 1.8.2
+          version: 1.8.3
           virtualenvs-create: true
       - uses: actions/setup-python@v5
         with:
@@ -98,7 +98,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
-          version: 1.8.2
+          version: 1.8.3
           virtualenvs-create: true
       - uses: actions/setup-python@v5
         with:
@@ -143,7 +143,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
-          version: 1.8.2
+          version: 1.8.3
           virtualenvs-create: true
       - uses: actions/setup-python@v5
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,10 +15,10 @@ ENV HTTP_KEEP_ALIVE 2
 ENV GUNICORN_CMD_ARGS -c gunicorn_config.py
 
 COPY pyproject.toml pyproject.toml
-COPY poetry.lock poetry.lock 
+COPY poetry.lock poetry.lock
 
 RUN groupadd -r appuser && useradd -r -g appuser -u 9000 appuser && chown -R appuser:appuser .
-RUN pip install "poetry==1.8.2" && \
+RUN pip install "poetry==1.8.3" && \
     poetry config virtualenvs.create false && \
     poetry install --only main && \
     make build

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ pip install --upgrade pip setuptools
 Install poetry, poetry dotenv plugin and install dependencies:
 
 ``` shell
-curl -sSL https://install.python-poetry.org | python3 - --version 1.8.2
+curl -sSL https://install.python-poetry.org | python3 - --version 1.8.3
 poetry self add poetry-plugin-dotenv
 poetry install
 ```


### PR DESCRIPTION
### What is the context of this PR?
Our test-unit GitHub action is currently failing because of the dotenv poetry plugin now depends on poetry >= v1.8.3. We are currently running v1.8.2, this PR updates that to v1.8.3.

### How to review
- GitHub actions pass
- Can run `poetry install` to install dependancies without error
- Can spin up runner and still launch schemas

### Checklist
* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
