### PR TITLE
Move babel ignore to the prod "pip" ecosystem

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -88,6 +88,10 @@ updates:
           - "cachetools"
           - "gevent"
           - "babel"
+    ignore:
+      # "babel" temporarily pinned to v2.14.0 - problem for translations found in v2.15.0, see: https://github.com/ONSdigital/eq-questionnaire-runner/pull/1384
+      - dependency-name: "babel"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
 
   - package-ecosystem: "pip"
     directory: "/"
@@ -123,7 +127,3 @@ updates:
           - "playwright"
           - "black"
           - "djlint"
-    ignore:
-      # "babel" temporarily pinned to v2.14.0 - problem for translations found in v2.15.0, see: https://github.com/ONSdigital/eq-questionnaire-runner/pull/1384
-      - dependency-name: "babel"
-        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]


### PR DESCRIPTION
### What is the context of this PR?
At the moment "babel" ignore exception in Dependabot config is added to the development ecosystem, it needs to be moved to the production one.

### How to review
Fork the repo with all branches, merge this branch, enable Dependabot, check if prod dependencies PRs raised don't have babel update anymore.

Proof of it working in a fork:
https://github.com/petechd/eq-questionnaire-runner/pull/4

### Checklist
* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
