### PR TITLE
Remove hub submit and npm caches

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -39,7 +39,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version-file : ".nvmrc"
-          cache: "npm"
       - name: Install npm deps
         run: npm install
   lint:
@@ -52,7 +51,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
-          cache: "npm"
       - name: Write app version
         run: printf "${{ github.event.pull_request.head.sha }}" > .application-version
       - name: Install Poetry
@@ -137,7 +135,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
-          cache: "npm"
       - run: |
           echo "PYTHON_VERSION=$(cat .python-version)" >> $GITHUB_ENV
       - name: Install Poetry

--- a/tests/functional/spec/features/calculated_summary/new_calculated_summary_repeating_and_static_answers.spec.js
+++ b/tests/functional/spec/features/calculated_summary/new_calculated_summary_repeating_and_static_answers.spec.js
@@ -22,7 +22,6 @@ describe("Calculated summary with repeating answers", () => {
   before("Completing the list collector and dynamic answer", async () => {
     await browser.openQuestionnaire("test_new_calculated_summary_repeating_and_static_answers.json");
     await $(HubPage.acceptCookies()).click();
-    await click(HubPage.submit());
     await $(AnySupermarketPage.yes()).click();
     await click(AnySupermarketPage.submit());
     await $(ListCollectorAddPage.supermarketName()).setValue("Tesco");


### PR DESCRIPTION
### What is the context of this PR?
Removes a line from the `new_calculated_summary_repeating_and_static_answers` functional test suite that was leading to flaky test issues. The line removed was not needed, as the schema does not render the Hub page on Launch.

Also removes the npm caches in our Actions workflow as they were added to provide performance benefit but not having any real impact at the moment. It maybe having an adverse affect on our flakyness and we are going to progress a ticket to investigate our npm and actions workflow separately.

### How to review
Check that the updated test passes.

### Checklist
* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
