### PR TITLE
Fix panel implementation on thank you page

### DIFF
--- a/templates/layouts/_submit.html
+++ b/templates/layouts/_submit.html
@@ -13,7 +13,7 @@
     {% block post_title_panel %}
         {% if content.warning %}
             {# djlint:off #}
-            {% call onsPanel({ "variant": "warn"}) %}
+            {% call onsPanel({ "variant": "warn" }) %}
                 <p data-qa="warning">{{ content.warning }}</p>
             {% endcall %}
             {# djlint:on #}

--- a/templates/thank-you.html
+++ b/templates/thank-you.html
@@ -32,7 +32,7 @@
     {# djlint:off #}
     {% call
          onsPanel({
-              "type": "success",
+              "variant": "success",
               "iconType": "check",
               "iconSize": "xl",
               "classes": "ons-u-mb-m"


### PR DESCRIPTION
### What is the context of this PR?
The success panel implementation on the thank you page is currently incorrect and because of this is using the blue information panel for the success message. Like this below:

<img width="758" alt="Screenshot 2024-11-06 at 11 35 50" src="https://github.com/user-attachments/assets/a812b17a-bcdb-4938-ba1f-21784841ffbb">

This PR updates the configuration for the panel to use the `variant` param instead of the previously used `type` param. After this change the panel should use the green success panel with a green tick icon. Like this below:

<img width="787" alt="Screenshot 2024-11-06 at 11 38 34" src="https://github.com/user-attachments/assets/c73036d0-c825-431e-8906-6ae4b40f3619">

### How to review
Test by opening the `test_thank_you` schema and navigating to the thank you page. Compare this branch against main and check that the correct panel is now being used.

### Checklist
* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
