### PR TITLE
Remove Ruff ignore rule UP034 (pyupgrade)

### DIFF
--- a/app/questionnaire/questionnaire_schema.py
+++ b/app/questionnaire/questionnaire_schema.py
@@ -301,7 +301,7 @@ class QuestionnaireSchema:  # pylint: disable=too-many-public-methods
     @classmethod
     def get_mutable_deepcopy(cls, data: Any) -> Any:
         if isinstance(data, tuple):
-            return list((cls.get_mutable_deepcopy(item) for item in data))
+            return [cls.get_mutable_deepcopy(item) for item in data]
         if isinstance(data, ImmutableDict):
             key_value_tuples = {k: cls.get_mutable_deepcopy(v) for k, v in data.items()}
             return dict(key_value_tuples)

--- a/app/questionnaire/questionnaire_store_updater.py
+++ b/app/questionnaire/questionnaire_store_updater.py
@@ -62,11 +62,9 @@ class QuestionnaireStoreUpdaterBase:
 
     def is_dirty(self) -> bool:
         return bool(
-            (
-                self._answer_store.is_dirty
-                or self._list_store.is_dirty
-                or self._progress_store.is_dirty
-            )
+            self._answer_store.is_dirty
+            or self._list_store.is_dirty
+            or self._progress_store.is_dirty
         )
 
     def update_relationships_answer(

--- a/app/utilities/make_immutable.py
+++ b/app/utilities/make_immutable.py
@@ -8,7 +8,7 @@ def make_immutable(data: Any) -> Any:
     if isinstance(data, abc.Hashable):
         return data
     if isinstance(data, list):
-        return tuple((make_immutable(item) for item in data))
+        return tuple(make_immutable(item) for item in data)
     if isinstance(data, dict):
         key_value_tuples = {k: make_immutable(v) for k, v in data.items()}
         return ImmutableDict(key_value_tuples)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,7 +124,6 @@ extend-ignore = [
     "EM102", # EM102 Exception must not use an f-string literal, assign to variable first
     "UP032", # Use f-string instead of `format` call
     "UP018", # Unnecessary {literal_type} call (rewrite as a literal)
-    "UP034", # Avoid extraneous parentheses
     "UP015", # Unnecessary open mode parameters
     "UP007", # Use `X | Y` for type annotations
     "UP006", # Use `type` instead of `Type` for type annotation


### PR DESCRIPTION
### What is the context of this PR?
This PR removes the ignore rule for Ruff's pyupgrade plugin "UP034" error ("Avoid extraneous parentheses"). It's part of the ongoing task of improving the Python code base by gradually fixing all the remaining issues ignored by the linters.

### How to review
Check that the rule now applies and the issues in the code were fixed.

### Checklist
* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
