### PR TITLE
Update the messages.pot file for 2025

### DIFF
--- a/app/translations/messages.pot
+++ b/app/translations/messages.pot
@@ -1,14 +1,14 @@
 # Translations template for PROJECT.
-# Copyright (C) 2024 ORGANIZATION
+# Copyright (C) 2025 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
 #
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-09-12 12:26+0100\n"
+"POT-Creation-Date: 2025-01-10 12:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -49,7 +49,7 @@ msgstr ""
 msgid "Change your answer for: {question_title_or_answer_label}"
 msgstr ""
 
-#: app/jinja_filters.py:741
+#: app/jinja_filters.py:765
 #: templates/partials/summary/collapsible-summary.html:27
 #: templates/partials/summary/summary.html:24
 msgid "No answer provided"
@@ -229,29 +229,29 @@ msgstr ""
 msgid "Menu"
 msgstr ""
 
-#: app/helpers/template_helpers.py:142
+#: app/helpers/template_helpers.py:138
 msgid "The following links open in a new tab"
 msgstr ""
 
-#: app/helpers/template_helpers.py:167
+#: app/helpers/template_helpers.py:163
 msgid ""
 "Make sure you <a href='{sign_out_url}'>leave this page</a> or close your "
 "browser if using a shared device"
 msgstr ""
 
-#: app/questionnaire/placeholder_transforms.py:202
+#: app/questionnaire/placeholder_transforms.py:203
 msgid "{number_of_years} year"
 msgid_plural "{number_of_years} years"
 msgstr[0] ""
 msgstr[1] ""
 
-#: app/questionnaire/placeholder_transforms.py:208
+#: app/questionnaire/placeholder_transforms.py:209
 msgid "{number_of_months} month"
 msgid_plural "{number_of_months} months"
 msgstr[0] ""
 msgstr[1] ""
 
-#: app/questionnaire/placeholder_transforms.py:213
+#: app/questionnaire/placeholder_transforms.py:214
 msgid "{number_of_days} day"
 msgid_plural "{number_of_days} days"
 msgstr[0] ""
@@ -426,7 +426,7 @@ msgstr ""
 #: templates/individual_response/confirmation-post.html:26
 #: templates/individual_response/confirmation-text-message.html:39
 #: templates/individual_response/question.html:5 templates/interstitial.html:7
-#: templates/listcollectorcontent.html:6 templates/sectionsummary.html:11
+#: templates/listcollectorcontent.html:8 templates/sectionsummary.html:11
 #: templates/sectionsummary.html:51
 msgid "Continue"
 msgstr ""
@@ -922,19 +922,19 @@ msgid ""
 "submitted-response-link\">save or print your answers</a>."
 msgstr ""
 
-#: templates/layouts/_base.html:148 templates/thank-you.html:84
+#: templates/layouts/_base.html:147 templates/thank-you.html:84
 msgid "minute"
 msgstr ""
 
-#: templates/layouts/_base.html:149 templates/thank-you.html:85
+#: templates/layouts/_base.html:148 templates/thank-you.html:85
 msgid "minutes"
 msgstr ""
 
-#: templates/layouts/_base.html:150 templates/thank-you.html:86
+#: templates/layouts/_base.html:149 templates/thank-you.html:86
 msgid "second"
 msgstr ""
 
-#: templates/layouts/_base.html:151 templates/thank-you.html:87
+#: templates/layouts/_base.html:150 templates/thank-you.html:87
 msgid "seconds"
 msgstr ""
 
@@ -1239,29 +1239,29 @@ msgstr ""
 msgid "Hide"
 msgstr ""
 
-#: templates/layouts/_base.html:115
+#: templates/layouts/_base.html:114
 msgid "Skip to main content"
 msgstr ""
 
-#: templates/layouts/_base.html:143
+#: templates/layouts/_base.html:142
 msgid "You will be signed out soon"
 msgstr ""
 
-#: templates/layouts/_base.html:144
+#: templates/layouts/_base.html:143
 msgid "It appears you have been inactive for a while."
 msgstr ""
 
-#: templates/layouts/_base.html:145
+#: templates/layouts/_base.html:144
 msgid ""
 "To protect your information, your progress will be saved and you will be "
 "signed out in"
 msgstr ""
 
-#: templates/layouts/_base.html:146
+#: templates/layouts/_base.html:145
 msgid "You are being signed out"
 msgstr ""
 
-#: templates/layouts/_base.html:147
+#: templates/layouts/_base.html:146
 msgid "Continue survey"
 msgstr ""
 


### PR DESCRIPTION
### What is the context of this PR?
The translations template `messages.pot` file fails the lint check in the actions workflow which checks for any changes as it still expects to see the year `2024` referenced within the file.

### How to review
Check the newly updated .pot file is correct and that the lint check passes.

### Checklist
* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
