### PR TITLE
Pin Poetry dotenv plugin version in our actions workflow

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
-          version: 2.0.1
+          version: 1.8.4
           virtualenvs-create: true
       - uses: actions/setup-python@v5
         with:
@@ -56,7 +56,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
-          version: 2.0.1
+          version: 1.8.4
           virtualenvs-create: true
       - uses: actions/setup-python@v5
         with:
@@ -95,7 +95,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
-          version: 2.0.1
+          version: 1.8.4
           virtualenvs-create: true
       - uses: actions/setup-python@v5
         with:
@@ -122,7 +122,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
-          version: 2.0.1
+          version: 1.8.4
           virtualenvs-create: true
       - uses: actions/setup-python@v5
         with:
@@ -151,7 +151,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
-          version: 2.0.1
+          version: 1.8.4
           virtualenvs-create: true
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
-          version: 1.8.4
+          version: 2.0.1
           virtualenvs-create: true
       - uses: actions/setup-python@v5
         with:
@@ -56,7 +56,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
-          version: 1.8.4
+          version: 2.0.1
           virtualenvs-create: true
       - uses: actions/setup-python@v5
         with:
@@ -95,14 +95,14 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
-          version: 1.8.4
+          version: 2.0.1
           virtualenvs-create: true
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: "poetry"
       - name: Install dotenv plugin
-        run: poetry self add poetry-plugin-dotenv
+        run: poetry self add poetry-plugin-dotenv@2.6.1
       - name: Load templates
         run: make load-design-system-templates
       - name: Compile translations
@@ -122,7 +122,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
-          version: 1.8.4
+          version: 2.0.1
           virtualenvs-create: true
       - uses: actions/setup-python@v5
         with:
@@ -151,7 +151,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
-          version: 1.8.4
+          version: 2.0.1
           virtualenvs-create: true
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
### What is the context of this PR?
Pins the version of the Poetry Dotenv plugin to v2.6.1 as versions => 2.7.3 require a minimum version of Poetry 2.0.0 (we currently use v1.8.4). We will look to unpin and resolve any dependency issues separately.

### How to review
Check that the actions workflow is passing as expected.

### Checklist
* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
