### PR TITLE
Remove cache from setup-python action

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -21,15 +21,14 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - run: |
           echo "PYTHON_VERSION=$(cat .python-version)" >> $GITHUB_ENV
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
       - name: Install Poetry
         uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1.4.1
         with:
           version: 2.1.2
           virtualenvs-create: true
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-          cache: 'poetry'
       - name: Install virtual environment
         run: |
           sudo apt-get install libsnappy-dev

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -90,6 +90,14 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - run: |
           echo "PYTHON_VERSION=$(cat .python-version)" >> $GITHUB_ENV
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Install Poetry
+        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1.4.1
+        with:
+          version: 2.1.2
+          virtualenvs-create: true
       - name: Install apt dependencies
         run: |
             sudo apt-get install libsnappy-dev libgconf-2-4 jq
@@ -99,14 +107,6 @@ jobs:
             sudo dpkg -i wkhtmltox_0.12.6-1.bionic_amd64.deb
       - name: Write app version
         run: printf "${{ github.event.pull_request.head.sha }}" > .application-version
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-      - name: Install Poetry
-        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1.4.1
-        with:
-          version: 2.1.2
-          virtualenvs-create: true
       - name: Install dotenv plugin
         run: poetry self add poetry-plugin-dotenv@2.9.0
       - name: Load templates

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -100,15 +100,15 @@ jobs:
             sudo dpkg -i wkhtmltox_0.12.6-1.bionic_amd64.deb
       - name: Write app version
         run: printf "${{ github.event.pull_request.head.sha }}" > .application-version
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: "poetry"
       - name: Install Poetry
         uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1.4.1
         with:
           version: 2.1.2
           virtualenvs-create: true
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-          cache: "poetry"
       - name: Install dotenv plugin
         run: poetry self add poetry-plugin-dotenv@2.9.0
       - name: Load templates

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -101,9 +101,7 @@ jobs:
           version: 2.1.2
           virtualenvs-create: true
       - name: Install virtual environment
-        run: |
-          sudo apt-get install libsnappy-dev
-          poetry install
+        run: poetry install
       - name: Install apt dependencies
         run: |
             sudo apt-get install libsnappy-dev libgconf-2-4 jq
@@ -170,9 +168,7 @@ jobs:
           version: 2.1.2
           virtualenvs-create: true
       - name: Install virtual environment
-        run: |
-          sudo apt-get install libsnappy-dev
-          poetry install
+        run: poetry install
       - name: Install npm deps
         run: npm install
       - name: Docker compose

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -129,15 +129,14 @@ jobs:
           echo "PYTHON_VERSION=$(cat .python-version)" >> $GITHUB_ENV
       - name: Run validator
         run: ./scripts/run_validator.sh
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
       - name: Install Poetry
         uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1.4.1
         with:
           version: 2.1.2
           virtualenvs-create: true
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-          cache: "poetry"
       - name: Running schema validation
         run: make validate-test-schemas
   test-functional:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -66,6 +66,10 @@ jobs:
         with:
           version: 2.1.2
           virtualenvs-create: true
+      - name: Install virtual environment
+        run: |
+          sudo apt-get install libsnappy-dev
+          poetry install
       - name: Compile translations
         run: make translate
       - name: Running translation tests

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -58,15 +58,14 @@ jobs:
           node-version-file: ".nvmrc"
       - name: Write app version
         run: printf "${{ github.event.pull_request.head.sha }}" > .application-version
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
       - name: Install Poetry
         uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1.4.1
         with:
           version: 2.1.2
           virtualenvs-create: true
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-          cache: "poetry"
       - name: Compile translations
         run: make translate
       - name: Running translation tests
@@ -103,7 +102,6 @@ jobs:
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-          cache: "poetry"
       - name: Install Poetry
         uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1.4.1
         with:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -102,6 +102,10 @@ jobs:
         with:
           version: 2.1.2
           virtualenvs-create: true
+      - name: Install virtual environment
+        run: |
+          sudo apt-get install libsnappy-dev
+          poetry install
       - name: Install apt dependencies
         run: |
             sudo apt-get install libsnappy-dev libgconf-2-4 jq
@@ -167,6 +171,10 @@ jobs:
         with:
           version: 2.1.2
           virtualenvs-create: true
+      - name: Install virtual environment
+        run: |
+          sudo apt-get install libsnappy-dev
+          poetry install
       - name: Install npm deps
         run: npm install
       - name: Docker compose

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -67,9 +67,7 @@ jobs:
           version: 2.1.2
           virtualenvs-create: true
       - name: Install virtual environment
-        run: |
-          sudo apt-get install libsnappy-dev
-          poetry install
+        run: poetry install
       - name: Compile translations
         run: make translate
       - name: Running translation tests

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -155,15 +155,15 @@ jobs:
           node-version-file: ".nvmrc"
       - run: |
           echo "PYTHON_VERSION=$(cat .python-version)" >> $GITHUB_ENV
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: "poetry"
       - name: Install Poetry
         uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1.4.1
         with:
           version: 2.1.2
           virtualenvs-create: true
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-          cache: "poetry"
       - name: Install npm deps
         run: npm install
       - name: Docker compose

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -158,7 +158,6 @@ jobs:
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-          cache: "poetry"
       - name: Install Poetry
         uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1.4.1
         with:


### PR DESCRIPTION
### What is the context of this PR?
This pull request updates the GitHub Actions workflow configuration to address version mismatch issues.  The problem is potentially linked to the setup-python action's cache functionality (https://github.com/actions/setup-python?tab=readme-ov-file#caching-packages-dependencies), which has been reported to malfunction in recent repository issues (https://github.com/actions/setup-python/issues). 
Additionally, the action relies on the @actions/toolkit (https://github.com/actions/toolkit/tree/main/packages/cache#%EF%B8%8F-important-changes), which recently started rolling out significant changes that could be contributing to the issue.  
As part of this pull request, Poetry caching has been removed, and the `setup-python` and `install-poetry` steps have been reordered, aligning them with the workflow configurations used in the validator and proxy service repositories.

### How to review
Check if the steps in the yaml file are correct and no jobs are skipped. All tests and actions should run.

### Checklist
* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
