### PR TITLE
Update run_validator to retrieve latest Docker image

### DIFF
--- a/scripts/run_validator.sh
+++ b/scripts/run_validator.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 tag=latest
+TAG=${tag} docker compose -f docker-compose-schema-validator.yml pull
 TAG=${tag} docker compose -f docker-compose-schema-validator.yml up -d


### PR DESCRIPTION
### What is the context of this PR?
The `run_validator` script used in `make run-validator` only contained the command to start the containers. The script didn't pull the latest images for validator and only ran the containers using images that were stored locally. As a result, it created the problem of incorrect/older images being used when running Validator through Docker.

To address this, I added in a command to retrieve the latest images of Validator from GCP to ensure the latest images are being used.

### How to review
- Run `make run-validator` and see if it pulls the latest images for validator
- Use `docker images --digests` to see if the SHA of the latest Docker image you pulled matches the latest in GCP

### Checklist
* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
