### PR TITLE
EQS-842-Add and configure new custom Dockerfile for local datastore emulation

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,6 +1,6 @@
 services:
     datastore:
-        image: knarz/datastore-emulator
+        image: europe-west2-docker.pkg.dev/ons-eq-ci/docker-images/datastore-emulator:latest
         networks:
             - eq-env
         ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
 
     datastore:
-        image: knarz/datastore-emulator
+        image: europe-west2-docker.pkg.dev/ons-eq-ci/docker-images/datastore-emulator:latest
         networks:
             - eq-env
 


### PR DESCRIPTION
### What is the context of this PR?
This PR addresses an issue where we cannot pull the `datastore-emulator` image as it is no longer supported and isn’t present on Docker Hub. The temporary fix is to push up a working image locally to our GAR in `ons-eq-ci` and point our Docker Compose files to the image.

### How to review
- Ensure `make dev-compose-up` works  and pulls the new image and the Docker Compose steps in Actions work.

### Checklist
* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
