### PR TITLE
EQS-862: Install wkhtmltopdf from packaging release

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -219,10 +219,12 @@ jobs:
         run: |
           echo "Writing SHA $SHA to .application_version"
           printf $SHA > .application-version
-      - name: Build
-        run: docker build -t ${{ secrets.GAR_LOCATION }}/${{ secrets.GAR_PROJECT_ID }}/docker-images/eq-questionnaire-runner:$TAG .
-      - name: Push to GAR
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+      - name: Build & push
         run: |
-          gcloud auth configure-docker ${{ secrets.GAR_LOCATION }}
-          echo "Pushing to GAR with tag $TAG"
-          docker push ${{ secrets.GAR_LOCATION }}/${{ secrets.GAR_PROJECT_ID }}/docker-images/eq-questionnaire-runner:$TAG
+            gcloud auth configure-docker ${{ secrets.GAR_LOCATION }}
+            echo "Building & pushing to GAR with tag $TAG"
+            docker buildx build --platform linux/amd64,linux/arm64 -t ${{ secrets.GAR_LOCATION }}/${{ secrets.GAR_PROJECT_ID }}/docker-images/eq-questionnaire-runner:$TAG --push .

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,23 @@ FROM python:3.13-slim-bookworm
 
 EXPOSE 5000
 
-RUN apt update && apt install -y curl unzip libsnappy-dev build-essential jq wkhtmltopdf
+# wkhtmltopdf is installed from the upstream packaging release rather than apt
+ARG WKHTMLTOX_VERSION=0.12.6.1-3
+ARG WKHTMLTOX_DISTRO=bookworm
+ARG WKHTMLTOX_SHA256=98ba0d157b50d36f23bd0dedf4c0aa28c7b0c50fcdcdc54aa5b6bbba81a3941d
+
+RUN apt-get update && \
+apt-get install -y --no-install-recommends \
+curl unzip libsnappy-dev build-essential jq \
+xfonts-base xfonts-75dpi fontconfig \
+libjpeg62-turbo libxrender1 libxext6 && \
+curl -fsSL -o /tmp/wkhtmltox.deb \
+"https://github.com/wkhtmltopdf/packaging/releases/download/${WKHTMLTOX_VERSION}/wkhtmltox_${WKHTMLTOX_VERSION}.${WKHTMLTOX_DISTRO}_amd64.deb" && \
+test "$(sha256sum /tmp/wkhtmltox.deb | cut -d' ' -f1)" = "${WKHTMLTOX_SHA256}" && \
+apt-get install -y --no-install-recommends /tmp/wkhtmltox.deb && \
+rm -f /tmp/wkhtmltox.deb && \
+rm -rf /var/lib/apt/lists/* && \
+wkhtmltopdf --version | grep -qi "with patched qt"
 
 COPY . /runner
 WORKDIR /runner

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,16 +5,24 @@ EXPOSE 5000
 # wkhtmltopdf is installed from the upstream packaging release rather than apt
 ARG WKHTMLTOX_VERSION=0.12.6.1-3
 ARG WKHTMLTOX_DISTRO=bookworm
-ARG WKHTMLTOX_SHA256=98ba0d157b50d36f23bd0dedf4c0aa28c7b0c50fcdcdc54aa5b6bbba81a3941d
+ARG WKHTMLTOX_SHA256_AMD64=98ba0d157b50d36f23bd0dedf4c0aa28c7b0c50fcdcdc54aa5b6bbba81a3941d
+ARG WKHTMLTOX_SHA256_ARM64=b6606157b27c13e044d0abbe670301f88de4e1782afca4f9c06a5817f3e03a9c
+ARG TARGETARCH
 
 RUN apt-get update && \
 apt-get install -y --no-install-recommends \
 curl unzip libsnappy-dev build-essential jq \
 xfonts-base xfonts-75dpi fontconfig \
 libjpeg62-turbo libxrender1 libxext6 && \
+case "${TARGETARCH}" in \
+amd64) WK_SHA256="${WKHTMLTOX_SHA256_AMD64}" ;; \
+arm64) WK_SHA256="${WKHTMLTOX_SHA256_ARM64}" ;; \
+esac && \
 curl -fsSL -o /tmp/wkhtmltox.deb \
-"https://github.com/wkhtmltopdf/packaging/releases/download/${WKHTMLTOX_VERSION}/wkhtmltox_${WKHTMLTOX_VERSION}.${WKHTMLTOX_DISTRO}_amd64.deb" && \
-test "$(sha256sum /tmp/wkhtmltox.deb | cut -d' ' -f1)" = "${WKHTMLTOX_SHA256}" && \
+"https://github.com/wkhtmltopdf/packaging/releases/download/${WKHTMLTOX_VERSION}/wkhtmltox_${WKHTMLTOX_VERSION}.${WKHTMLTOX_DISTRO}_${TARGETARCH}.deb" && \
+echo "EXPECTED=[${WK_SHA256}]" && \
+echo "ACTUAL=[$(sha256sum /tmp/wkhtmltox.deb | cut -d' ' -f1)]" && \
+test "$(sha256sum /tmp/wkhtmltox.deb | cut -d' ' -f1)" = "${WK_SHA256}" && \
 apt-get install -y --no-install-recommends /tmp/wkhtmltox.deb && \
 rm -f /tmp/wkhtmltox.deb && \
 rm -rf /var/lib/apt/lists/* && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,23 +10,22 @@ ARG WKHTMLTOX_SHA256_ARM64=b6606157b27c13e044d0abbe670301f88de4e1782afca4f9c06a5
 ARG TARGETARCH
 
 RUN apt-get update && \
-apt-get install -y --no-install-recommends \
-curl unzip libsnappy-dev build-essential jq \
-xfonts-base xfonts-75dpi fontconfig \
-libjpeg62-turbo libxrender1 libxext6 && \
-case "${TARGETARCH}" in \
-amd64) WK_SHA256="${WKHTMLTOX_SHA256_AMD64}" ;; \
-arm64) WK_SHA256="${WKHTMLTOX_SHA256_ARM64}" ;; \
-esac && \
-curl -fsSL -o /tmp/wkhtmltox.deb \
-"https://github.com/wkhtmltopdf/packaging/releases/download/${WKHTMLTOX_VERSION}/wkhtmltox_${WKHTMLTOX_VERSION}.${WKHTMLTOX_DISTRO}_${TARGETARCH}.deb" && \
-echo "EXPECTED=[${WK_SHA256}]" && \
-echo "ACTUAL=[$(sha256sum /tmp/wkhtmltox.deb | cut -d' ' -f1)]" && \
-test "$(sha256sum /tmp/wkhtmltox.deb | cut -d' ' -f1)" = "${WK_SHA256}" && \
-apt-get install -y --no-install-recommends /tmp/wkhtmltox.deb && \
-rm -f /tmp/wkhtmltox.deb && \
-rm -rf /var/lib/apt/lists/* && \
-wkhtmltopdf --version | grep -qi "with patched qt"
+    apt-get install -y --no-install-recommends \
+    curl unzip libsnappy-dev build-essential jq \
+    xfonts-base xfonts-75dpi fontconfig \
+    libjpeg62-turbo libxrender1 libxext6 && \
+    case "${TARGETARCH}" in \
+    amd64) WK_SHA256="${WKHTMLTOX_SHA256_AMD64}" ;; \
+    arm64) WK_SHA256="${WKHTMLTOX_SHA256_ARM64}" ;; \
+    *) echo "Unsupported TARGETARCH: ${TARGETARCH}" >&2 && exit 1 ;; \
+    esac && \
+    curl -fsSL -o /tmp/wkhtmltox.deb \
+    "https://github.com/wkhtmltopdf/packaging/releases/download/${WKHTMLTOX_VERSION}/wkhtmltox_${WKHTMLTOX_VERSION}.${WKHTMLTOX_DISTRO}_${TARGETARCH}.deb" && \
+    echo "${WK_SHA256}  /tmp/wkhtmltox.deb" | sha256sum -c - && \
+    apt-get install -y --no-install-recommends /tmp/wkhtmltox.deb && \
+    rm -f /tmp/wkhtmltox.deb && \
+    rm -rf /var/lib/apt/lists/* && \
+    wkhtmltopdf --version | grep -qi "with patched qt"
 
 COPY . /runner
 WORKDIR /runner

--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ Install [Docker](https://www.docker.com/) for your system. Make sure that you've
 ``` shell
 brew install docker
 brew install docker-compose
+brew install docker-buildx
+```
+
+brew installs buildx as a standalone binary so it also needs symlinking before Docker picks it up:
+```shell
+mkdir -p ~/.docker/cli-plugins
+ln -sfn "$(brew --prefix docker-buildx)/bin/docker-buildx" ~/.docker/cli-plugins/docker-buildx
 ```
 
 On MacOS install container runtimes, eg. [Colima](https://github.com/abiosoft/colima):
@@ -64,8 +71,20 @@ git clone git@github.com:ONSdigital/eq-questionnaire-runner.git
 In order to run locally you'll need Node.js, snappy, pyenv, jq and wkhtmltopdf installed
 
 ``` shell
-brew install snappy npm pyenv jq wkhtmltopdf
+brew install snappy npm pyenv jq
 ```
+
+wkhtmltopdf It is no longer installable via Homebrew: the cask was disabled on 2024-12-16 and later removed
+Install it from the project's own packaging releases, choosing the macOS package for your architecture
+
+Example for Apple Silicon:
+``` shell
+curl -fsSLO https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-2/wkhtmltox-0.12.6-2.macos-cocoa.pkg
+sudo installer -pkg wkhtmltox-0.12.6-2.macos-cocoa.pkg -target /
+wkhtmltopdf --version
+```
+
+wkhtmltopdf --version should report with patched Qt
 
 ### Setup
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ Example for Apple Silicon:
 ``` shell
 docker buildx build --platform linux/arm64 -t eq-questionnaire-runner .
 ```
+Or build for multiple platforms:
+
+```
+docker buildx build --platform linux/amd64,linux/arm64 -t eq-questionnaire-runner .
+```
 
 To launch a survey, navigate to [http://localhost:8000/](http://localhost:8000/)
 

--- a/README.md
+++ b/README.md
@@ -16,13 +16,6 @@ Install [Docker](https://www.docker.com/) for your system. Make sure that you've
 ``` shell
 brew install docker
 brew install docker-compose
-brew install docker-buildx
-```
-
-brew installs buildx as a standalone binary so it also needs symlinking before Docker picks it up:
-```shell
-mkdir -p ~/.docker/cli-plugins
-ln -sfn "$(brew --prefix docker-buildx)/bin/docker-buildx" ~/.docker/cli-plugins/docker-buildx
 ```
 
 On MacOS install container runtimes, eg. [Colima](https://github.com/abiosoft/colima):
@@ -39,6 +32,13 @@ To get eq-questionnaire-runner running the following command will build and run 
 
 ``` shell
 RUNNER_ENV_FILE=.development.env docker compose up -d
+```
+
+You can also build for a specific platform using Docker’s extended build tool - buildx
+
+Example for Apple Silicon:
+``` shell
+docker buildx build --platform linux/arm64 -t eq-questionnaire-runner .
 ```
 
 To launch a survey, navigate to [http://localhost:8000/](http://localhost:8000/)


### PR DESCRIPTION
### What is the context of this PR?
Implemented by following similar approach to CI: pulling the prebuilt .deb from the wkhtmltopdf/packaging repo.
The source zip route wasn't viable because the patched Qt lives in a git submodule, which GitHub's tag archives don't include, so there's nothing for qmake to build against.
Verified the bookworm .deb installs and runs on a trixie base (reports "with patched Qt") on both arm64 and amd64.

Pinned TARGETARCH - meaning that Dockerfile will pick the correct wkhtmltoped .deb for whatever architecture its being built on. TARGETARCH is populated by BuildKit so this PR will require the team to install buildx. 

### How to review
Build image using buildx (commands are described in README)
Test thoroughly ensuring that the download-pdf endpoint still functions correctly 
Run benchmark
