### PR TITLE
Remove skip functional tests logic

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -150,7 +150,6 @@ jobs:
            browser: [chromium]
            shard: [1, 2, 3, 4, 5, 6]
            shard_count: [6]
-    if: "!contains(github.event.pull_request.labels.*.name, 'tests not required')"
     permissions:
       contents: 'read'
     needs: [python-dependencies, node-dependencies]


### PR DESCRIPTION
### What is the context of this PR?
Since we started using shards (matrix) for functional tests, the skip required test-functional task is no longer and does not work as expected anymore for schema releases. This skip is only removed for the functional tests, it still applies to unit and integration tests.

### How to review
Rerun Actions with "tests not required" label attached and see if the build passes, all functional tests run and it could be merged after two approvals.

### Checklist
* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
